### PR TITLE
Simplify the iterator interface

### DIFF
--- a/tests/test_consumers.rs
+++ b/tests/test_consumers.rs
@@ -99,7 +99,7 @@ fn test_produce_consume_iter() {
     let consumer = create_base_consumer(&rand_test_group(), None);
     consumer.subscribe(&[topic_name.as_str()]).unwrap();
 
-    for message in consumer.iter(None).take(100) {
+    for message in consumer.iter().take(100) {
         match message {
             Ok(m) => {
                 let id = message_map[&(m.partition(), m.offset())];


### PR DESCRIPTION
As the result of the talk we had online, this retries inside the iterator if the poll returns no message (it still returns the errors).

Also, got rid of the timeout, as it looks strange on the iterator and would terminate it „randomly“, which would probably be strange.