### PR TITLE
Add manual assignement to consumer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: rust
+script:
+  - cargo build --verbose
+  - cargo test --lib --verbose
 
 notifications:
   webhooks:

--- a/README.md
+++ b/README.md
@@ -81,6 +81,23 @@ You can find examples in the `examples` folder. To run them:
 cargo run --example <example_name> -- <example_args>
 ```
 
+## Tests
+
+The unit tests can run without a Kafka broker present:
+
+```
+cargo test --lib
+```
+
+To run the full suite:
+
+```
+cargo test
+```
+
+In this case there is a broker expected to be running on
+`localhost:9292`. Travis currently only runs the unit tests.
+
 ## Documentation
 
 Documentation is available on [docs.rs](https://docs.rs/rdkafka/).

--- a/examples/simple_consumer.rs
+++ b/examples/simple_consumer.rs
@@ -16,7 +16,6 @@ use rdkafka::topic_partition_list::TopicPartitionList;
 mod example_utils;
 use example_utils::setup_logger;
 
-
 // Use a Context to set up custom callbacks for rebalancing.
 struct LoggingContext { }
 

--- a/examples/simple_consumer.rs
+++ b/examples/simple_consumer.rs
@@ -11,7 +11,6 @@ use rdkafka::consumer::{Consumer, CommitMode};
 use rdkafka::consumer::stream_consumer::StreamConsumer;
 use rdkafka::config::{ClientConfig, TopicConfig};
 use rdkafka::util::get_rdkafka_version;
-use rdkafka::topic_partition_list::TopicPartitionList;
 
 mod example_utils;
 use example_utils::setup_logger;
@@ -29,7 +28,7 @@ impl Context for LoggingContext {
     }
 }
 
-fn consume_and_print(brokers: &str, group_id: &str, topics: &TopicPartitionList) {
+fn consume_and_print(brokers: &str, group_id: &str, topics: &Vec<&str>) {
     let context = LoggingContext{};
 
     let mut consumer = ClientConfig::new()
@@ -114,7 +113,7 @@ fn main() {
     let (version_n, version_s) = get_rdkafka_version();
     info!("rd_kafka_version: 0x{:08x}, {}", version_n, version_s);
 
-    let topics = TopicPartitionList::with_topics(&matches.values_of("topics").unwrap().collect::<Vec<&str>>());
+    let topics = matches.values_of("topics").unwrap().collect::<Vec<&str>>();
     let brokers = matches.value_of("brokers").unwrap();
     let group_id = matches.value_of("group-id").unwrap();
 

--- a/examples/simple_producer.rs
+++ b/examples/simple_producer.rs
@@ -7,7 +7,7 @@ use clap::{App, Arg};
 use futures::*;
 
 use rdkafka::config::{ClientConfig, TopicConfig};
-use rdkafka::producer::{FutureProducer};
+use rdkafka::producer::FutureProducer;
 use rdkafka::util::get_rdkafka_version;
 
 mod example_utils;
@@ -77,5 +77,3 @@ fn main() {
 
     produce(brokers, topic);
 }
-
-

--- a/src/client.rs
+++ b/src/client.rs
@@ -205,7 +205,14 @@ impl<'a, C: Context> Topic<'a, C> {
         }
     }
 
-    /// Returns a pointer to the correspondent rdkafka `RDKafkaTopic` stuct.
+    /// Get topic's name
+    pub fn get_name(&self) -> String {
+        unsafe {
+            cstr_to_owned(rdkafka::rd_kafka_topic_name(self.ptr))
+        }
+    }
+
+    /// Returns a pointer to the correspondent rdkafka `rd_kafka_topic_t` stuct.
     pub fn get_ptr(&self) -> *mut RDKafkaTopic {
         self.ptr
     }
@@ -217,5 +224,28 @@ impl<'a, C: Context> Drop for Topic<'a, C> {
         unsafe {
             rdkafka::rd_kafka_topic_destroy(self.ptr);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // Just call everything to test there no panics by default, behavior
+    // is tested in the integrations tests.
+
+    use config::{ClientConfig,TopicConfig};
+    use super::*;
+
+    #[test]
+    fn test_client() {
+        let client = Client::new(&ClientConfig::new(), ClientType::Consumer, EmptyContext::new()).unwrap();
+        assert!(!client.get_ptr().is_null());
+    }
+
+    #[test]
+    fn test_topic() {
+        let client = Client::new(&ClientConfig::new(), ClientType::Consumer, EmptyContext::new()).unwrap();
+        let topic = Topic::new(&client, "topic_name", &TopicConfig::new()).unwrap();
+        assert_eq!(topic.get_name(), "topic_name");
+        assert!(!topic.get_ptr().is_null());
     }
 }

--- a/src/consumer/base_consumer.rs
+++ b/src/consumer/base_consumer.rs
@@ -41,8 +41,8 @@ impl<C: Context> BaseConsumer<C> {
     /// Subscribes the consumer to a list of topics and/or topic sets (using regex).
     /// Strings starting with `^` will be regex-matched to the full list of topics in
     /// the cluster and matching topics will be added to the subscription list.
-    pub fn subscribe(&mut self, topics: &TopicPartitionList) -> KafkaResult<()> {
-        let tp_list = topics.create_native_topic_partition_list();
+    pub fn subscribe(&mut self, topics: &Vec<&str>) -> KafkaResult<()> {
+        let tp_list = TopicPartitionList::with_topics(topics).create_native_topic_partition_list();
         let ret_code = unsafe { rdkafka::rd_kafka_subscribe(self.client.get_ptr(), tp_list) };
         if ret_code.is_error() {
             let error = unsafe { cstr_to_owned(rdkafka::rd_kafka_err2str(ret_code)) };
@@ -55,6 +55,18 @@ impl<C: Context> BaseConsumer<C> {
     /// Unsubscribe from previous subscription list.
     pub fn unsubscribe(&mut self) {
         unsafe { rdkafka::rd_kafka_unsubscribe(self.client.get_ptr()) };
+    }
+
+    /// Manually assign topics and partitions to consume.
+    pub fn assign(&mut self, assignment: &TopicPartitionList) -> KafkaResult<()> {
+        let tp_list = assignment.create_native_topic_partition_list();
+        let ret_code = unsafe { rdkafka::rd_kafka_assign(self.client.get_ptr(), tp_list) };
+        if ret_code.is_error() {
+            let error = unsafe { cstr_to_owned(rdkafka::rd_kafka_err2str(ret_code)) };
+            return Err(KafkaError::Subscription(error))
+        };
+        unsafe { rdkafka::rd_kafka_topic_partition_list_destroy(tp_list) };
+        Ok(())
     }
 
     /// Returns a list of topics or topic patterns the consumer is subscribed to.

--- a/src/consumer/base_consumer.rs
+++ b/src/consumer/base_consumer.rs
@@ -72,7 +72,12 @@ impl<C: Context> BaseConsumer<C> {
         }
         let error = unsafe { (*message_ptr).err };
         if error.is_error() {
-            return Err(KafkaError::MessageConsumption(error));
+            return Err(match error {
+                rdkafka::rd_kafka_resp_err_t::RD_KAFKA_RESP_ERR__PARTITION_EOF => {
+                    KafkaError::PartitionEof
+                },
+                e => KafkaError::MessageConsumption(e)
+            })
         }
         let kafka_message = Message::new(message_ptr);
         Ok(Some(kafka_message))

--- a/src/consumer/mod.rs
+++ b/src/consumer/mod.rs
@@ -28,8 +28,13 @@ pub trait Consumer<C: Context> {
     // Default implementations
 
     /// Subscribe the consumer to a list of topics.
-    fn subscribe(&mut self, topics: &TopicPartitionList) -> KafkaResult<()> {
+    fn subscribe(&mut self, topics: &Vec<&str>) -> KafkaResult<()> {
         self.get_base_consumer_mut().subscribe(topics)
+    }
+
+    /// Manually assign topics and partitions to the consumer.
+    fn assign(&mut self, assignment: &TopicPartitionList) -> KafkaResult<()> {
+        self.get_base_consumer_mut().assign(assignment)
     }
 
     /// Commit a specific message. If mode is set to CommitMode::Sync,

--- a/src/error.rs
+++ b/src/error.rs
@@ -38,6 +38,7 @@ pub enum KafkaError {
     Subscription(String),
     TopicConfig((RDKafkaConfRes, String, String, String)),
     TopicCreation(String),
+    PartitionEof
 }
 
 impl From<std::ffi::NulError> for KafkaError {

--- a/tests/produce_consume_base_test.rs
+++ b/tests/produce_consume_base_test.rs
@@ -10,7 +10,6 @@ use rdkafka::consumer::{Consumer, CommitMode};
 use rdkafka::consumer::stream_consumer::StreamConsumer;
 use rdkafka::message::Message;
 use rdkafka::producer::FutureProducer;
-use rdkafka::topic_partition_list::TopicPartitionList;
 
 #[test]
 fn test_produce_consume_base() {
@@ -30,7 +29,7 @@ fn test_produce_consume_base() {
         )
         .create_with_context::<_, StreamConsumer<EmptyContext>>(context)
         .expect("Consumer creation failed");
-    consumer.subscribe(&TopicPartitionList::with_topics(&vec!["produce_consume_base"])).expect("Can't subscribe to specified topics");
+    consumer.subscribe(&vec!["produce_consume_base"]).expect("Can't subscribe to specified topics");
     let message_stream = consumer.start();
 
     // Produce some messages

--- a/tests/produce_consume_base_test.rs
+++ b/tests/produce_consume_base_test.rs
@@ -1,0 +1,83 @@
+extern crate futures;
+extern crate rdkafka;
+
+use futures::*;
+use futures::stream::Stream;
+
+use rdkafka::client::EmptyContext;
+use rdkafka::config::{ClientConfig, TopicConfig};
+use rdkafka::consumer::{Consumer, CommitMode};
+use rdkafka::consumer::stream_consumer::StreamConsumer;
+use rdkafka::message::Message;
+use rdkafka::producer::FutureProducer;
+use rdkafka::topic_partition_list::TopicPartitionList;
+
+#[test]
+fn test_produce_consume_base() {
+    let context = EmptyContext::new();
+
+    // Create consumer
+    let mut consumer = ClientConfig::new()
+        .set("group.id", "produce_consume_base")
+        .set("bootstrap.servers", "localhost:9092")
+        .set("enable.partition.eof", "false")
+        .set("session.timeout.ms", "6000")
+        .set("enable.auto.commit", "false")
+        .set_default_topic_config(
+             TopicConfig::new()
+                 .set("auto.offset.reset", "earliest")
+                 .finalize()
+        )
+        .create_with_context::<_, StreamConsumer<EmptyContext>>(context)
+        .expect("Consumer creation failed");
+    consumer.subscribe(&TopicPartitionList::with_topics(&vec!["produce_consume_base"])).expect("Can't subscribe to specified topics");
+    let message_stream = consumer.start();
+
+    // Produce some messages
+    let mut producer = ClientConfig::new()
+        .set("bootstrap.servers", "localhost:9092")
+        .create::<FutureProducer<_>>()
+        .expect("Producer creation error");
+
+    producer.start();
+
+    let topic_config = TopicConfig::new()
+        .set("produce.offset.report", "true")
+        .finalize();
+
+    let topic = producer.get_topic("produce_consume_base", &topic_config)
+        .expect("Topic creation error");
+
+    let futures = (0..5)
+        .map(|i| {
+            let value = format!("Message {}", i);
+            producer.send_copy(&topic, None, Some(&value), Some(&vec![0, 1, 2, 3]))
+                .expect("Production failed")
+        })
+        .collect::<Vec<_>>();
+
+    for future in futures {
+        future.wait().expect("Waiting for future failed");
+    }
+
+    // Consume the messages
+    let messages: Vec<Message> = message_stream.take(5).wait().map({ |message|
+        match message {
+            Ok(m) => {
+                consumer.commit_message(&m, CommitMode::Async);
+                m
+            },
+            Err(e) => panic!("Error receiving message: {:?}", e)
+        }
+    }).collect();
+
+    for i in 0..5 {
+        match messages.get(i) {
+            Some(ref message) => {
+                assert_eq!(message.get_key_view::<[u8]>().unwrap().unwrap(), [0, 1, 2, 3]);
+                assert_eq!(message.get_payload_view::<str>().unwrap().unwrap(), format!("Message {}", i));
+            }
+            None => panic!("Message expected")
+        }
+    }
+}


### PR DESCRIPTION
Add separate function to manually assign a topic/partition list for a consumer. Change back `subscribe` to accept a vector of strings to set the correct expectation on how to use it.

Based on #8, will rebase once that's merged.