### PR TITLE
Bump to futures 0.1.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ rdkafka-sys = { path = "rdkafka-sys", version = "0.9.2-3" }
 clap = "2.18.0"
 env_logger = "^0.3.0"
 errno = "^0.1.8"
-futures = "=0.1.3"
+futures = "^0.1.7"
 libc = "^0.2.0"
 log = "^0.3.0"
 

--- a/tests/produce_consume_base_test.rs
+++ b/tests/produce_consume_base_test.rs
@@ -2,7 +2,6 @@ extern crate futures;
 extern crate rdkafka;
 
 use futures::*;
-use futures::stream::Stream;
 
 use rdkafka::config::{ClientConfig, TopicConfig};
 use rdkafka::consumer::{Consumer, CommitMode};


### PR DESCRIPTION
Seems to compile; this change will allow folks to use the current version of `tokio` in the same project as `rust-rdkafka`.