### PR TITLE
Added `committed_offsets` method

### DIFF
--- a/src/consumer/base_consumer.rs
+++ b/src/consumer/base_consumer.rs
@@ -284,6 +284,18 @@ impl<C: ConsumerContext> Consumer<C> for BaseConsumer<C> {
         }
     }
 
+    fn committed_offsets<T: Into<Option<Duration>>>(&self, mut tpl: TopicPartitionList, timeout: T) -> KafkaResult<TopicPartitionList> {
+        let committed_error = unsafe {
+            rdsys::rd_kafka_committed(self.client.native_ptr(), tpl.ptr(), timeout_to_ms(timeout))
+        };
+
+        if committed_error.is_error() {
+            Err(KafkaError::MetadataFetch(committed_error.into()))
+        } else {
+            Ok(tpl)
+        }
+    }
+
     fn offsets_for_timestamp<T: Into<Option<Duration>>>(&self, timestamp: i64, timeout: T)
         -> KafkaResult<TopicPartitionList>
     {

--- a/src/consumer/base_consumer.rs
+++ b/src/consumer/base_consumer.rs
@@ -273,15 +273,7 @@ impl<C: ConsumerContext> Consumer<C> for BaseConsumer<C> {
             return Err(KafkaError::MetadataFetch(assignment_error.into()));
         }
 
-        let committed_error = unsafe {
-            rdsys::rd_kafka_committed(self.client.native_ptr(), tpl_ptr, timeout_to_ms(timeout))
-        };
-
-        if committed_error.is_error() {
-            Err(KafkaError::MetadataFetch(committed_error.into()))
-        } else {
-            Ok(unsafe { TopicPartitionList::from_ptr(tpl_ptr) })
-        }
+        self.committed_offsets(unsafe { TopicPartitionList::from_ptr(tpl_ptr) }, timeout)
     }
 
     fn committed_offsets<T: Into<Option<Duration>>>(&self, mut tpl: TopicPartitionList, timeout: T) -> KafkaResult<TopicPartitionList> {

--- a/src/consumer/mod.rs
+++ b/src/consumer/mod.rs
@@ -193,6 +193,13 @@ pub trait Consumer<C: ConsumerContext=DefaultConsumerContext> {
         self.get_base_consumer().committed(timeout)
     }
 
+    fn committed_offsets<T>(&self, mut tpl: TopicPartitionList, timeout: T) -> KafkaResult<TopicPartitionList>
+    where
+        T: Into<Option<Duration>>,
+    {
+        self.get_base_consumer().committed_offsets(tpl, timeout)
+    }
+
     /// Lookup the offsets for this consumer's partitions by timestamp.
     fn offsets_for_timestamp<T>(&self, timestamp: i64, timeout: T)
         -> KafkaResult<TopicPartitionList>


### PR DESCRIPTION
This method allows to specify a TPL for which to get committed offsets.

The main reason is to allow getting committed offsets without/before subscribing to anything.