### PR TITLE
Added `offsets_for_times` method

### DIFF
--- a/src/consumer/base_consumer.rs
+++ b/src/consumer/base_consumer.rs
@@ -297,22 +297,12 @@ impl<C: ConsumerContext> Consumer<C> for BaseConsumer<C> {
         // Set the timestamp we want in the offset field for every partition as librdkafka expects.
         tpl.set_all_offsets(Offset(timestamp));
 
-        // This call will then put the offset in the offset field of this topic partition list.
-        let offsets_for_times_error = unsafe {
-            rdsys::rd_kafka_offsets_for_times(
-                self.client.native_ptr(),
-                tpl.ptr(),
-                timeout_to_ms(timeout)
-            )
-        };
-
-        if offsets_for_times_error.is_error() {
-            Err(KafkaError::MetadataFetch(offsets_for_times_error.into()))
-        } else {
-            Ok(tpl)
-        }
+        self.offsets_for_times(tpl, timeout)
     }
 
+    /**
+     * `timestamps` is a `TopicPartitionList` with timestamps instead of offsets.
+    */
     fn offsets_for_times<T: Into<Option<Duration>>>(&self, mut timestamps: TopicPartitionList, timeout: T)
                                                     -> KafkaResult<TopicPartitionList>
     {

--- a/src/consumer/mod.rs
+++ b/src/consumer/mod.rs
@@ -204,6 +204,16 @@ pub trait Consumer<C: ConsumerContext=DefaultConsumerContext> {
             .offsets_for_timestamp(timestamp, timeout)
     }
 
+    fn offsets_for_times<T>(&self, mut timestamps: TopicPartitionList, timeout: T)
+                            -> KafkaResult<TopicPartitionList>
+    where
+        T: Into<Option<Duration>>,
+        Self: Sized,
+    {
+        self.get_base_consumer()
+            .offsets_for_times(timestamps, timeout)
+    }
+
     /// Retrieve current positions (offsets) for topics and partitions.
     fn position(&self) -> KafkaResult<TopicPartitionList> {
         self.get_base_consumer().position()


### PR DESCRIPTION
This method allows to specify a TPL for which to get offsets.
The main reason is to allow getting offsets for timestamps without/before subscribing to anything.