### PR TITLE
Iterator interface for the consumer

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ## master
 
+* Added iterator interface to the `BaseConsumer`.
 * Change timeout to more rust-idiomatic `Option<Duration>`.
 * Add `external_lz4` feature to use external lz4 library instead of
   the one one built in librdkafka. Disable by default.


### PR DESCRIPTION
Allow iterating over the consumer instead of calling poll to get the
messages.

I didn't find any test for the base consumer ‒ should I try creating one, to test the iterator?