### PR TITLE
Reexport DeliveryFuture from the producer module

### DIFF
--- a/src/producer/mod.rs
+++ b/src/producer/mod.rs
@@ -85,4 +85,7 @@ pub use self::base_producer::{
     ProducerContext,
     ThreadedProducer
 };
-pub use self::future_producer::FutureProducer;
+pub use self::future_producer::{
+    FutureProducer,
+    DeliveryFuture
+};


### PR DESCRIPTION
It seems that `DeliveryFuture` was left out from the reexported producer structs. This change fixes this omission, making possible to use `FutureProducer::send_copy_result()` by using just `rdkafka::producer::*` rather than having to include the struct from the `future_producer` module.