### PR TITLE
Make documentation links relative if possible

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,11 +55,11 @@
 //!
 //! For more information about consumers and producers, refer to their module-level documentation.
 //!
-//! [`BaseConsumer`]: https://docs.rs/rdkafka/*/rdkafka/consumer/base_consumer/struct.BaseConsumer.html
-//! [`BaseProducer`]: https://docs.rs/rdkafka/*/rdkafka/producer/base_producer/struct.BaseProducer.html
-//! [`ThreadedProducer`]: https://docs.rs/rdkafka/*/rdkafka/producer/base_producer/struct.ThreadedProducer.html
-//! [`StreamConsumer`]: https://docs.rs/rdkafka/*/rdkafka/consumer/stream_consumer/struct.StreamConsumer.html
-//! [`FutureProducer`]: https://docs.rs/rdkafka/*/rdkafka/producer/future_producer/struct.FutureProducer.html
+//! [`BaseConsumer`]: consumer/base_consumer/struct.BaseConsumer.html
+//! [`BaseProducer`]: producer/base_producer/struct.BaseProducer.html
+//! [`ThreadedProducer`]: producer/base_producer/struct.ThreadedProducer.html
+//! [`StreamConsumer`]: consumer/stream_consumer/struct.StreamConsumer.html
+//! [`FutureProducer`]: producer/future_producer/struct.FutureProducer.html
 //! [librdkafka]: https://github.com/edenhill/librdkafka
 //! [futures]: https://github.com/alexcrichton/futures-rs
 //! [`future`]: https://docs.rs/futures/0.1.3/futures/trait.Future.html


### PR DESCRIPTION
To link to the *same* version of documentation, not the newest (could be
confusing if someone explicitly looks through older version), or to the
local one in case of development version or offline usage.