### PR TITLE
Make subscribe and assign take a non-mutable self

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["kafka", "rdkafka"]
 categories = ["api-bindings"]
 
 [dependencies]
-rdkafka-sys = { path = "rdkafka-sys", version = "0.9.3-0" }
+rdkafka-sys = { path = "rdkafka-sys", version = "0.9.4-0" }
 env_logger = "^0.3.0"
 errno = "^0.1.8"
 futures = "^0.1.7"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 Kafka client library for Rust based on [librdkafka].
 
 ## The library
-`rust-rdkafka` provides a safe Rust interface to librdkafka. It is currently based on librdkafka 0.9.3.
+`rust-rdkafka` provides a safe Rust interface to librdkafka. It is currently based on librdkafka 0.9.4.
 
 ### Documentation
 

--- a/rdkafka-sys/Cargo.toml
+++ b/rdkafka-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rdkafka-sys"
-version = "0.9.3-0"
+version = "0.9.4-0"
 authors = ["Federico Giraud <giraud.federico@gmail.com>"]
 build = "build.rs"
 links = "rdkafka"

--- a/src/consumer/base_consumer.rs
+++ b/src/consumer/base_consumer.rs
@@ -25,10 +25,6 @@ impl<C: ConsumerContext> Consumer<C> for BaseConsumer<C> {
     fn get_base_consumer(&self) -> &BaseConsumer<C> {
         self
     }
-
-    fn get_base_consumer_mut(&mut self) -> &mut BaseConsumer<C> {
-        self
-    }
 }
 
 impl FromClientConfig for BaseConsumer<EmptyConsumerContext> {
@@ -52,7 +48,7 @@ impl<C: ConsumerContext> BaseConsumer<C> {
     /// Subscribes the consumer to a list of topics and/or topic sets (using regex).
     /// Strings starting with `^` will be regex-matched to the full list of topics in
     /// the cluster and matching topics will be added to the subscription list.
-    pub fn subscribe(&mut self, topics: &[&str]) -> KafkaResult<()> {
+    pub fn subscribe(&self, topics: &[&str]) -> KafkaResult<()> {
         let tp_list = TopicPartitionList::with_topics(topics).create_native_topic_partition_list();
         let ret_code = unsafe { rdsys::rd_kafka_subscribe(self.client.native_ptr(), tp_list) };
         if ret_code.is_error() {
@@ -64,12 +60,12 @@ impl<C: ConsumerContext> BaseConsumer<C> {
     }
 
     /// Unsubscribe from previous subscription list.
-    pub fn unsubscribe(&mut self) {
+    pub fn unsubscribe(&self) {
         unsafe { rdsys::rd_kafka_unsubscribe(self.client.native_ptr()) };
     }
 
     /// Manually assign topics and partitions to consume.
-    pub fn assign(&mut self, assignment: &TopicPartitionList) -> KafkaResult<()> {
+    pub fn assign(&self, assignment: &TopicPartitionList) -> KafkaResult<()> {
         let tp_list = assignment.create_native_topic_partition_list();
         let ret_code = unsafe { rdsys::rd_kafka_assign(self.client.native_ptr(), tp_list) };
         if ret_code.is_error() {

--- a/src/consumer/mod.rs
+++ b/src/consumer/mod.rs
@@ -111,19 +111,17 @@ pub enum CommitMode {
 pub trait Consumer<C: ConsumerContext> {
     /// Returns a reference to the BaseConsumer.
     fn get_base_consumer(&self) -> &BaseConsumer<C>;
-    /// Returns a mutable reference to the BaseConsumer.
-    fn get_base_consumer_mut(&mut self) -> &mut BaseConsumer<C>;
 
     // Default implementations
 
     /// Subscribe the consumer to a list of topics.
-    fn subscribe(&mut self, topics: &Vec<&str>) -> KafkaResult<()> {
-        self.get_base_consumer_mut().subscribe(topics)
+    fn subscribe(&self, topics: &Vec<&str>) -> KafkaResult<()> {
+        self.get_base_consumer().subscribe(topics)
     }
 
     /// Manually assign topics and partitions to the consumer.
-    fn assign(&mut self, assignment: &TopicPartitionList) -> KafkaResult<()> {
-        self.get_base_consumer_mut().assign(assignment)
+    fn assign(&self, assignment: &TopicPartitionList) -> KafkaResult<()> {
+        self.get_base_consumer().assign(assignment)
     }
 
     /// Commit offsets on broker for the provided list of partitions.

--- a/src/consumer/stream_consumer.rs
+++ b/src/consumer/stream_consumer.rs
@@ -32,10 +32,6 @@ impl<C: ConsumerContext> Consumer<C> for StreamConsumer<C> {
     fn get_base_consumer(&self) -> &BaseConsumer<C> {
         Arc::as_ref(&self.consumer)
     }
-
-    fn get_base_consumer_mut(&mut self) -> &mut BaseConsumer<C> {
-        Arc::get_mut(&mut self.consumer).expect("Could not get mutable consumer from context")  // TODO add check?
-    }
 }
 
 impl FromClientConfig for StreamConsumer<EmptyConsumerContext> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 //! Kafka client library for Rust based on [librdkafka].
 //!
 //! ## The library
-//! `rust-rdkafka` provides a safe Rust interface to librdkafka. It is currently based on librdkafka 0.9.3.
+//! `rust-rdkafka` provides a safe Rust interface to librdkafka. It is currently based on librdkafka 0.9.4.
 //!
 //! ### Documentation
 //!

--- a/tests/test_utils.rs
+++ b/tests/test_utils.rs
@@ -108,7 +108,7 @@ pub fn produce_messages<P, K, J, Q>(topic_name: &str, count: i32, value_fn: &P, 
 pub fn create_stream_consumer(topic_name: &str, group_id: &str) -> StreamConsumer<TestContext> {
     let cons_context = TestContext;
 
-    let mut consumer = ClientConfig::new()
+    let consumer = ClientConfig::new()
         .set("group.id", group_id)
         .set("client.id", "rdkafka_integration_test_client")
         .set("bootstrap.servers", "localhost:9092")


### PR DESCRIPTION
Rdkafka takes care of thread safety itself, do Rust doesn't need to enforce this for us. Completely removes the `get_base_consumer_mut` function.

This is based of #37, so that should be merged before this one.