### PR TITLE
Add offsets_for_timestamp to consumer

### DIFF
--- a/src/consumer/mod.rs
+++ b/src/consumer/mod.rs
@@ -156,6 +156,11 @@ pub trait Consumer<C: ConsumerContext> {
         self.get_base_consumer().committed(timeout_ms)
     }
 
+    /// Lookup the offsets for this consumer's partitions by timestamp.
+    fn offsets_for_timestamp(&self, timestamp: i64, timeout_ms: i32) -> KafkaResult<TopicPartitionList> {
+        self.get_base_consumer().offsets_for_timestamp(timestamp, timeout_ms)
+    }
+
     /// Retrieve current positions (offsets) for topics and partitions.
     fn position(&self) -> KafkaResult<TopicPartitionList> {
         self.get_base_consumer().position()

--- a/tests/produce_consume_base_test.rs
+++ b/tests/produce_consume_base_test.rs
@@ -70,6 +70,12 @@ fn test_produce_consume_with_timestamp() {
             Ok(())
         })
         .wait();
+
+    produce_messages(&topic_name, 100, &value_fn, &key_fn, None, Some(999999));
+
+    // Lookup the offsets
+    let mut offsets = consumer.offsets_for_timestamp(999999, 100).unwrap();
+    assert!(offsets.topics.remove(&topic_name).unwrap().take().unwrap().get(0).unwrap().offset > 10);
 }
 
 // All messages should go to the same partition.


### PR DESCRIPTION
This allows you to look up the first offset for a certain timestamp.

It is possible to have a separate timestamp per partition, but we don't need this for our use case. We could add a `offsets_for_timestamps` that takes a map of partition/timestamp as well later if the need arises.