### PR TITLE
Make EmptyProducerContext public

### DIFF
--- a/src/producer.rs
+++ b/src/producer.rs
@@ -34,7 +34,7 @@ pub trait ProducerContext: Context {
 }
 
 #[derive(Clone)]
-struct EmptyProducerContext;
+pub struct EmptyProducerContext;
 
 impl Context for EmptyProducerContext { }
 impl ProducerContext for EmptyProducerContext {


### PR DESCRIPTION
I need this for the type signature of one of the structs in our project.