### PR TITLE
Made `tpl` in `rebalance` mutable

### DIFF
--- a/src/consumer/base_consumer.rs
+++ b/src/consumer/base_consumer.rs
@@ -48,9 +48,9 @@ unsafe extern "C" fn native_rebalance_cb<C: ConsumerContext>(
     // let context: &C = &*(opaque_ptr as *const C);
     let context = Box::from_raw(opaque_ptr as *mut C);
     let native_client = NativeClient::from_ptr(rk);
-    let tpl = TopicPartitionList::from_ptr(native_tpl);
+    let mut tpl = TopicPartitionList::from_ptr(native_tpl);
 
-    context.rebalance(&native_client, err, &tpl);
+    context.rebalance(&native_client, err, &mut tpl);
 
     mem::forget(context); // Do not free the context
     mem::forget(native_client); // Do not free native client

--- a/src/consumer/mod.rs
+++ b/src/consumer/mod.rs
@@ -42,7 +42,7 @@ pub trait ConsumerContext: ClientContext {
         &self,
         native_client: &NativeClient,
         err: RDKafkaRespErr,
-        tpl: &TopicPartitionList,
+        tpl: &mut TopicPartitionList,
     ) {
 
         let rebalance = match err {


### PR DESCRIPTION
`tpl` should be mutable in the rebalance hook.

An example: https://github.com/edenhill/librdkafka/blob/bd74dc31ba6edf431749b4ad5a00aa4fc78882fc/tests/0029-assign_offset.c#L70