### PR TITLE
Store integer value in CommitMode enum

### DIFF
--- a/src/consumer/base_consumer.rs
+++ b/src/consumer/base_consumer.rs
@@ -109,12 +109,7 @@ impl<C: ConsumerContext> BaseConsumer<C> {
 
     /// Commits the current message. The commit can be synk (blocking), or async.
     pub fn commit_message(&self, message: &Message, mode: CommitMode) {
-        let async = match mode {
-            CommitMode::Sync => 0,
-            CommitMode::Async => 1,
-        };
-
-        unsafe { rdkafka::rd_kafka_commit_message(self.client.native_ptr(), message.ptr(), async) };
+        unsafe { rdkafka::rd_kafka_commit_message(self.client.native_ptr(), message.ptr(), mode as i32) };
     }
 
     /// Returns the metadata information of the entire cluster for all the topics in the cluster.

--- a/src/consumer/mod.rs
+++ b/src/consumer/mod.rs
@@ -106,9 +106,9 @@ unsafe extern "C" fn rebalance_cb<C: ConsumerContext>(rk: *mut RDKafka,
 /// or asynchronously.
 pub enum CommitMode {
     /// Synchronous commit.
-    Sync,
+    Sync = 0,
     /// Asynchronous commit.
-    Async,
+    Async = 1,
 }
 
 /// Common trait for all consumers


### PR DESCRIPTION
I like this pattern of storing the integer representation in the enum itself.