### PR TITLE
WIP: Use Option<Duration> for timeouts

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## master
 
+* Change timeout to more rust-idiomatic `Option<Duration>`.
 * Add `external_lz4` feature to use external lz4 library instead of
   the one one built in librdkafka. Disable by default.
 * Mark all `from_ptr` methods as unsafe.

--- a/src/producer/future_producer.rs
+++ b/src/producer/future_producer.rs
@@ -147,7 +147,7 @@ impl<C: Context + 'static> FutureProducer<C> {
                         if block_ms == -1 {
                             continue;
                         } else if block_ms > 0 && start_time.elapsed() < Duration::from_millis(block_ms as u64) {
-                            self.poll(100);
+                            self.poll(Duration::from_millis(100));
                             continue;
                         }
                     }
@@ -186,13 +186,13 @@ impl<C: Context + 'static> FutureProducer<C> {
 
     /// Polls the internal producer. This is not normally required since the `ThreadedProducer` had
     /// a thread dedicated to calling `poll` regularly.
-    pub fn poll(&self, timeout_ms: i32) {
-        self.producer.poll(timeout_ms);
+    pub fn poll<T: Into<Option<Duration>>>(&self, timeout: T) {
+        self.producer.poll(timeout);
     }
 
     /// Flushes the producer. Should be called before termination.
-    pub fn flush(&self, timeout_ms: i32) {
-        self.producer.flush(timeout_ms);
+    pub fn flush<T: Into<Option<Duration>>>(&self, timeout: T) {
+        self.producer.flush(timeout);
     }
 
     /// Returns the number of messages waiting to be sent, or send but not acknowledged yet.

--- a/src/util.rs
+++ b/src/util.rs
@@ -18,6 +18,14 @@ pub fn duration_to_millis(duration: Duration) -> u64 {
     duration.as_secs() * 1000 + u64::from(duration.subsec_nanos()) / 1_000_000
 }
 
+/// Converts a timeout to the kafka's expected representation
+pub(crate) fn timeout_to_ms<T: Into<Option<Duration>>>(timeout: T) -> i32 {
+    timeout
+        .into()
+        .map(|t| duration_to_millis(t) as i32)
+        .unwrap_or(-1)
+}
+
 /// Converts the given time to milliseconds since unix epoch.
 pub fn millis_to_epoch(time: SystemTime) -> i64 {
     duration_to_millis(

--- a/tests/test_consumers.rs
+++ b/tests/test_consumers.rs
@@ -169,7 +169,7 @@ fn test_produce_consume_with_timestamp() {
     populate_topic(&topic_name, 10, &value_fn, &key_fn, Some(0), Some(999_999));
 
     // Lookup the offsets
-    let tpl = consumer.offsets_for_timestamp(999_999, 10_000).unwrap();
+    let tpl = consumer.offsets_for_timestamp(999_999, Duration::from_secs(10)).unwrap();
     let tp = tpl.find_partition(&topic_name, 0).unwrap();
     assert_eq!(tp.topic(), topic_name);
     assert_eq!(tp.offset(), Offset::Offset(100));
@@ -240,9 +240,10 @@ fn test_consumer_commit_message() {
         })
         .wait();
 
-    assert_eq!(consumer.fetch_watermarks(&topic_name, 0, 5000).unwrap(), (0, 10));
-    assert_eq!(consumer.fetch_watermarks(&topic_name, 1, 5000).unwrap(), (0, 11));
-    assert_eq!(consumer.fetch_watermarks(&topic_name, 2, 5000).unwrap(), (0, 12));
+    let timeout = Duration::from_secs(5);
+    assert_eq!(consumer.fetch_watermarks(&topic_name, 0, timeout).unwrap(), (0, 10));
+    assert_eq!(consumer.fetch_watermarks(&topic_name, 1, timeout).unwrap(), (0, 11));
+    assert_eq!(consumer.fetch_watermarks(&topic_name, 2, timeout).unwrap(), (0, 12));
 
     let mut assignment = TopicPartitionList::new();
     assignment.add_partition_offset(&topic_name, 0, Offset::Invalid);
@@ -254,7 +255,7 @@ fn test_consumer_commit_message() {
     committed.add_partition_offset(&topic_name, 0, Offset::Invalid);
     committed.add_partition_offset(&topic_name, 1, Offset::Offset(11));
     committed.add_partition_offset(&topic_name, 2, Offset::Invalid);
-    assert_eq!(committed, consumer.committed(5000).unwrap());
+    assert_eq!(committed, consumer.committed(timeout).unwrap());
 
     let mut position = TopicPartitionList::new();
     position.add_partition_offset(&topic_name, 0, Offset::Offset(10));
@@ -296,9 +297,10 @@ fn test_consumer_store_offset_commit() {
     // Commit the whole current state
     consumer.commit_consumer_state(CommitMode::Sync).unwrap();
 
-    assert_eq!(consumer.fetch_watermarks(&topic_name, 0, 5000).unwrap(), (0, 10));
-    assert_eq!(consumer.fetch_watermarks(&topic_name, 1, 5000).unwrap(), (0, 11));
-    assert_eq!(consumer.fetch_watermarks(&topic_name, 2, 5000).unwrap(), (0, 12));
+    let timeout = Duration::from_secs(5);
+    assert_eq!(consumer.fetch_watermarks(&topic_name, 0, timeout).unwrap(), (0, 10));
+    assert_eq!(consumer.fetch_watermarks(&topic_name, 1, timeout).unwrap(), (0, 11));
+    assert_eq!(consumer.fetch_watermarks(&topic_name, 2, timeout).unwrap(), (0, 12));
 
     let mut assignment = TopicPartitionList::new();
     assignment.add_partition_offset(&topic_name, 0, Offset::Invalid);
@@ -310,7 +312,7 @@ fn test_consumer_store_offset_commit() {
     committed.add_partition_offset(&topic_name, 0, Offset::Invalid);
     committed.add_partition_offset(&topic_name, 1, Offset::Offset(11));
     committed.add_partition_offset(&topic_name, 2, Offset::Invalid);
-    assert_eq!(committed, consumer.committed(5000).unwrap());
+    assert_eq!(committed, consumer.committed(timeout).unwrap());
 
     let mut position = TopicPartitionList::new();
     position.add_partition_offset(&topic_name, 0, Offset::Offset(10));

--- a/tests/test_metadata.rs
+++ b/tests/test_metadata.rs
@@ -10,6 +10,8 @@ use rdkafka::consumer::{Consumer, EmptyConsumerContext, StreamConsumer};
 use rdkafka::topic_partition_list::TopicPartitionList;
 use rdkafka::config::ClientConfig;
 
+use std::time::Duration;
+
 mod utils;
 use utils::*;
 
@@ -36,7 +38,7 @@ fn test_metadata() {
     populate_topic(&topic_name, 1, &value_fn, &key_fn, Some(2), None);
     let consumer = create_consumer(&rand_test_group());
 
-    let metadata = consumer.fetch_metadata(None, 5000).unwrap();
+    let metadata = consumer.fetch_metadata(None, Duration::from_secs(5)).unwrap();
     assert_eq!(metadata.orig_broker_id(), -1);
     assert!(!metadata.orig_broker_name().is_empty());
 
@@ -66,7 +68,8 @@ fn test_metadata() {
     assert_eq!(topic_metadata.partitions()[0].replicas(), &[0]);
     assert_eq!(topic_metadata.partitions()[0].isr(), &[0]);
 
-    let metadata_one_topic = consumer.fetch_metadata(Some(&topic_name), 5000).unwrap();
+    let metadata_one_topic = consumer.fetch_metadata(Some(&topic_name), Duration::from_secs(5))
+        .unwrap();
     assert_eq!(metadata_one_topic.topics().len(), 1);
 }
 
@@ -104,7 +107,7 @@ fn test_group_membership() {
         .for_each(|_| Ok(()))
         .wait();
 
-    let group_list = consumer.fetch_group_list(None, 5000).unwrap();
+    let group_list = consumer.fetch_group_list(None, Duration::from_secs(5)).unwrap();
 
     // Print all the data, valgrind will check memory access
     for group in group_list.groups().iter() {
@@ -114,7 +117,8 @@ fn test_group_membership() {
         }
     }
 
-    let group_list2 = consumer.fetch_group_list(Some(&group_name), 5000).unwrap();
+    let group_list2 = consumer.fetch_group_list(Some(&group_name), Duration::from_secs(5))
+        .unwrap();
     assert_eq!(group_list2.groups().len(), 1);
 
     let consumer_group = group_list2.groups().iter().find(|&g| g.name() == group_name).unwrap();

--- a/tests/test_producers.rs
+++ b/tests/test_producers.rs
@@ -16,6 +16,7 @@ use utils::*;
 use std::sync::Mutex;
 use std::sync::Arc;
 use std::collections::{HashMap, HashSet};
+use std::time::Duration;
 
 
 struct PrintingContext {
@@ -126,7 +127,7 @@ fn test_base_producer_queue_full() {
             )
         }).collect::<Vec<_>>();
     while producer.in_flight_count() > 0 {
-        producer.poll(100);
+        producer.poll(Duration::from_millis(100));
     }
 
     let errors = results.iter()
@@ -156,7 +157,7 @@ fn test_base_producer_timeout() {
         .filter(|r| r == &Ok(()))
         .count();
 
-    producer.flush(10_000);
+    producer.flush(Duration::from_secs(10));
 
     assert_eq!(results_count, 10);
 
@@ -183,7 +184,7 @@ fn test_threaded_producer_send() {
         .count();
 
     assert_eq!(results_count, 10);
-    producer.flush(10_000);
+    producer.flush(Duration::from_secs(10));
 
     let delivery_results = context.results.lock().unwrap();
     let mut ids = HashSet::new();


### PR DESCRIPTION
Using i32 for milliseconds, with special case of -1 as no timeout, is
error prone and less self-documenting.

I tried to replace all externally-looking timeouts with the proper timeout encapsulation. What I'm not entirely sure of:
* If all them allow the `None`/-1 case for infinite timeout (I guess they probably do, but I haven't gone reading the rdkafka docs)
* That I got them all ‒ it was more of a search&replace than reading it manually from start to end.
* I also thought about taking `T: Into<Option<Duration>>` as the parameter. That would allow calling `poll(Duration::from_secs(10)` as well as `poll(None)`. While this is a bit less typing, it is also potentially bit more confusing and it would make certain traits not object safe, so I left it with this.