### PR TITLE
Convert unwraps to expects and test for custom product context

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -75,7 +75,7 @@ impl ClientConfig {
             if let Err(e) = topic_config {
                 return Err(e);
             } else {
-                unsafe { rdkafka::rd_kafka_conf_set_default_topic_conf(conf, topic_config.unwrap()) };
+                unsafe { rdkafka::rd_kafka_conf_set_default_topic_conf(conf, topic_config.expect("No topic config present when creating native config")) };
             }
         }
         unsafe { rdkafka::rd_kafka_conf_set_log_cb(conf, Some(log_cb)) };

--- a/src/consumer/stream_consumer.rs
+++ b/src/consumer/stream_consumer.rs
@@ -36,7 +36,7 @@ impl<C: ConsumerContext> Consumer<C> for StreamConsumer<C> {
     }
 
     fn get_base_consumer_mut(&mut self) -> &mut BaseConsumer<C> {
-        Arc::get_mut(&mut self.consumer).unwrap()  // TODO add check?
+        Arc::get_mut(&mut self.consumer).expect("Could not get mutable consumer from context")  // TODO add check?
     }
 }
 
@@ -101,7 +101,7 @@ impl<C: ConsumerContext> StreamConsumer<C> {
             trace!("Stopping polling");
             self.should_stop.store(true, Ordering::Relaxed);
             trace!("Waiting for polling thread termination");
-            match self.handle.take().unwrap().join() {
+            match self.handle.take().expect("no handle present in consumer context").join() {
                 Ok(()) => trace!("Polling stopped"),
                 Err(e) => warn!("Failure while terminating thread: {:?}", e),
             };

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -17,7 +17,7 @@ use self::futures::{Canceled, Complete, Future, Poll, Oneshot};
 
 use client::{Client, Context};
 use config::{ClientConfig, FromClientConfig, FromClientConfigAndContext, TopicConfig};
-use error::{KafkaError, KafkaResult};
+use error::{KafkaError, KafkaResult, IsError};
 use message::ToBytes;
 use util::cstr_to_owned;
 
@@ -153,9 +153,13 @@ impl DeliveryReport {
         }
     }
 
-    /// Returns the error associated with the production of the message.
-    pub fn error(&self) -> RDKafkaRespErr {
-        self.error
+    /// Returns the result of the production of the message.
+    pub fn result(&self) -> Result<(), KafkaError> {
+        if self.error.is_error() {
+            Err(KafkaError::MessageProduction(self.error))
+        } else {
+            Ok(())
+        }
     }
 
     /// Returns the partition of the message.

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -41,7 +41,7 @@ impl NativeTopic {
     /// the client it was created from.
     unsafe fn new(client: *mut RDKafka, name: &str, topic_config_ptr: *mut RDKafkaTopicConf)
             -> KafkaResult<NativeTopic> {
-        let name_ptr = CString::new(name.to_string()).unwrap(); // TODO: remove unwrap
+        let name_ptr = CString::new(name.to_string()).expect("could not create name CString"); // TODO: remove expect
         let topic_ptr = rdkafka::rd_kafka_topic_new(client, name_ptr.as_ptr(), topic_config_ptr);
         if topic_ptr.is_null() {
             Err(KafkaError::TopicCreation(name.to_owned()))
@@ -353,7 +353,7 @@ impl<C: ProducerContext> _FutureProducer<C> {
                     trace!("Stopping polling");
                     self.should_stop.store(true, Ordering::Relaxed);
                     trace!("Waiting for polling thread termination");
-                    match handle.take().unwrap().join() {
+                    match handle.take().expect("no handle present in producer context").join() {
                         Ok(()) => trace!("Polling stopped"),
                         Err(e) => warn!("Failure while terminating thread: {:?}", e),
                     };

--- a/src/topic_partition_list.rs
+++ b/src/topic_partition_list.rs
@@ -89,7 +89,7 @@ impl TopicPartitionList {
         let tp_list = unsafe { rdkafka::rd_kafka_topic_partition_list_new(self.topics.len() as i32) };
 
         for (topic, partitions) in self.topics.iter() {
-            let topic_cstring = CString::new(topic.as_str()).unwrap();
+            let topic_cstring = CString::new(topic.as_str()).expect("could not create name CString");
             match partitions {
                 &Some(ref ps) => {
                     // Partitions specified

--- a/tests/produce_consume_custom_context_test.rs
+++ b/tests/produce_consume_custom_context_test.rs
@@ -1,0 +1,104 @@
+extern crate futures;
+extern crate rdkafka;
+
+use futures::*;
+
+use rdkafka::client::Context;
+use rdkafka::config::{ClientConfig, TopicConfig};
+use rdkafka::consumer::{Consumer, CommitMode};
+use rdkafka::consumer::stream_consumer::StreamConsumer;
+use rdkafka::message::Message;
+use rdkafka::producer::{DeliveryReport,FutureProducer,ProducerContext};
+
+static NUMBER_OF_MESSAGES: u64 = 100;
+
+pub struct CustomProducerContext {
+    pub name: &'static str
+}
+impl CustomProducerContext {
+    pub fn new(name: &'static str) -> CustomProducerContext {
+        CustomProducerContext { name: name }
+    }
+}
+impl Context for CustomProducerContext { }
+impl ProducerContext for CustomProducerContext {
+    type DeliveryContext = ();
+
+    fn delivery(&self, report: DeliveryReport, _: Self::DeliveryContext) {
+        println!("Delivery on {}: {:?}", self.name, report);
+    }
+}
+
+#[test]
+fn produce_consume_custom_context_test() {
+    // Create consumer
+    let mut consumer = ClientConfig::new()
+        .set("group.id", "produce_consume_custom_context")
+        .set("bootstrap.servers", "localhost:9092")
+        .set("enable.partition.eof", "false")
+        .set("session.timeout.ms", "6000")
+        .set("enable.auto.commit", "false")
+        .set_default_topic_config(
+             TopicConfig::new()
+                 .set("auto.offset.reset", "earliest")
+                 .finalize()
+        )
+        .create::<StreamConsumer<_>>()
+        .expect("Consumer creation failed");
+    consumer.subscribe(&vec!["produce_consume_custom_context"]).expect("Can't subscribe to specified topics");
+    let message_stream = consumer.start();
+
+    // Produce some messages
+    let producer = ClientConfig::new()
+        .set("bootstrap.servers", "localhost:9092")
+        .create_with_context::<_, FutureProducer<_>>(CustomProducerContext::new("producer"))
+        .expect("Producer creation error");
+
+    producer.start();
+
+    let topic_config = TopicConfig::new()
+        .set("produce.offset.report", "true")
+        .finalize();
+
+    let topic = producer.get_topic("produce_consume_custom_context", &topic_config)  // TODO: randomize topic name
+        .expect("Topic creation error");
+
+    let futures = (0..NUMBER_OF_MESSAGES)
+        .map(|i| {
+            let value = format!("Message {}", i);
+            topic.send_copy(None, Some(&value), Some(&vec![0, 1, 2, 3]))
+                .expect("Production failed")
+        })
+        .collect::<Vec<_>>();
+
+    for future in futures {
+        match future.wait() {
+            Ok(report) => match report.result() {
+                Err(e) => panic!("Delivery failed: {}", e),
+                Ok(_) => ()
+            },
+            Err(e) => panic!("Waiting for future failed: {}", e)
+        }
+    }
+
+    // Consume the messages
+    let messages: Vec<Message> = message_stream.take(NUMBER_OF_MESSAGES).wait().map({ |message|
+        match message {
+            Ok(m) => {
+                consumer.commit_message(&m, CommitMode::Async);
+                m
+            },
+            Err(e) => panic!("Error receiving message: {:?}", e)
+        }
+    }).collect();
+
+    for i in 0..NUMBER_OF_MESSAGES {
+        match messages.get(i as usize) {
+            Some(ref message) => {
+                assert_eq!(message.key_view::<[u8]>().unwrap().unwrap(), [0, 1, 2, 3]);
+                assert_eq!(message.payload_view::<str>().unwrap().unwrap(), format!("Message {}", i));
+            }
+            None => panic!("Message expected")
+        }
+    }
+}


### PR DESCRIPTION
This converts some unwraps to expects so I could rule out some causes of a crash I'm seeing. It looks like the crash is caused by using a custom producer context, so I've added an integration test for this.

The test in this pull runs indefinitely. When you change line 54 back to this:

```rust
.create::<FutureProducer<_>>()
```

The test passes within a second or two again. Seems like something breaks when using `create_with_context` instead of `create`, so far I have no idea why. Any thoughts?