### PR TITLE
Directly return a DeliveryFuture from FutureProducer::send_copy

### DIFF
--- a/examples/asynchronous_processing.rs
+++ b/examples/asynchronous_processing.rs
@@ -104,7 +104,7 @@ fn run_async_processor(brokers: &str, group_id: &str, input_topic: &str, output_
             }).and_then(move |computation_result| {
                 // Send the result of the computation to Kafka, asynchronously.
                 info!("Sending result");
-                producer.send_copy::<String, ()>(&topic_name, None, Some(&computation_result), None, None).unwrap()
+                producer.send_copy::<String, ()>(&topic_name, None, Some(&computation_result), None, None)
             }).and_then(|d_report| {
                 // Once the message has been produced, print the delivery report and terminate
                 // the pipeline.

--- a/examples/at_least_once.rs
+++ b/examples/at_least_once.rs
@@ -148,8 +148,7 @@ fn main() {
                 join_all(
                     output_topics.iter()
                         .map(|output_topic|
-                            producer.send_copy(output_topic, None, m.payload(), m.key(), None)  // TODO: fix timestamp
-                                .expect("Failed to produce message")))
+                            producer.send_copy(output_topic, None, m.payload(), m.key(), None)))  // TODO: fix timestamp
                     .wait()
                     .expect("Message delivery failed for some topic");
                 // Now that the message is completely processed, add it's position to the offset

--- a/examples/simple_producer.rs
+++ b/examples/simple_producer.rs
@@ -31,7 +31,6 @@ fn produce(brokers: &str, topic_name: &str) {
             // The send operation on the topic returns a future, that will be completed once the
             // result or failure from Kafka will be received.
             producer.send_copy(topic_name, None, Some(&value), Some(&vec![0, 1, 2, 3]), None)
-                .expect("Production failed")
                 .map(move |delivery_status| {   // This will be executed onw the result is received
                     info!("Delivery status for message {} received", i);
                     delivery_status

--- a/src/error.rs
+++ b/src/error.rs
@@ -46,6 +46,7 @@ pub enum KafkaError {
     TopicConfig(RDKafkaConfRes, String, String, String),
     TopicCreation(String),
     Global(RDKafkaError),
+    FutureCanceled
 }
 
 impl fmt::Debug for KafkaError {
@@ -68,6 +69,7 @@ impl fmt::Debug for KafkaError {
             KafkaError::TopicConfig(_, ref desc, ref key, ref value) => write!(f, "KafkaError (Topic config error: {} {} {})", desc, key, value),
             KafkaError::TopicCreation(ref err) => write!(f, "KafkaError (Topic creation error: {})", err),
             KafkaError::Global(err) => write!(f, "KafkaError (Global error: {})", err),
+            KafkaError::FutureCanceled => write!(f, "KafkaError (Future canceled)")
         }
     }
 }
@@ -92,6 +94,7 @@ impl fmt::Display for KafkaError {
             KafkaError::TopicConfig(_, ref desc, ref key, ref value) => write!(f, "Topic config error: {} {} {}", desc, key, value),
             KafkaError::TopicCreation(ref err) => write!(f, "Topic creation error: {}", err),
             KafkaError::Global(err) => write!(f, "Global error: {}", err),
+            KafkaError::FutureCanceled => write!(f, "Future canceled")
         }
     }
 }
@@ -116,6 +119,7 @@ impl error::Error for KafkaError {
             KafkaError::TopicConfig(_, _, _, _) => "Topic config error",
             KafkaError::TopicCreation(_) => "Topic creation error",
             KafkaError::Global(_) => "Global error",
+            KafkaError::FutureCanceled => "Future canceled"
         }
     }
 
@@ -137,7 +141,8 @@ impl error::Error for KafkaError {
             KafkaError::Subscription(_) => None,
             KafkaError::TopicConfig(_, _, _, _) => None,
             KafkaError::TopicCreation(_) => None,
-            KafkaError::Global(ref err) => Some(err)
+            KafkaError::Global(ref err) => Some(err),
+            KafkaError::FutureCanceled => None
         }
     }
 }

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -228,7 +228,7 @@ impl<C: Context + 'static> ProducerContext for FutureProducerContext<C> {
     type DeliveryContext = Complete<KafkaResult<DeliveryReport>>;
 
     fn delivery(&self, status: DeliveryReport, tx: Complete<KafkaResult<DeliveryReport>>) {
-        tx.send(Ok(status));
+        let _ = tx.send(Ok(status));
     }
 }
 
@@ -305,7 +305,7 @@ impl<C: Context + 'static> _FutureProducer<C> {
             Ok(_) => DeliveryFuture{ rx },
             Err(e) => {
                 let (tx, rx) = futures::oneshot();
-                tx.send(Err(e));
+                let _ = tx.send(Err(e));
                 DeliveryFuture { rx }
             }
         }

--- a/src/producer.rs
+++ b/src/producer.rs
@@ -361,6 +361,12 @@ pub struct DeliveryFuture {
     rx: Oneshot<KafkaResult<DeliveryReport>>,
 }
 
+impl DeliveryFuture {
+    pub fn close(&mut self) {
+        self.rx.close();
+    }
+}
+
 impl Future for DeliveryFuture {
     type Item = DeliveryReport;
     type Error = KafkaError;

--- a/tests/test_utils.rs
+++ b/tests/test_utils.rs
@@ -77,8 +77,7 @@ pub fn produce_messages<P, K, J, Q>(topic_name: &str, count: i32, value_fn: &P, 
 
     let futures = (0..count)
         .map(|id| {
-            let future = producer.send_copy(topic_name, partition, Some(&value_fn(id)), Some(&key_fn(id)), timestamp)
-                .expect("Production failed");
+            let future = producer.send_copy(topic_name, partition, Some(&value_fn(id)), Some(&key_fn(id)), timestamp);
             (id, future)
         }).collect::<Vec<_>>();
 


### PR DESCRIPTION
Returning a Result made it very difficult to use `send_copy()` in a chain of futures, and, since a Future is just an asynchronous Result, this commit changes the DeliveryFuture to yield a KafkaError on failure. Previously, the DeliveryFuture would only yield Canceled, and, to continue supporting this, a new variant of KafkaError was added, `FutureCanceled`.

This makes the FutureProducer API considerably more ergonomic. For example, in a function which returns a `BoxFuture<(), ::std::io::Error>`, this is what was necessary before:
```rust
return match kafka_producer.send_copy::<_, ()>(
    "test", None, Some(&*format!("msg on {}", topic)), None, None) {
    Ok(report) => {
        report
            .map_err(|_| io::Error::new(io::ErrorKind::Other,
                                        "failed to send kafka message"))
            .and_then(|_| future::ok(()))
            .boxed()
    },

    Err(_) => {
        future::err(io::Error::new(
                io::ErrorKind::InvalidData, "failed to send kafka message"))
            .boxed()
    }
}
```

This becomes even more complicated with the fact that match arms must return the same type and the types of chained Futures can easily get very complex.

Compare that to the code one can write with this PR applied:

```rust
return kafka_producer
    .send_copy::<_, ()>("test", None, Some(&*format!("msg on {}", topic)), None, None)
    .map_err(|_| io::Error::new(io::ErrorKind::Other,
                                "failed to send kafka message"))
    .and_then(|_| future::ok(()))
    .boxed();
```

Much less verbose, and, more importantly, it flows naturally as part of a chain of futures.

Full disclosure: there is a compilation warning for the unused `Result` returned by `tx.send()` in two places, but this warning was present before the change and I'm also not sure what the correct way to handle an error arising in such a situation actually is.