### PR TITLE
Integrate rdkafka logging with log crate

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -5,6 +5,8 @@ use std::ffi::CString;
 use std::os::raw::c_void;
 use std::ptr;
 
+use log::LogLevel;
+
 use self::rdkafka::types::*;
 
 use config::{ClientConfig, TopicConfig};
@@ -154,6 +156,18 @@ impl<C: Context> Client<C> {
             let descr = unsafe { bytes_cstr_to_owned(&errstr) };
             return Err(KafkaError::ClientCreation(descr));
         }
+
+        // Set log level based on log crate's settings
+        let log_level = if log_enabled!(LogLevel::Debug) {
+            7
+        } else if log_enabled!(LogLevel::Info) {
+            5
+        } else if log_enabled!(LogLevel::Warn) {
+            4
+        } else {
+            3
+        };
+        unsafe { rdkafka::rd_kafka_set_log_level(client_ptr, log_level) };
 
         Ok(Client {
             native: NativeClient { ptr: client_ptr },

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,13 +4,33 @@ extern crate rdkafka_sys as rdkafka;
 use self::rdkafka::types::*;
 
 use std::collections::HashMap;
-use std::ffi::CString;
+use std::ffi::{CStr, CString};
 use util::bytes_cstr_to_owned;
 
 use error::{KafkaError, KafkaResult, IsError};
 use client::{Context, DeliveryCallback, EmptyContext};
 
 const ERR_LEN: usize = 256;
+
+unsafe extern "C" fn log_cb(
+    _: *const rdkafka::rd_kafka_s,
+    level: i32,
+    fac: *const i8,
+    buf: *const i8
+) {
+    let fac_str = CStr::from_ptr(fac).to_string_lossy();
+    let buf_str = CStr::from_ptr(buf).to_string_lossy();
+    match level {
+        0 => error!("rdkafka {}: {}", fac_str, buf_str),
+        1 => error!("rdkafka {}: {}", fac_str, buf_str),
+        2 => error!("rdkafka {}: {}", fac_str, buf_str),
+        3 => error!("rdkafka {}: {}", fac_str, buf_str),
+        4 => warn!("rdkafka {}: {}", fac_str, buf_str),
+        5 => info!("rdkafka {}: {}", fac_str, buf_str),
+        6 => info!("rdkafka {}: {}", fac_str, buf_str),
+        _ => debug!("rdkafka {}: {}", fac_str, buf_str),
+    }
+}
 
 /// Client configuration.
 #[derive(Clone)]
@@ -72,6 +92,7 @@ impl ClientConfig {
                 unsafe { rdkafka::rd_kafka_conf_set_default_topic_conf(conf, topic_config.unwrap()) };
             }
         }
+        unsafe { rdkafka::rd_kafka_conf_set_log_cb(conf, Some(log_cb)) };
         Ok(conf)
     }
 


### PR DESCRIPTION
Pipe rdkafka logs to Rust logging, so they show up in the same format and with the same levels as your normal logs.