### PR TITLE
Add lz4-sys crate

### DIFF
--- a/rdkafka-sys/Cargo.toml
+++ b/rdkafka-sys/Cargo.toml
@@ -10,9 +10,9 @@ description = "Native bindings to the librdkafka library"
 keywords = ["kafka", "rdkafka"]
 
 [dependencies]
-# lz4-sys = { git = "https://github.com/thijsc/lz4-rs.git" }
-libz-sys = ">= 1.0.7"
-openssl-sys = "> 0.7.0"
+lz4-sys = "^ 1.0"
+libz-sys = "^ 1.0"
+openssl-sys = "~ 0.9.0"
 
 [build-dependencies]
 num_cpus = "~ 0.2.0"

--- a/rdkafka-sys/src/lib.rs
+++ b/rdkafka-sys/src/lib.rs
@@ -1,7 +1,7 @@
 #[cfg(feature = "ssl")]
 extern crate openssl_sys;
 
-// extern crate lz4_sys;
+extern crate lz4_sys;
 extern crate libz_sys;
 
 pub mod bindings;


### PR DESCRIPTION
The separate `lz4-sys` crate was published, so we can re-add the dependency.