### PR TITLE
Only build librdkafka libs

### DIFF
--- a/rdkafka-sys/build.rs
+++ b/rdkafka-sys/build.rs
@@ -82,7 +82,7 @@ fn build_librdkafka() {
     run_command_or_fail("librdkafka", "./configure", configure_flags.as_slice());
 
     println!("Compiling librdkafka");
-    run_command_or_fail("librdkafka", "make", &["-j", &num_cpus::get().to_string()]);
+    run_command_or_fail("librdkafka", "make", &["-j", &num_cpus::get().to_string(), "libs"]);
 
     println!("cargo:rustc-link-search=native={}/librdkafka/src",
              env::current_dir().expect("Can't find current dir").display());


### PR DESCRIPTION
Don't build examples.

I got some errors when cross compile to x86_64-unknown-linux-musl target, it was caused by librdkafka examples compiling, somehow `ld` it used isn't the cross compiling one but the host one. Disable librdkafka examples build fixed it.

As for `rust-rdkafka`, the librdkafka examples isn't really useful anyway.

https://github.com/edenhill/librdkafka/blob/7fada8feaa4d8b0450fb9027347ac80d29d4388d/Makefile#L19