### PR TITLE
Pause and resume consumers

### DIFF
--- a/examples/simple_consumer.rs
+++ b/examples/simple_consumer.rs
@@ -27,7 +27,7 @@ impl ConsumerContext for ConsumerLoggingContext {
         info!("Pre rebalance {:?}", rebalance);
     }
 
-    fn post_rebalance(&self, rebalance: &Rebalance) {
+    fn post_rebalance(&self, rebalance: Rebalance) {
         info!("Post rebalance {:?}", rebalance);
     }
 }

--- a/src/consumer/base_consumer.rs
+++ b/src/consumer/base_consumer.rs
@@ -81,6 +81,26 @@ impl<C: ConsumerContext> BaseConsumer<C> {
         Ok(())
     }
 
+    /// Pause consuming of this consumer.
+    pub fn pause(&self) {
+        unsafe {
+            let mut tp_list = rdkafka::rd_kafka_topic_partition_list_new(0);
+            rdkafka::rd_kafka_assignment(self.client.native_ptr(), &mut tp_list);
+            rdkafka::rd_kafka_pause_partitions(self.client.native_ptr(), tp_list);
+            rdkafka::rd_kafka_topic_partition_list_destroy(tp_list);
+        }
+    }
+
+    /// Resume consuming of this consumer.
+    pub fn resume(&self) {
+        unsafe {
+            let mut tp_list = rdkafka::rd_kafka_topic_partition_list_new(0);
+            rdkafka::rd_kafka_assignment(self.client.native_ptr(), &mut tp_list);
+            rdkafka::rd_kafka_resume_partitions(self.client.native_ptr(), tp_list);
+            rdkafka::rd_kafka_topic_partition_list_destroy(tp_list);
+        }
+    }
+
     /// Returns a list of topics or topic patterns the consumer is subscribed to.
     pub fn get_subscriptions(&self) -> TopicPartitionList {
         let mut tp_list = unsafe { rdkafka::rd_kafka_topic_partition_list_new(0) };

--- a/src/consumer/mod.rs
+++ b/src/consumer/mod.rs
@@ -67,7 +67,8 @@ pub trait ConsumerContext: Context {
                 }
             }
         }
-        self.post_rebalance(&rebalance);
+
+        self.post_rebalance(rebalance);
     }
 
     /// Pre-rebalance callback. This method will run before the rebalance and should
@@ -76,7 +77,7 @@ pub trait ConsumerContext: Context {
 
     /// Post-rebalance callback. This method will run after the rebalance and should
     /// terminate its execution quickly.
-    fn post_rebalance(&self, _rebalance: &Rebalance) { }
+    fn post_rebalance(&self, _rebalance: Rebalance) { }
 }
 
 /// An empty consumer context that can be user when no context is needed.

--- a/src/consumer/mod.rs
+++ b/src/consumer/mod.rs
@@ -126,6 +126,16 @@ pub trait Consumer<C: ConsumerContext> {
         self.get_base_consumer_mut().assign(assignment)
     }
 
+    /// Pause consuming of this consumer.
+    fn pause(&self) {
+        self.get_base_consumer().pause()
+    }
+
+    /// Resume consuming of this consumer.
+    fn resume(&self) {
+        self.get_base_consumer().resume()
+    }
+
     /// Commit offsets on broker for the provided list of partitions.
     /// If mode is set to CommitMode::Sync, the call will block until
     /// the message has been succesfully committed.

--- a/tests/produce_consume_base_test.rs
+++ b/tests/produce_consume_base_test.rs
@@ -1,6 +1,9 @@
 extern crate futures;
 extern crate rdkafka;
 
+use std::thread::sleep;
+use std::time::Duration;
+
 use futures::*;
 
 use rdkafka::config::{ClientConfig, TopicConfig};
@@ -69,12 +72,21 @@ fn test_produce_consume_base() {
         match message {
             Ok(Ok(m)) => {
                 consumer.commit_message(&m, CommitMode::Async);
+                // Pause and resume
+                consumer.pause();
+                consumer.resume();
                 m
             },
             Ok(Err(e)) => panic!("Error receiving message: {:?}", e),
             Err(e) => panic!("Error receiving message: {:?}", e)
         }
     }).collect();
+
+
+    // Pause, wait for a few polls and then and resume
+    consumer.pause();
+    sleep(Duration::from_millis(500));
+    consumer.resume();
 
     // Test that committing separately does not crash
     let mut tpl = TopicPartitionList::new();


### PR DESCRIPTION
Pause and resume for both the base and streaming consumer.

The streaming consumer starts a separate thread that polls while the consumer is paused. This ensures that the consumer will be considered alive by Kafka even when we're not accepting the future on the other end.