### PR TITLE
Add pause and resume to consumer

### DIFF
--- a/rdkafka-sys/src/bindings.rs
+++ b/rdkafka-sys/src/bindings.rs
@@ -976,7 +976,7 @@ pub enum rd_kafka_queue_s { }
 pub type rd_kafka_queue_t = rd_kafka_queue_s;
 #[derive(Copy, Clone)]
 #[repr(i32)]
-#[derive(Debug)]
+#[derive(Debug,PartialEq)]
 pub enum rd_kafka_resp_err_t {
     RD_KAFKA_RESP_ERR__BEGIN = -200,
     RD_KAFKA_RESP_ERR__BAD_MSG = -199,

--- a/src/consumer/base_consumer.rs
+++ b/src/consumer/base_consumer.rs
@@ -81,6 +81,24 @@ impl<C: ConsumerContext> BaseConsumer<C> {
         Ok(())
     }
 
+    /// Pause consuming of this consumer for given topics. Success or error is returned per-partition in the partitions list.
+    pub fn pause(&self, topics: &Vec<&str>) -> TopicPartitionList {
+        let tp_list = TopicPartitionList::with_topics(topics).create_native_topic_partition_list();
+        unsafe { rdkafka::rd_kafka_pause_partitions(self.client.native_ptr(), tp_list) };
+        let out_list = TopicPartitionList::from_rdkafka(tp_list);
+        unsafe { rdkafka::rd_kafka_topic_partition_list_destroy(tp_list) };
+        out_list
+    }
+
+    /// Resume consuming of this consumer for given topics. Success or error is returned per-partition in the partitions list.
+    pub fn resume(&self, topics: &Vec<&str>) -> TopicPartitionList {
+        let tp_list = TopicPartitionList::with_topics(topics).create_native_topic_partition_list();
+        unsafe { rdkafka::rd_kafka_resume_partitions(self.client.native_ptr(), tp_list) };
+        let out_list = TopicPartitionList::from_rdkafka(tp_list);
+        unsafe { rdkafka::rd_kafka_topic_partition_list_destroy(tp_list) };
+        out_list
+    }
+
     /// Returns a list of topics or topic patterns the consumer is subscribed to.
     pub fn get_subscriptions(&self) -> TopicPartitionList {
         let mut tp_list = unsafe { rdkafka::rd_kafka_topic_partition_list_new(0) };

--- a/src/consumer/base_consumer.rs
+++ b/src/consumer/base_consumer.rs
@@ -81,22 +81,24 @@ impl<C: ConsumerContext> BaseConsumer<C> {
         Ok(())
     }
 
-    /// Pause consuming of this consumer for given topics. Success or error is returned per-partition in the partitions list.
-    pub fn pause(&self, topics: &Vec<&str>) -> TopicPartitionList {
-        let tp_list = TopicPartitionList::with_topics(topics).create_native_topic_partition_list();
-        unsafe { rdkafka::rd_kafka_pause_partitions(self.client.native_ptr(), tp_list) };
-        let out_list = TopicPartitionList::from_rdkafka(tp_list);
-        unsafe { rdkafka::rd_kafka_topic_partition_list_destroy(tp_list) };
-        out_list
+    /// Pause consuming of this consumer.
+    pub fn pause(&self) {
+        unsafe {
+            let mut tp_list = rdkafka::rd_kafka_topic_partition_list_new(0);
+            rdkafka::rd_kafka_assignment(self.client.native_ptr(), &mut tp_list);
+            rdkafka::rd_kafka_pause_partitions(self.client.native_ptr(), tp_list);
+            rdkafka::rd_kafka_topic_partition_list_destroy(tp_list);
+        }
     }
 
-    /// Resume consuming of this consumer for given topics. Success or error is returned per-partition in the partitions list.
-    pub fn resume(&self, topics: &Vec<&str>) -> TopicPartitionList {
-        let tp_list = TopicPartitionList::with_topics(topics).create_native_topic_partition_list();
-        unsafe { rdkafka::rd_kafka_resume_partitions(self.client.native_ptr(), tp_list) };
-        let out_list = TopicPartitionList::from_rdkafka(tp_list);
-        unsafe { rdkafka::rd_kafka_topic_partition_list_destroy(tp_list) };
-        out_list
+    /// Resume consuming of this consumer.
+    pub fn resume(&self) {
+        unsafe {
+            let mut tp_list = rdkafka::rd_kafka_topic_partition_list_new(0);
+            rdkafka::rd_kafka_assignment(self.client.native_ptr(), &mut tp_list);
+            rdkafka::rd_kafka_resume_partitions(self.client.native_ptr(), tp_list);
+            rdkafka::rd_kafka_topic_partition_list_destroy(tp_list);
+        }
     }
 
     /// Returns a list of topics or topic patterns the consumer is subscribed to.

--- a/src/consumer/mod.rs
+++ b/src/consumer/mod.rs
@@ -130,6 +130,16 @@ pub trait Consumer<C: ConsumerContext> {
         self.get_base_consumer_mut().assign(assignment)
     }
 
+    /// Pause consuming of this consumer for given topics. Success or error is returned per-partition in the partitions list.
+    fn pause(&self, topics: &Vec<&str>) -> TopicPartitionList {
+        self.get_base_consumer().pause(topics)
+    }
+
+    /// Resume consuming of this consumer for given topics. Success or error is returned per-partition in the partitions list.
+    fn resume(&self, topics: &Vec<&str>) -> TopicPartitionList {
+        self.get_base_consumer().resume(topics)
+    }
+
     /// Commit a specific message. If mode is set to CommitMode::Sync,
     /// the call will block until the message has been succesfully
     /// committed.

--- a/src/consumer/mod.rs
+++ b/src/consumer/mod.rs
@@ -130,14 +130,14 @@ pub trait Consumer<C: ConsumerContext> {
         self.get_base_consumer_mut().assign(assignment)
     }
 
-    /// Pause consuming of this consumer for given topics. Success or error is returned per-partition in the partitions list.
-    fn pause(&self, topics: &Vec<&str>) -> TopicPartitionList {
-        self.get_base_consumer().pause(topics)
+    /// Pause consuming of this consumer.
+    fn pause(&self) {
+        self.get_base_consumer().pause()
     }
 
-    /// Resume consuming of this consumer for given topics. Success or error is returned per-partition in the partitions list.
-    fn resume(&self, topics: &Vec<&str>) -> TopicPartitionList {
-        self.get_base_consumer().resume(topics)
+    /// Resume consuming of this consumer.
+    fn resume(&self) {
+        self.get_base_consumer().resume()
     }
 
     /// Commit a specific message. If mode is set to CommitMode::Sync,

--- a/src/consumer/mod.rs
+++ b/src/consumer/mod.rs
@@ -92,15 +92,14 @@ pub enum Rebalance {
 /// Native rebalance callback. This callback will run on every rebalance, and it will call the
 /// rebalance method defined in the current `Context`.
 unsafe extern "C" fn rebalance_cb<C: ConsumerContext>(rk: *mut RDKafka,
-                                                          err: RDKafkaRespErr,
-                                                          partitions: *mut RDKafkaTopicPartitionList,
-                                                          opaque_ptr: *mut c_void) {
+                                                      err: RDKafkaRespErr,
+                                                      partitions: *mut RDKafkaTopicPartitionList,
+                                                      opaque_ptr: *mut c_void) {
     let context: &C = &*(opaque_ptr as *const C);
     let native_client = NativeClient::new(rk);
 
     context.rebalance(&native_client, err, partitions);
 }
-
 
 /// Specifies if the commit should be performed synchronously
 /// or asynchronously.

--- a/src/consumer/stream_consumer.rs
+++ b/src/consumer/stream_consumer.rs
@@ -17,13 +17,13 @@ use message::Message;
 
 use consumer::{Consumer, ConsumerContext, EmptyConsumerContext};
 use consumer::base_consumer::BaseConsumer;
-use topic_partition_list::TopicPartitionList;
 
 /// A Consumer with an associated polling thread. This consumer doesn't need to
 /// be polled and it will return all consumed messages as a `Stream`.
 #[must_use = "Consumer polling thread will stop immediately if unused"]
 pub struct StreamConsumer<C: ConsumerContext + 'static> {
     consumer: Arc<BaseConsumer<C>>,
+    paused: Arc<AtomicBool>,
     should_stop: Arc<AtomicBool>,
     handle: Option<JoinHandle<()>>,
 }
@@ -49,6 +49,7 @@ impl<C: ConsumerContext> FromClientConfigAndContext<C> for StreamConsumer<C> {
     fn from_config_and_context(config: &ClientConfig, context: C) -> KafkaResult<StreamConsumer<C>> {
         let stream_consumer = StreamConsumer {
             consumer: Arc::new(try!(BaseConsumer::from_config_and_context(config, context))),
+            paused: Arc::new(AtomicBool::new(false)),
             should_stop: Arc::new(AtomicBool::new(false)),
             handle: None,
         };
@@ -61,11 +62,12 @@ impl<C: ConsumerContext> StreamConsumer<C> {
     pub fn start(&mut self) -> Receiver<Message, KafkaError> {
         let (sender, receiver) = stream::channel();
         let consumer = self.consumer.clone();
+        let paused = self.paused.clone();
         let should_stop = self.should_stop.clone();
         let handle = thread::Builder::new()
             .name("poll".to_string())
             .spawn(move || {
-                poll_loop(consumer, sender, should_stop);
+                poll_loop(consumer, sender, paused, should_stop);
             })
             .expect("Failed to start polling thread");
         self.handle = Some(handle);
@@ -86,16 +88,18 @@ impl<C: ConsumerContext> StreamConsumer<C> {
         }
     }
 
-    /// Pause consuming of this consumer for given topics. Success or error is returned per-partition in the partitions list.
-    pub fn pause(&self, topics: &Vec<&str>) -> TopicPartitionList {
+    /// Pause consuming of this consumer.
+    pub fn pause(&mut self) {
         trace!("Pausing consumer");
-        self.consumer.pause(topics)
+        self.consumer.pause();
+        self.paused.store(true, Ordering::Relaxed);
     }
 
-    /// Resume consuming of this consumer for given topics. Success or error is returned per-partition in the partitions list.
-    pub fn resume(&self, topics: &Vec<&str>) -> TopicPartitionList {
+    /// Resume consuming of this consumer.
+    pub fn resume(&mut self) {
         trace!("Resuming consumer");
-        self.consumer.resume(topics)
+        self.consumer.resume();
+        self.paused.store(false, Ordering::Relaxed);
     }
 }
 
@@ -107,15 +111,33 @@ impl<C: ConsumerContext> Drop for StreamConsumer<C> {
 }
 
 /// Internal consumer loop.
-fn poll_loop<C: ConsumerContext>(consumer: Arc<BaseConsumer<C>>, sender: Sender<Message, KafkaError>, should_stop: Arc<AtomicBool>) {
+fn poll_loop<C: ConsumerContext>(
+    consumer: Arc<BaseConsumer<C>>,
+    sender: Sender<Message, KafkaError>,
+    paused: Arc<AtomicBool>,
+    should_stop: Arc<AtomicBool>
+) {
     trace!("Polling thread loop started");
     let mut curr_sender = sender;
     while !should_stop.load(Ordering::Relaxed) {
+        // Poll Kafka and create a future if there is a result
         let future_sender = match consumer.poll(100) {
             Ok(None) => continue,
             Ok(Some(m)) => curr_sender.send(Ok(m)),
             Err(e) => curr_sender.send(Err(e)),
         };
+
+        // If we're paused we should still poll, even if the future
+        // is not being received on the other end.
+        while paused.load(Ordering::Relaxed) {
+            match consumer.poll(100) {
+                Ok(None) => continue,
+                Ok(Some(_)) => panic!("Received result from poll while paused"),
+                Err(e) => error!("Error polling while paused: {}", e)
+            }
+        }
+
+        // Wait for the future until we go to the next poll
         match future_sender.wait() {
             Ok(new_sender) => curr_sender = new_sender,
             Err(e) => {

--- a/src/consumer/stream_consumer.rs
+++ b/src/consumer/stream_consumer.rs
@@ -17,7 +17,7 @@ use message::Message;
 
 use consumer::{Consumer, ConsumerContext, EmptyConsumerContext};
 use consumer::base_consumer::BaseConsumer;
-
+use topic_partition_list::TopicPartitionList;
 
 /// A Consumer with an associated polling thread. This consumer doesn't need to
 /// be polled and it will return all consumed messages as a `Stream`.
@@ -84,6 +84,18 @@ impl<C: ConsumerContext> StreamConsumer<C> {
                 Err(e) => warn!("Failure while terminating thread: {:?}", e),
             };
         }
+    }
+
+    /// Pause consuming of this consumer for given topics. Success or error is returned per-partition in the partitions list.
+    pub fn pause(&self, topics: &Vec<&str>) -> TopicPartitionList {
+        trace!("Pausing consumer");
+        self.consumer.pause(topics)
+    }
+
+    /// Resume consuming of this consumer for given topics. Success or error is returned per-partition in the partitions list.
+    pub fn resume(&self, topics: &Vec<&str>) -> TopicPartitionList {
+        trace!("Resuming consumer");
+        self.consumer.resume(topics)
     }
 }
 

--- a/tests/produce_consume_base_test.rs
+++ b/tests/produce_consume_base_test.rs
@@ -67,6 +67,11 @@ fn test_produce_consume_base() {
         }
     }).collect();
 
+    // Pause and resume
+    consumer.pause(&vec!["produce_consume_base"]);
+    consumer.resume(&vec!["produce_consume_base"]);
+
+    // See if we have valid messages
     for i in 0..5 {
         match messages.get(i) {
             Some(ref message) => {

--- a/tests/produce_consume_base_test.rs
+++ b/tests/produce_consume_base_test.rs
@@ -61,15 +61,14 @@ fn test_produce_consume_base() {
         match message {
             Ok(m) => {
                 consumer.commit_message(&m, CommitMode::Async);
+                // Pause and resume
+                consumer.pause();
+                consumer.resume();
                 m
             },
             Err(e) => panic!("Error receiving message: {:?}", e)
         }
     }).collect();
-
-    // Pause and resume
-    consumer.pause(&vec!["produce_consume_base"]);
-    consumer.resume(&vec!["produce_consume_base"]);
 
     // See if we have valid messages
     for i in 0..5 {


### PR DESCRIPTION
Add pause and resume so you can pause consuming messages without triggering a rebalance.