### PR TITLE
Topic partition list and rebalance callback

### DIFF
--- a/examples/simple_consumer.rs
+++ b/examples/simple_consumer.rs
@@ -10,12 +10,13 @@ use rdkafka::consumer::{Consumer, CommitMode};
 use rdkafka::consumer::stream_consumer::StreamConsumer;
 use rdkafka::config::{ClientConfig, TopicConfig};
 use rdkafka::util::get_rdkafka_version;
+use rdkafka::topic_partition_list::TopicPartitionList;
 
 mod example_utils;
 use example_utils::setup_logger;
 
 
-fn consume_and_print(brokers: &str, group_id: &str, topics: &Vec<&str>) {
+fn consume_and_print(brokers: &str, group_id: &str, topics: &TopicPartitionList) {
     let mut consumer = ClientConfig::new()
         .set("group.id", group_id)
         .set("bootstrap.servers", brokers)
@@ -99,7 +100,7 @@ fn main() {
     let (version_n, version_s) = get_rdkafka_version();
     info!("rd_kafka_version: 0x{:08x}, {}", version_n, version_s);
 
-    let topics = matches.values_of("topics").unwrap().collect::<Vec<&str>>();
+    let topics = TopicPartitionList::with_topics(&matches.values_of("topics").unwrap().collect::<Vec<&str>>());
     let brokers = matches.value_of("brokers").unwrap();
     let group_id = matches.value_of("group-id").unwrap();
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -4,10 +4,13 @@ extern crate rdkafka_sys as rdkafka;
 
 use std::ffi::CString;
 use std::os::raw::c_void;
+use std::mem;
+use std::ptr;
 
 use config::{ClientConfig, TopicConfig};
 use error::{KafkaError, KafkaResult};
-use util::bytes_cstr_to_owned;
+use topic_partition_list::TopicPartitionList;
+use util::{bytes_cstr_to_owned,cstr_to_owned};
 
 /// Specifies the type of client.
 pub enum ClientType {
@@ -17,9 +20,62 @@ pub enum ClientType {
     Producer,
 }
 
+pub struct Opaque {
+    pub rebalances: Vec<Rebalance>
+}
+
+impl Opaque {
+    pub fn new() -> Opaque {
+        Opaque {
+            rebalances: Vec::new()
+        }
+    }
+
+    pub fn rebalance_callback(&mut self, rebalance: Rebalance) {
+        self.rebalances.push(rebalance);
+    }
+}
+
+pub enum Rebalance {
+    Assign(TopicPartitionList),
+    Revoke,
+    Error(String)
+}
+
+unsafe extern "C" fn rebalance_cb(rk: *mut rdkafka::rd_kafka_t,
+                                  err: rdkafka::rd_kafka_resp_err_t,
+                                  partitions: *mut rdkafka::rd_kafka_topic_partition_list_t,
+                                  opaque_ptr: *mut c_void) {
+    // Get our opaque for callbacks
+    let mut opaque = Box::from_raw(opaque_ptr as *mut Opaque);
+
+    // Handle callback
+    match err {
+        rdkafka::rd_kafka_resp_err_t::RD_KAFKA_RESP_ERR__ASSIGN_PARTITIONS => {
+            rdkafka::rd_kafka_assign(rk, partitions);
+            let topic_partition_list = TopicPartitionList::from_rdkafka(partitions);
+            opaque.rebalance_callback(Rebalance::Assign(topic_partition_list));
+        },
+        rdkafka::rd_kafka_resp_err_t::RD_KAFKA_RESP_ERR__REVOKE_PARTITIONS => {
+            rdkafka::rd_kafka_assign(rk, ptr::null());
+            opaque.rebalance_callback(Rebalance::Revoke);
+        },
+        _ => {
+            let error = cstr_to_owned(rdkafka::rd_kafka_err2str(err));
+            error!("Error rebalancing: {}", error);
+            rdkafka::rd_kafka_assign(rk, ptr::null());
+            opaque.rebalance_callback(Rebalance::Error(error));
+        }
+    }
+
+    // This will only be cleaned up in the client's drop
+    mem::forget(opaque);
+}
+
 /// A librdkafka client.
 pub struct Client {
     pub ptr: *mut rdkafka::rd_kafka_t,
+    pub opaque_ptr: *mut Opaque
 }
 
 unsafe impl Sync for Client {}
@@ -37,7 +93,12 @@ impl Client {
         let errstr = [0i8; 1024];
         let config_ptr = try!(config.create_native_config());
         let rd_kafka_type = match client_type {
-            ClientType::Consumer => rdkafka::rd_kafka_type_t::RD_KAFKA_CONSUMER,
+            ClientType::Consumer => {
+                if config.is_rebalance_tracking_enabled() {
+                    unsafe { rdkafka::rd_kafka_conf_set_rebalance_cb(config_ptr, Some(rebalance_cb)) };
+                }
+                rdkafka::rd_kafka_type_t::RD_KAFKA_CONSUMER
+            },
             ClientType::Producer => {
                 if config.get_delivery_cb().is_some() {
                     unsafe { rdkafka::rd_kafka_conf_set_dr_msg_cb(config_ptr, config.get_delivery_cb()) };
@@ -51,15 +112,40 @@ impl Client {
             let descr = unsafe { bytes_cstr_to_owned(&errstr) };
             return Err(KafkaError::ClientCreation(descr));
         }
-        Ok(Client { ptr: client_ptr })
+
+        // Set opaque to handle callbacks
+        let opaque = Box::new(Opaque::new());
+        let opaque_ptr = Box::into_raw(opaque);
+        unsafe { rdkafka::rd_kafka_conf_set_opaque(config_ptr, opaque_ptr as *mut c_void) };
+
+        Ok(Client {
+            ptr: client_ptr,
+            opaque_ptr: opaque_ptr
+        })
+    }
+
+    /// Take rebalance events that were recorded. This only returns results if
+    /// rebalance tracking has been enabled in the config for this client.
+    pub fn take_rebalances(&mut self) -> Vec<Rebalance> {
+        let mut opaque = unsafe { Box::from_raw(self.opaque_ptr as *mut Opaque) };
+
+        let rebalances = opaque.rebalances.drain(0..).collect();
+
+        // This will only be cleaned up in the client's drop
+        mem::forget(opaque);
+
+        rebalances
     }
 }
 
 impl Drop for Client {
     fn drop(&mut self) {
         trace!("Destroy rd_kafka");
-        unsafe { rdkafka::rd_kafka_destroy(self.ptr) };
-        unsafe { rdkafka::rd_kafka_wait_destroyed(1000) };
+        unsafe {
+            rdkafka::rd_kafka_destroy(self.ptr);
+            rdkafka::rd_kafka_wait_destroyed(1000);
+            Box::from_raw(self.opaque_ptr);
+        }
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,6 +16,7 @@ pub struct ClientConfig {
     conf_map: HashMap<String, String>,
     delivery_cb: Option<DeliveryCallback>,
     default_topic_config: Option<TopicConfig>,
+    rebalance_tracking_enabled: bool,
 }
 
 impl ClientConfig {
@@ -25,6 +26,7 @@ impl ClientConfig {
             conf_map: HashMap::new(),
             delivery_cb: None,
             default_topic_config: None,
+            rebalance_tracking_enabled: false
         }
     }
 
@@ -46,6 +48,15 @@ impl ClientConfig {
     pub fn set_default_topic_config<'a>(&'a mut self, default_topic_config: TopicConfig) -> &'a mut ClientConfig {
         self.default_topic_config = Some(default_topic_config);
         self
+    }
+
+    pub fn enable_rebalance_tracking<'a>(&'a mut self) -> &'a mut ClientConfig {
+        self.rebalance_tracking_enabled = true;
+        self
+    }
+
+    pub fn is_rebalance_tracking_enabled(&self) -> bool {
+        self.rebalance_tracking_enabled
     }
 
     pub fn create_native_config(&self) -> KafkaResult<*mut rdkafka::rd_kafka_conf_t> {

--- a/src/consumer/base_consumer.rs
+++ b/src/consumer/base_consumer.rs
@@ -4,7 +4,7 @@ extern crate futures;
 use std::ffi::CString;
 use std::str;
 
-use client::{Client, ClientType};
+use client::{Client, ClientType, Rebalance};
 use config::{FromClientConfig, ClientConfig};
 use consumer::{Consumer, CommitMode};
 use error::{KafkaError, KafkaResult, IsError};
@@ -97,6 +97,12 @@ impl BaseConsumer {
         };
 
         unsafe { rdkafka::rd_kafka_commit_message(self.client.ptr, message.ptr, async) };
+    }
+
+    /// Take rebalance events that were recorded. This only returns results if
+    /// `track_rebalances` is on in the config for this client.
+    pub fn take_rebalances(&mut self) -> Vec<Rebalance> {
+        self.client.take_rebalances()
     }
 }
 

--- a/src/consumer/base_consumer.rs
+++ b/src/consumer/base_consumer.rs
@@ -1,7 +1,6 @@
 extern crate rdkafka_sys as rdkafka;
 extern crate futures;
 
-use std::ffi::CString;
 use std::str;
 
 use client::{Client, ClientType, Rebalance};
@@ -10,7 +9,7 @@ use consumer::{Consumer, CommitMode};
 use error::{KafkaError, KafkaResult, IsError};
 use message::Message;
 use util::cstr_to_owned;
-
+use topic_partition_list::TopicPartitionList;
 
 /// A BaseConsumer client.
 pub struct BaseConsumer {
@@ -40,18 +39,13 @@ impl BaseConsumer {
     /// Subscribes the consumer to a list of topics and/or topic sets (using regex).
     /// Strings starting with `^` will be regex-matched to the full list of topics in
     /// the cluster and matching topics will be added to the subscription list.
-    pub fn subscribe(&mut self, topics: &Vec<&str>) -> KafkaResult<()> {
-        let tp_list = unsafe { rdkafka::rd_kafka_topic_partition_list_new(topics.len() as i32) };
-        for &topic in topics {
-            let topic_c = CString::new(topic).unwrap();
-            let ret_code = unsafe {
-                rdkafka::rd_kafka_topic_partition_list_add(tp_list, topic_c.as_ptr(), -1);
-                rdkafka::rd_kafka_subscribe(self.client.ptr, tp_list)
-            };
-            if ret_code.is_error() {
-                return Err(KafkaError::Subscription(topic.to_string()))
-            };
-        }
+    pub fn subscribe(&mut self, topics: &TopicPartitionList) -> KafkaResult<()> {
+        let tp_list = topics.create_native_topic_partition_list();
+        let ret_code = unsafe { rdkafka::rd_kafka_subscribe(self.client.ptr, tp_list) };
+        if ret_code.is_error() {
+            let error = unsafe { cstr_to_owned(rdkafka::rd_kafka_err2str(ret_code)) };
+            return Err(KafkaError::Subscription(error))
+        };
         unsafe { rdkafka::rd_kafka_topic_partition_list_destroy(tp_list) };
         Ok(())
     }
@@ -61,19 +55,11 @@ impl BaseConsumer {
         unsafe { rdkafka::rd_kafka_unsubscribe(self.client.ptr) };
     }
 
-    /// Returns a vector of topics or topic patterns the consumer is subscribed to.
-    pub fn get_subscriptions(&self) -> Vec<String> {
+    /// Returns a list of topics or topic patterns the consumer is subscribed to.
+    pub fn get_subscriptions(&self) -> TopicPartitionList {
         let mut tp_list = unsafe { rdkafka::rd_kafka_topic_partition_list_new(0) };
         unsafe { rdkafka::rd_kafka_subscription(self.client.ptr, &mut tp_list as *mut *mut rdkafka::rd_kafka_topic_partition_list_t) };
-
-        let mut tp_res = Vec::new();
-        for i in 0..unsafe { (*tp_list).cnt } {
-            let elem = unsafe { (*tp_list).elems.offset(i as isize) };
-            let topic_name = unsafe { cstr_to_owned((*elem).topic) };
-            tp_res.push(topic_name);
-        }
-        unsafe { rdkafka::rd_kafka_topic_partition_list_destroy(tp_list) };
-        tp_res
+        TopicPartitionList::from_rdkafka(tp_list)
     }
 
     /// Polls the consumer for events. It won't block more than the specified timeout.

--- a/src/consumer/mod.rs
+++ b/src/consumer/mod.rs
@@ -5,6 +5,7 @@ use message::Message;
 use error::KafkaResult;
 
 use consumer::base_consumer::BaseConsumer;
+use topic_partition_list::TopicPartitionList;
 
 /// Specifies if the commit should be performed synchronously
 /// or asynchronously.
@@ -25,7 +26,7 @@ pub trait Consumer {
     // Default implementations
 
     /// Subscribe the consumer to a list of topics.
-    fn subscribe(&mut self, topics: &Vec<&str>) -> KafkaResult<()> {
+    fn subscribe(&mut self, topics: &TopicPartitionList) -> KafkaResult<()> {
         self.get_base_consumer_mut().subscribe(topics)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,4 +80,5 @@ pub mod consumer;
 pub mod error;
 pub mod message;
 pub mod producer;
+pub mod topic_partition_list;
 pub mod util;

--- a/src/topic_partition_list.rs
+++ b/src/topic_partition_list.rs
@@ -1,0 +1,137 @@
+extern crate rdkafka_sys as rdkafka;
+
+use std::collections::HashMap;
+use std::ffi::CString;
+use std::ops::Deref;
+use std::slice;
+
+use util::cstr_to_owned;
+
+/// Configuration of a partition
+#[derive(Debug,PartialEq)]
+pub struct Partition {
+    pub partition: i32,
+    pub offset: i64
+}
+
+pub type Topics = HashMap<String, Option<Vec<Partition>>>;
+
+/// Map of of topics with optionally partition configuration.
+#[derive(Debug,PartialEq)]
+pub struct TopicPartitionList {
+    pub topics: Topics
+}
+
+impl TopicPartitionList {
+    /// Create list based on a list from the rdkafka side.
+    pub fn from_rdkafka(tp_list: *const rdkafka::rd_kafka_topic_partition_list_t) -> TopicPartitionList {
+        let mut topics: Topics = HashMap::new();
+
+        unsafe {
+            let elements = slice::from_raw_parts((*tp_list).elems, (*tp_list).cnt as usize);
+            for tp in elements {
+                let topic_name = cstr_to_owned(tp.topic);
+                if tp.partition >= 0 || tp.offset >= 0 {
+                    let topic = topics.entry(topic_name).or_insert(Some(vec![]));
+                    match *topic {
+                        Some(ref mut p) => {
+                            p.push(Partition {
+                                partition: tp.partition,
+                                offset: tp.offset
+                            });
+                        },
+                        None => ()
+                    }
+                } else {
+                    // No configuration
+                    topics.insert(topic_name, None);
+                };
+            }
+        }
+
+        TopicPartitionList {
+            topics: topics
+        }
+    }
+
+    /// Create an empty list
+    pub fn new() -> TopicPartitionList {
+        TopicPartitionList {
+            topics: HashMap::new()
+        }
+    }
+
+    /// Create list with specified topics with default configuration
+    pub fn with_topics(topic_names: &Vec<&str>) -> TopicPartitionList {
+        let mut topics: Topics = HashMap::with_capacity(topic_names.len());
+
+        for topic_name in topic_names {
+            topics.insert(topic_name.to_string(), None);
+        }
+
+        TopicPartitionList {
+            topics: topics
+        }
+    }
+
+    /// Add topic with partitions configured
+    pub fn add_topic_with_partitions(&mut self, topic: &str, partitions: &Vec<i32>) {
+        let partitions_configs: Vec<Partition> = partitions.iter().map(|p| Partition { partition: *p, offset: -1001 } ).collect();
+        self.topics.insert(topic.to_string(), Some(partitions_configs));
+    }
+
+    pub fn create_native_topic_partition_list(&self) -> *mut rdkafka::rd_kafka_topic_partition_list_t {
+        let tp_list = unsafe { rdkafka::rd_kafka_topic_partition_list_new(self.topics.len() as i32) };
+
+        for (topic, partitions) in self.topics.iter() {
+            let topic_cstring = CString::new(topic.as_str()).unwrap();
+            match partitions {
+                &Some(ref ps) => {
+                    // Partitions specified
+                    for p in ps {
+                        unsafe { rdkafka::rd_kafka_topic_partition_list_add(tp_list, topic_cstring.as_ptr(), p.partition); }
+                    }
+                },
+                &None => {
+                    // No partitions specified
+                    unsafe { rdkafka::rd_kafka_topic_partition_list_add(tp_list, topic_cstring.as_ptr(), -1); }
+                }
+            }
+        }
+
+        tp_list
+    }
+}
+
+impl Deref for TopicPartitionList {
+    type Target = Topics;
+
+    fn deref(&self) -> &Topics {
+        &self.topics
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    extern crate rdkafka_sys as rdkafka;
+    use super::*;
+
+    #[test]
+    fn test_topic_partition_list_no_configuration() {
+        let list = TopicPartitionList::with_topics(&vec!["topic_1", "topic_2"]);
+        let through_rdkafka = TopicPartitionList::from_rdkafka(list.create_native_topic_partition_list());
+
+        assert_eq!(list, through_rdkafka);
+    }
+
+    #[test]
+    fn test_topic_partition_list_with_configuration() {
+        let mut list = TopicPartitionList::new();
+        list.add_topic_with_partitions("topic_1", &vec![1, 2, 3]);
+        list.add_topic_with_partitions("topic_2", &vec![1, 3, 5]);
+
+        let through_rdkafka = TopicPartitionList::from_rdkafka(list.create_native_topic_partition_list());
+
+        assert_eq!(list, through_rdkafka);
+    }
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -18,6 +18,6 @@ pub unsafe fn bytes_cstr_to_owned(bytes_cstr: &[i8]) -> String {
 }
 
 /// Converts a C string into a String.
-pub unsafe fn cstr_to_owned(cstr: *mut i8) -> String {
+pub unsafe fn cstr_to_owned(cstr: *const i8) -> String {
     CStr::from_ptr(cstr).to_string_lossy().into_owned()
 }


### PR DESCRIPTION
The rebalance callback uses the same data structure that's used for managing subscriptions. This adds a wrapper around this structure which now is also used when subscribing.

Currently there's no way to get rebalance events in the streaming consumer. Not sure how to do that yet.