### PR TITLE
Make OpenSSL dependency optional

### DIFF
--- a/rdkafka-sys/Cargo.toml
+++ b/rdkafka-sys/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["external-ffi-bindings"]
 [dependencies]
 lz4-sys = "^ 1.0"
 libz-sys = "^ 1.0"
-openssl-sys = "~ 0.9.0"
+openssl-sys = { version = "~ 0.9.0", optional = true }
 
 [build-dependencies]
 num_cpus = "~ 0.2.0"
@@ -25,5 +25,5 @@ path = "src/lib.rs"
 [features]
 default = []
 
-ssl = []
+ssl = ["openssl-sys"]
 sasl = ["ssl"]


### PR DESCRIPTION
We don't need to build openssl if the ssl feature isn't selected.
This was preventing me from building rust-rdkafka with musl.