### PR TITLE
Modify topic_mirror to include questions, notes

### DIFF
--- a/src/producer/base_producer.rs
+++ b/src/producer/base_producer.rs
@@ -70,7 +70,7 @@ pub trait ProducerContext: ClientContext {
 
     /// This method will be called once the message has been delivered (or failed to). The
     /// `DeliveryOpaque` will be the one provided by the user when calling send.
-    fn delivery(&mut self, delivery_result: &DeliveryResult, delivery_opaque: Self::DeliveryOpaque);
+    fn delivery(&self, delivery_result: &DeliveryResult, delivery_opaque: Self::DeliveryOpaque);
 }
 
 /// Default producer context that can be use when a custom context is not required.
@@ -81,7 +81,7 @@ impl ClientContext for DefaultProducerContext {}
 impl ProducerContext for DefaultProducerContext {
     type DeliveryOpaque = ();
 
-    fn delivery(&mut self, _: &DeliveryResult, _: Self::DeliveryOpaque) {}
+    fn delivery(&self, _: &DeliveryResult, _: Self::DeliveryOpaque) {}
 }
 
 /// Callback that gets called from librdkafka every time a message succeeds or fails to be
@@ -91,7 +91,7 @@ unsafe extern "C" fn delivery_cb<C: ProducerContext>(
     msg: *const RDKafkaMessage,
     _opaque: *mut c_void,
 ) {
-    let mut producer_context = Box::from_raw(_opaque as *mut C);
+    let producer_context = Box::from_raw(_opaque as *mut C);
     let delivery_opaque = C::DeliveryOpaque::from_ptr((*msg)._private);
     let owner = 42u8;
     // Wrap the message pointer into a BorrowedMessage that will only live for the body of this

--- a/src/producer/base_producer.rs
+++ b/src/producer/base_producer.rs
@@ -70,9 +70,8 @@ pub trait ProducerContext: ClientContext {
 
     /// This method will be called once the message has been delivered (or failed to). The
     /// `DeliveryOpaque` will be the one provided by the user when calling send.
-    fn delivery(&self, delivery_result: &DeliveryResult, delivery_opaque: Self::DeliveryOpaque);
+    fn delivery(&mut self, delivery_result: &DeliveryResult, delivery_opaque: Self::DeliveryOpaque);
 }
-
 
 /// Default producer context that can be use when a custom context is not required.
 #[derive(Clone)]
@@ -82,7 +81,7 @@ impl ClientContext for DefaultProducerContext {}
 impl ProducerContext for DefaultProducerContext {
     type DeliveryOpaque = ();
 
-    fn delivery(&self, _: &DeliveryResult, _: Self::DeliveryOpaque) {}
+    fn delivery(&mut self, _: &DeliveryResult, _: Self::DeliveryOpaque) {}
 }
 
 /// Callback that gets called from librdkafka every time a message succeeds or fails to be
@@ -92,7 +91,7 @@ unsafe extern "C" fn delivery_cb<C: ProducerContext>(
     msg: *const RDKafkaMessage,
     _opaque: *mut c_void,
 ) {
-    let producer_context = Box::from_raw(_opaque as *mut C);
+    let mut producer_context = Box::from_raw(_opaque as *mut C);
     let delivery_opaque = C::DeliveryOpaque::from_ptr((*msg)._private);
     let owner = 42u8;
     // Wrap the message pointer into a BorrowedMessage that will only live for the body of this

--- a/src/producer/future_producer.rs
+++ b/src/producer/future_producer.rs
@@ -137,7 +137,7 @@ impl<C: ClientContext + 'static> ClientContext for FutureProducerContext<C> {
 impl<C: ClientContext + 'static> ProducerContext for FutureProducerContext<C> {
     type DeliveryOpaque = Box<Complete<OwnedDeliveryResult>>;
 
-    fn delivery(&self, delivery_result: &DeliveryResult, tx: Box<Complete<OwnedDeliveryResult>>) {
+    fn delivery(&mut self, delivery_result: &DeliveryResult, tx: Box<Complete<OwnedDeliveryResult>>) {
         let owned_delivery_result = match *delivery_result {
             Ok(ref message) => Ok((message.partition(), message.offset())),
             Err((ref error, ref message)) => Err((error.clone(), message.detach())),

--- a/src/producer/future_producer.rs
+++ b/src/producer/future_producer.rs
@@ -137,7 +137,7 @@ impl<C: ClientContext + 'static> ClientContext for FutureProducerContext<C> {
 impl<C: ClientContext + 'static> ProducerContext for FutureProducerContext<C> {
     type DeliveryOpaque = Box<Complete<OwnedDeliveryResult>>;
 
-    fn delivery(&mut self, delivery_result: &DeliveryResult, tx: Box<Complete<OwnedDeliveryResult>>) {
+    fn delivery(&self, delivery_result: &DeliveryResult, tx: Box<Complete<OwnedDeliveryResult>>) {
         let owned_delivery_result = match *delivery_result {
             Ok(ref message) => Ok((message.partition(), message.offset())),
             Err((ref error, ref message)) => Err((error.clone(), message.detach())),

--- a/src/topic_partition_list.rs
+++ b/src/topic_partition_list.rs
@@ -34,18 +34,21 @@ pub enum Offset {
     /// Offset not assigned or invalid.
     Invalid,
     /// A specific offset to consume from.
-    Offset(i64)
+    Offset(i64),
 }
 
 impl PartialOrd for Offset {
-    fn partial_cmp(&self, _other: &Offset) -> Option<Ordering> {
-        unimplemented!()
+    fn partial_cmp(&self, other: &Offset) -> Option<Ordering> {
+        match (self, other) {
+            (Offset::Offset(l), Offset::Offset(r)) => l.partial_cmp(r),
+            (_, _) => None,
+        }
     }
 }
 
 impl Ord for Offset {
-    fn cmp(&self, _other: &Offset) -> Ordering {
-        unimplemented!()
+    fn cmp(&self, other: &Offset) -> Ordering {
+        self.partial_cmp(other).unwrap()
     }
 }
 

--- a/src/topic_partition_list.rs
+++ b/src/topic_partition_list.rs
@@ -43,6 +43,12 @@ impl PartialOrd for Offset {
     }
 }
 
+impl Ord for Offset {
+    fn cmp(&self, _other: &Offset) -> Ordering {
+        unimplemented!()
+    }
+}
+
 impl Offset {
     /// Converts the integer representation of an offset use by librdkafka to an `Offset`.
     pub fn from_raw(raw_offset: i64) -> Offset {

--- a/src/topic_partition_list.rs
+++ b/src/topic_partition_list.rs
@@ -7,6 +7,7 @@ use IntoOpaque;
 use error::{IsError, KafkaError, KafkaResult};
 use message::{BorrowedMessage, Message};
 
+use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::ffi::{CStr, CString};
 use std::fmt;
@@ -34,6 +35,12 @@ pub enum Offset {
     Invalid,
     /// A specific offset to consume from.
     Offset(i64)
+}
+
+impl PartialOrd for Offset {
+    fn partial_cmp(&self, _other: &Offset) -> Option<Ordering> {
+        unimplemented!()
+    }
 }
 
 impl Offset {
@@ -116,6 +123,12 @@ impl<'a> PartialEq for TopicPartitionListElem<'a> {
         self.topic() == other.topic() &&
             self.partition() == other.partition() &&
             self.offset() == other.offset()
+    }
+}
+
+impl<'a> PartialOrd for TopicPartitionListElem<'a> {
+    fn partial_cmp(&self, _other: &TopicPartitionListElem<'a>) -> Option<Ordering> {
+        unimplemented!()
     }
 }
 


### PR DESCRIPTION
This commit adjusts the topic_mirror example to include retry
in the case of enqueuing failure, removes the TopicPartitionList
in favor of performing offset commits directly with BorrowedMessage.
It's possible I've not understood the purpose of TopicPartitionList.

As it is now, I think I've saved on one allocation per incoming message
by removing TopicPartitionList, have imposed additional allocations per
failed enqueuing and have open questions around retrying when production
fails.

Apologies for some of the rustfmt reshuffling. 

Relevant issue: [#89](https://github.com/fede1024/rust-rdkafka/issues/89)

Signed-off-by: Brian L. Troutwine <briant@unity3d.com>