### PR TITLE
WIP - switch to std::future and async/await

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 
 [dependencies]
 rdkafka-sys = { path = "rdkafka-sys", version = "1.2.1" }
-futures = "0.1.21"
+futures-preview = "0.3.0-alpha.18"
 libc = "0.2.0"
 log = "0.4.8"
 serde = "1.0.0"
@@ -26,7 +26,7 @@ clap = "2.18.0"
 env_logger = "0.7.1"
 rand = "0.3.15"
 regex = "1.1.6"
-tokio = "0.1.7"
+tokio = "0.2.0-alpha.4"
 
 [features]
 default = []

--- a/examples/at_least_once.rs
+++ b/examples/at_least_once.rs
@@ -11,18 +11,17 @@
 /// For a simpler example of consumers and producers, check the `simple_consumer` and
 /// `simple_producer` files in the example folder.
 ///
-#[macro_use]
-extern crate log;
+#[macro_use] extern crate log;
 extern crate clap;
 extern crate futures;
 extern crate rdkafka;
 extern crate rdkafka_sys;
 
 use clap::{App, Arg};
+use futures::executor::{block_on, block_on_stream};
 use futures::future::join_all;
-use futures::stream::Stream;
-use futures::Future;
 
+use rdkafka::Message;
 use rdkafka::client::ClientContext;
 use rdkafka::config::{ClientConfig, RDKafkaLogLevel};
 use rdkafka::consumer::stream_consumer::StreamConsumer;
@@ -30,10 +29,10 @@ use rdkafka::consumer::{Consumer, ConsumerContext};
 use rdkafka::error::KafkaResult;
 use rdkafka::producer::{FutureProducer, FutureRecord};
 use rdkafka::util::get_rdkafka_version;
-use rdkafka::Message;
 
 mod example_utils;
 use crate::example_utils::setup_logger;
+
 
 // A simple context to customize the consumer behavior and print a log line every time
 // offsets are committed
@@ -42,11 +41,7 @@ struct LoggingConsumerContext;
 impl ClientContext for LoggingConsumerContext {}
 
 impl ConsumerContext for LoggingConsumerContext {
-    fn commit_callback(
-        &self,
-        result: KafkaResult<()>,
-        _offsets: *mut rdkafka_sys::RDKafkaTopicPartitionList,
-    ) {
+    fn commit_callback(&self, result: KafkaResult<()>, _offsets: *mut rdkafka_sys::RDKafkaTopicPartitionList) {
         match result {
             Ok(_) => info!("Offsets committed successfully"),
             Err(e) => warn!("Error while committing offsets: {}", e),
@@ -74,9 +69,7 @@ fn create_consumer(brokers: &str, group_id: &str, topic: &str) -> LoggingConsume
         .create_with_context(context)
         .expect("Consumer creation failed");
 
-    consumer
-        .subscribe(&[topic])
-        .expect("Can't subscribe to specified topic");
+    consumer.subscribe(&[topic]).expect("Can't subscribe to specified topic");
 
     consumer
 }
@@ -84,7 +77,7 @@ fn create_consumer(brokers: &str, group_id: &str, topic: &str) -> LoggingConsume
 fn create_producer(brokers: &str) -> FutureProducer {
     ClientConfig::new()
         .set("bootstrap.servers", brokers)
-        .set("queue.buffering.max.ms", "0") // Do not buffer
+        .set("queue.buffering.max.ms", "0")  // Do not buffer
         .create()
         .expect("Producer creation failed")
 }
@@ -93,43 +86,33 @@ fn main() {
     let matches = App::new("at-least-once")
         .version(option_env!("CARGO_PKG_VERSION").unwrap_or(""))
         .about("At-least-once delivery example")
-        .arg(
-            Arg::with_name("brokers")
-                .short("b")
-                .long("brokers")
-                .help("Broker list in kafka format")
-                .takes_value(true)
-                .default_value("localhost:9092"),
-        )
-        .arg(
-            Arg::with_name("group-id")
-                .short("g")
-                .long("group-id")
-                .help("Consumer group id")
-                .takes_value(true)
-                .default_value("example_consumer_group_id"),
-        )
-        .arg(
-            Arg::with_name("log-conf")
-                .long("log-conf")
-                .help("Configure the logging format (example: 'rdkafka=trace')")
-                .takes_value(true),
-        )
-        .arg(
-            Arg::with_name("input-topic")
-                .long("input-topic")
-                .help("Input topic name")
-                .takes_value(true)
-                .required(true),
-        )
-        .arg(
-            Arg::with_name("output-topics")
-                .long("output-topics")
-                .help("Output topics names")
-                .takes_value(true)
-                .multiple(true)
-                .required(true),
-        )
+        .arg(Arg::with_name("brokers")
+             .short("b")
+             .long("brokers")
+             .help("Broker list in kafka format")
+             .takes_value(true)
+             .default_value("localhost:9092"))
+        .arg(Arg::with_name("group-id")
+             .short("g")
+             .long("group-id")
+             .help("Consumer group id")
+             .takes_value(true)
+             .default_value("example_consumer_group_id"))
+        .arg(Arg::with_name("log-conf")
+             .long("log-conf")
+             .help("Configure the logging format (example: 'rdkafka=trace')")
+             .takes_value(true))
+        .arg(Arg::with_name("input-topic")
+             .long("input-topic")
+             .help("Input topic name")
+             .takes_value(true)
+             .required(true))
+        .arg(Arg::with_name("output-topics")
+            .long("output-topics")
+            .help("Output topics names")
+            .takes_value(true)
+            .multiple(true)
+            .required(true))
         .get_matches();
 
     setup_logger(true, matches.value_of("log-conf"));
@@ -138,39 +121,34 @@ fn main() {
     info!("rd_kafka_version: {}", version);
 
     let input_topic = matches.value_of("input-topic").unwrap();
-    let output_topics = matches
-        .values_of("output-topics")
-        .unwrap()
-        .collect::<Vec<&str>>();
+    let output_topics = matches.values_of("output-topics").unwrap().collect::<Vec<&str>>();
     let brokers = matches.value_of("brokers").unwrap();
     let group_id = matches.value_of("group-id").unwrap();
 
     let consumer = create_consumer(brokers, group_id, input_topic);
     let producer = create_producer(brokers);
 
-    for message in consumer.start().wait() {
+    for message in block_on_stream(consumer.start()) {
         match message {
-            Err(()) => {
-                warn!("Error while reading from stream");
-            }
-            Ok(Err(e)) => {
+            Err(e) => {
                 warn!("Kafka error: {}", e);
             }
-            Ok(Ok(m)) => {
+            Ok(m) => {
                 // Send a copy to the message to every output topic in parallel, and wait for the
                 // delivery report to be received.
-                join_all(output_topics.iter().map(|output_topic| {
-                    let mut record = FutureRecord::to(output_topic);
-                    if let Some(p) = m.payload() {
-                        record = record.payload(p);
-                    }
-                    if let Some(k) = m.key() {
-                        record = record.key(k);
-                    }
-                    producer.send(record, 1000)
-                }))
-                .wait()
-                .expect("Message delivery failed for some topic");
+                block_on(join_all(
+                    output_topics.iter()
+                        .map(|output_topic| {
+                            let mut record = FutureRecord::to(output_topic);
+                            if let Some(p) = m.payload() {
+                                record = record.payload(p);
+                            }
+                            if let Some(k) = m.key() {
+                                record = record.key(k);
+                            }
+                            producer.send(record, 1000)
+                        }))).into_iter().collect::<Result<Vec<_>, _>>()
+                    .expect("Message delivery failed for some topic");
                 // Now that the message is completely processed, add it's position to the offset
                 // store. The actual offset will be committed every 5 seconds.
                 if let Err(e) = consumer.store_offset(&m) {

--- a/examples/simple_consumer.rs
+++ b/examples/simple_consumer.rs
@@ -6,7 +6,7 @@ extern crate rdkafka;
 extern crate rdkafka_sys;
 
 use clap::{App, Arg};
-use futures::stream::Stream;
+use futures::executor::block_on_stream;
 
 use rdkafka::client::ClientContext;
 use rdkafka::config::{ClientConfig, RDKafkaLogLevel};
@@ -70,11 +70,10 @@ fn consume_and_print(brokers: &str, group_id: &str, topics: &[&str]) {
     // such as complex computations on a thread pool or asynchronous IO.
     let message_stream = consumer.start();
 
-    for message in message_stream.wait() {
+    for message in block_on_stream(message_stream) {
         match message {
-            Err(_) => warn!("Error while reading from stream."),
-            Ok(Err(e)) => warn!("Kafka error: {}", e),
-            Ok(Ok(m)) => {
+            Err(e) => warn!("Kafka error: {}", e),
+            Ok(m) => {
                 let payload = match m.payload_view::<str>() {
                     None => "",
                     Some(Ok(s)) => s,

--- a/examples/simple_producer.rs
+++ b/examples/simple_producer.rs
@@ -6,6 +6,7 @@ extern crate rdkafka;
 
 use clap::{App, Arg};
 use futures::*;
+use futures::executor::block_on;
 
 use rdkafka::config::ClientConfig;
 use rdkafka::producer::{FutureProducer, FutureRecord};
@@ -47,7 +48,7 @@ fn produce(brokers: &str, topic_name: &str) {
 
     // This loop will wait until all delivery statuses have been received received.
     for future in futures {
-        info!("Future completed. Result: {:?}", future.wait());
+        info!("Future completed. Result: {:?}", block_on(future));
     }
 }
 

--- a/rdkafka-sys/Cargo.toml
+++ b/rdkafka-sys/Cargo.toml
@@ -18,6 +18,7 @@ openssl-sys = { version = "~ 0.9.0", optional = true }
 lz4-sys = { version = "1.8.3", optional = true }
 
 [build-dependencies]
+bindgen = "0.51.1"
 num_cpus = "0.2.0"
 pkg-config = "0.3.9"
 cmake = { version = "^0.1", optional = true }

--- a/src/error.rs
+++ b/src/error.rs
@@ -74,47 +74,25 @@ impl fmt::Debug for KafkaError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             KafkaError::AdminOp(err) => write!(f, "KafkaError (Admin operation error: {})", err),
-            KafkaError::AdminOpCreation(ref err) => {
-                write!(f, "KafkaError (Admin operation creation error: {})", err)
-            }
+            KafkaError::AdminOpCreation(ref err) => write!(f, "KafkaError (Admin operation creation error: {})", err),
             KafkaError::Canceled => write!(f, "KafkaError (Client dropped)"),
-            KafkaError::ClientConfig(_, ref desc, ref key, ref value) => write!(
-                f,
-                "KafkaError (Client config error: {} {} {})",
-                desc, key, value
-            ),
-            KafkaError::ClientCreation(ref err) => {
-                write!(f, "KafkaError (Client creation error: {})", err)
+            KafkaError::ClientConfig(_, ref desc, ref key, ref value) => {
+                write!(f, "KafkaError (Client config error: {} {} {})", desc, key, value)
             }
-            KafkaError::ConsumerCommit(err) => {
-                write!(f, "KafkaError (Consumer commit error: {})", err)
-            }
+            KafkaError::ClientCreation(ref err) => write!(f, "KafkaError (Client creation error: {})", err),
+            KafkaError::ConsumerCommit(err) => write!(f, "KafkaError (Consumer commit error: {})", err),
             KafkaError::Global(err) => write!(f, "KafkaError (Global error: {})", err),
-            KafkaError::GroupListFetch(err) => {
-                write!(f, "KafkaError (Group list fetch error: {})", err)
-            }
-            KafkaError::MessageConsumption(err) => {
-                write!(f, "KafkaError (Message consumption error: {})", err)
-            }
-            KafkaError::MessageProduction(err) => {
-                write!(f, "KafkaError (Message production error: {})", err)
-            }
-            KafkaError::MetadataFetch(err) => {
-                write!(f, "KafkaError (Metadata fetch error: {})", err)
-            }
-            KafkaError::NoMessageReceived => {
-                write!(f, "No message received within the given poll interval")
-            }
+            KafkaError::GroupListFetch(err) => write!(f, "KafkaError (Group list fetch error: {})", err),
+            KafkaError::MessageConsumption(err) => write!(f, "KafkaError (Message consumption error: {})", err),
+            KafkaError::MessageProduction(err) => write!(f, "KafkaError (Message production error: {})", err),
+            KafkaError::MetadataFetch(err) => write!(f, "KafkaError (Metadata fetch error: {})", err),
+            KafkaError::NoMessageReceived => write!(f, "No message received within the given poll interval"),
             KafkaError::Nul(_) => write!(f, "FFI null error"),
             KafkaError::OffsetFetch(err) => write!(f, "KafkaError (Offset fetch error: {})", err),
             KafkaError::PartitionEOF(part_n) => write!(f, "KafkaError (Partition EOF: {})", part_n),
-            KafkaError::SetPartitionOffset(err) => {
-                write!(f, "KafkaError (Set partition offset error: {})", err)
-            }
+            KafkaError::SetPartitionOffset(err) => write!(f, "KafkaError (Set partition offset error: {})", err),
             KafkaError::StoreOffset(err) => write!(f, "KafkaError (Store offset error: {})", err),
-            KafkaError::Subscription(ref err) => {
-                write!(f, "KafkaError (Subscription error: {})", err)
-            }
+            KafkaError::Subscription(ref err) => write!(f, "KafkaError (Subscription error: {})", err),
         }
     }
 }
@@ -123,9 +101,7 @@ impl fmt::Display for KafkaError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             KafkaError::AdminOp(err) => write!(f, "Admin operation error: {}", err),
-            KafkaError::AdminOpCreation(ref err) => {
-                write!(f, "Admin operation creation error: {}", err)
-            }
+            KafkaError::AdminOpCreation(ref err) => write!(f, "Admin operation creation error: {}", err),
             KafkaError::Canceled => write!(f, "KafkaError (Client dropped)"),
             KafkaError::ClientConfig(_, ref desc, ref key, ref value) => {
                 write!(f, "Client config error: {} {} {}", desc, key, value)
@@ -137,9 +113,7 @@ impl fmt::Display for KafkaError {
             KafkaError::MessageConsumption(err) => write!(f, "Message consumption error: {}", err),
             KafkaError::MessageProduction(err) => write!(f, "Message production error: {}", err),
             KafkaError::MetadataFetch(err) => write!(f, "Meta data fetch error: {}", err),
-            KafkaError::NoMessageReceived => {
-                write!(f, "No message received within the given poll interval")
-            }
+            KafkaError::NoMessageReceived => write!(f, "No message received within the given poll interval"),
             KafkaError::Nul(_) => write!(f, "FFI nul error"),
             KafkaError::OffsetFetch(err) => write!(f, "Offset fetch error: {}", err),
             KafkaError::PartitionEOF(part_n) => write!(f, "Partition EOF: {}", part_n),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -219,7 +219,6 @@
 extern crate log;
 #[macro_use]
 extern crate serde_derive;
-extern crate futures;
 extern crate serde_json;
 
 extern crate rdkafka_sys as rdsys;

--- a/tests/test_admin.rs
+++ b/tests/test_admin.rs
@@ -1,14 +1,14 @@
 //! Test administrative commands using the admin API.
 
 use backoff::{ExponentialBackoff, Operation};
+use futures::executor::block_on;
 
-use futures::Future;
 
 use std::time::Duration;
 
 use rdkafka::admin::{
-    AdminClient, AdminOptions, AlterConfig, ConfigEntry, ConfigSource, NewPartitions, NewTopic,
-    OwnedResourceSpecifier, ResourceSpecifier, TopicReplication,
+    AdminClient, AdminOptions, AlterConfig, ConfigEntry, ConfigSource, NewPartitions, NewTopic, OwnedResourceSpecifier,
+    ResourceSpecifier, TopicReplication,
 };
 use rdkafka::client::DefaultClientContext;
 use rdkafka::consumer::{BaseConsumer, Consumer, DefaultConsumerContext};
@@ -26,14 +26,11 @@ fn create_config() -> ClientConfig {
 }
 
 fn create_admin_client() -> AdminClient<DefaultClientContext> {
-    create_config()
-        .create()
-        .expect("admin client creation failed")
+    create_config().create().expect("admin client creation failed")
 }
 
 fn fetch_metadata(topic: &str) -> Metadata {
-    let consumer: BaseConsumer<DefaultConsumerContext> =
-        create_config().create().expect("consumer creation failed");
+    let consumer: BaseConsumer<DefaultConsumerContext> = create_config().create().expect("consumer creation failed");
     let timeout = Some(Duration::from_secs(1));
 
     let mut backoff = ExponentialBackoff::default();
@@ -56,8 +53,7 @@ fn fetch_metadata(topic: &str) -> Metadata {
 }
 
 fn verify_delete(topic: &str) {
-    let consumer: BaseConsumer<DefaultConsumerContext> =
-        create_config().create().expect("consumer creation failed");
+    let consumer: BaseConsumer<DefaultConsumerContext> = create_config().create().expect("consumer creation failed");
     let timeout = Some(Duration::from_secs(1));
 
     let mut backoff = ExponentialBackoff::default();
@@ -66,9 +62,7 @@ fn verify_delete(topic: &str) {
         // Asking about the topic specifically will recreate it (under the
         // default Kafka configuration, at least) so we have to ask for the list
         // of all topics and search through it.
-        let metadata = consumer
-            .fetch_metadata(None, timeout)
-            .map_err(|e| e.to_string())?;
+        let metadata = consumer.fetch_metadata(None, timeout).map_err(|e| e.to_string())?;
         if let Some(_) = metadata.topics().iter().find(|t| t.name() == topic) {
             Err(format!("topic {} still exists", topic))?
         }
@@ -90,8 +84,8 @@ fn test_topics() {
         let name2 = rand_test_topic();
 
         // Test both the builder API and the literal construction.
-        let topic1 =
-            NewTopic::new(&name1, 1, TopicReplication::Fixed(1)).set("max.message.bytes", "1234");
+        let topic1 = NewTopic::new(&name1, 1, TopicReplication::Fixed(1))
+            .set("max.message.bytes", "1234");
         let topic2 = NewTopic {
             name: &name2,
             num_partitions: 3,
@@ -99,9 +93,8 @@ fn test_topics() {
             config: Vec::new(),
         };
 
-        let res = admin_client
-            .create_topics(&[topic1, topic2], &opts)
-            .wait()
+        let res = block_on(admin_client
+            .create_topics(&[topic1, topic2], &opts))
             .expect("topic creation failed");
         assert_eq!(res, &[Ok(name1.clone()), Ok(name2.clone())]);
 
@@ -116,15 +109,11 @@ fn test_topics() {
         assert_eq!(1, metadata_topic1.partitions().len());
         assert_eq!(3, metadata_topic2.partitions().len());
 
-        let res = admin_client
+        let res = block_on(admin_client
             .describe_configs(
-                &[
-                    ResourceSpecifier::Topic(&name1),
-                    ResourceSpecifier::Topic(&name2),
-                ],
+                &[ResourceSpecifier::Topic(&name1), ResourceSpecifier::Topic(&name2)],
                 &opts,
-            )
-            .wait()
+            ))
             .expect("describe configs failed");
         let config1 = &res[0].as_ref().expect("describe configs failed on topic 1");
         let config2 = &res[1].as_ref().expect("describe configs failed on topic 2");
@@ -153,19 +142,12 @@ fn test_topics() {
         let config_entries2 = config2.entry_map();
         assert_eq!(config1.entries.len(), config_entries1.len());
         assert_eq!(config2.entries.len(), config_entries2.len());
-        assert_eq!(
-            Some(&&expected_entry1),
-            config_entries1.get("max.message.bytes")
-        );
-        assert_eq!(
-            Some(&&expected_entry2),
-            config_entries2.get("max.message.bytes")
-        );
+        assert_eq!(Some(&&expected_entry1), config_entries1.get("max.message.bytes"));
+        assert_eq!(Some(&&expected_entry2), config_entries2.get("max.message.bytes"));
 
         let partitions1 = NewPartitions::new(&name1, 5);
-        let res = admin_client
-            .create_partitions(&[partitions1], &opts)
-            .wait()
+        let res = block_on(admin_client
+            .create_partitions(&[partitions1], &opts))
             .expect("partition creation failed");
         assert_eq!(res, &[Ok(name1.clone())]);
 
@@ -183,9 +165,8 @@ fn test_topics() {
         .retry(&mut backoff)
         .unwrap();
 
-        let res = admin_client
-            .delete_topics(&[&name1, &name2], &opts)
-            .wait()
+        let res = block_on(admin_client
+            .delete_topics(&[&name1, &name2], &opts))
             .expect("topic deletion failed");
         assert_eq!(res, &[Ok(name1.clone()), Ok(name2.clone())]);
         verify_delete(&name1);
@@ -196,7 +177,7 @@ fn test_topics() {
     // creating topics.
     {
         let topic = NewTopic::new("ignored", 1, TopicReplication::Variable(&[&[0], &[0]]));
-        let res = admin_client.create_topics(&[topic], &opts).wait();
+        let res = block_on(admin_client.create_topics(&[topic], &opts));
         assert_eq!(
             Err(KafkaError::AdminOpCreation(
                 "replication configuration for topic 'ignored' assigns 2 partition(s), \
@@ -213,9 +194,8 @@ fn test_topics() {
         let name = rand_test_topic();
         let topic = NewTopic::new(&name, 1, TopicReplication::Fixed(1));
 
-        let res = admin_client
-            .create_topics(vec![&topic], &opts)
-            .wait()
+        let res = block_on(admin_client
+            .create_topics(vec![&topic], &opts))
             .expect("topic creation failed");
         assert_eq!(res, &[Ok(name.clone())]);
         let _ = fetch_metadata(&name);
@@ -223,7 +203,7 @@ fn test_topics() {
         // This partition specification is obviously garbage, and so trips
         // a client-side error.
         let partitions = NewPartitions::new(&name, 2).assign(&[&[0], &[0], &[0]]);
-        let res = admin_client.create_partitions(&[partitions], &opts).wait();
+        let res = block_on(admin_client.create_partitions(&[partitions], &opts));
         assert_eq!(
             res,
             Err(KafkaError::AdminOpCreation(format!(
@@ -235,9 +215,8 @@ fn test_topics() {
 
         // Only the server knows that this partition specification is garbage.
         let partitions = NewPartitions::new(&name, 2).assign(&[&[0], &[0]]);
-        let res = admin_client
-            .create_partitions(&[partitions], &opts)
-            .wait()
+        let res = block_on(admin_client
+            .create_partitions(&[partitions], &opts))
             .expect("partition creation failed");
         assert_eq!(res, &[Err((name, RDKafkaError::InvalidReplicaAssignment))],);
     }
@@ -245,9 +224,8 @@ fn test_topics() {
     // Verify that deleting a non-existent topic fails.
     {
         let name = rand_test_topic();
-        let res = admin_client
-            .delete_topics(&[&name], &opts)
-            .wait()
+        let res = block_on(admin_client
+            .delete_topics(&[&name], &opts))
             .expect("delete topics failed");
         assert_eq!(res, &[Err((name, RDKafkaError::UnknownTopicOrPartition))]);
     }
@@ -261,16 +239,14 @@ fn test_topics() {
         let topic1 = NewTopic::new(&name1, 1, TopicReplication::Fixed(1));
         let topic2 = NewTopic::new(&name2, 1, TopicReplication::Fixed(1));
 
-        let res = admin_client
-            .create_topics(vec![&topic1], &opts)
-            .wait()
+        let res = block_on(admin_client
+            .create_topics(vec![&topic1], &opts))
             .expect("topic creation failed");
         assert_eq!(res, &[Ok(name1.clone())]);
         let _ = fetch_metadata(&name1);
 
-        let res = admin_client
-            .create_topics(vec![&topic1, &topic2], &opts)
-            .wait()
+        let res = block_on(admin_client
+            .create_topics(vec![&topic1, &topic2], &opts))
             .expect("topic creation failed");
         assert_eq!(
             res,
@@ -281,16 +257,14 @@ fn test_topics() {
         );
         let _ = fetch_metadata(&name2);
 
-        let res = admin_client
-            .delete_topics(&[&name1], &opts)
-            .wait()
+        let res = block_on(admin_client
+            .delete_topics(&[&name1], &opts))
             .expect("topic deletion failed");
         assert_eq!(res, &[Ok(name1.clone())]);
         verify_delete(&name1);
 
-        let res = admin_client
-            .delete_topics(&[&name2, &name1], &opts)
-            .wait()
+        let res = block_on(admin_client
+            .delete_topics(&[&name2, &name1], &opts))
             .expect("topic deletion failed");
         assert_eq!(
             res,
@@ -308,9 +282,8 @@ fn test_configs() {
     let opts = AdminOptions::new();
     let broker = ResourceSpecifier::Broker(0);
 
-    let res = admin_client
-        .describe_configs(&[broker], &opts)
-        .wait()
+    let res = block_on(admin_client
+        .describe_configs(&[broker], &opts))
         .expect("describe configs failed");
     let config = &res[0].as_ref().expect("describe configs failed");
     let orig_val = config
@@ -321,18 +294,16 @@ fn test_configs() {
         .expect("original value missing");
 
     let config = AlterConfig::new(broker).set("log.flush.interval.messages", "1234");
-    let res = admin_client
-        .alter_configs(&[config], &opts)
-        .wait()
+    let res = block_on(admin_client
+        .alter_configs(&[config], &opts))
         .expect("alter configs failed");
     assert_eq!(res, &[Ok(OwnedResourceSpecifier::Broker(0))]);
 
     let mut backoff = ExponentialBackoff::default();
     backoff.max_elapsed_time = Some(Duration::from_secs(5));
     (|| {
-        let res = admin_client
-            .describe_configs(&[broker], &opts)
-            .wait()
+        let res = block_on(admin_client
+            .describe_configs(&[broker], &opts))
             .expect("describe configs failed");
         let config = &res[0].as_ref().expect("describe configs failed");
         let entry = config.get("log.flush.interval.messages");
@@ -366,9 +337,8 @@ fn test_configs() {
     .unwrap();
 
     let config = AlterConfig::new(broker).set("log.flush.interval.ms", &orig_val);
-    let res = admin_client
-        .alter_configs(&[config], &opts)
-        .wait()
+    let res = block_on(admin_client
+        .alter_configs(&[config], &opts))
         .expect("alter configs failed");
     assert_eq!(res, &[Ok(OwnedResourceSpecifier::Broker(0))]);
 }
@@ -388,33 +358,18 @@ fn test_event_errors() {
         .expect("admin client creation failed");
     let opts = AdminOptions::new().request_timeout(Duration::from_nanos(1));
 
-    let res = admin_client.create_topics(&[], &opts).wait();
-    assert_eq!(
-        res,
-        Err(KafkaError::AdminOp(RDKafkaError::OperationTimedOut))
-    );
+    let res = block_on(admin_client.create_topics(&[], &opts));
+    assert_eq!(res, Err(KafkaError::AdminOp(RDKafkaError::OperationTimedOut)));
 
-    let res = admin_client.create_partitions(&[], &opts).wait();
-    assert_eq!(
-        res,
-        Err(KafkaError::AdminOp(RDKafkaError::OperationTimedOut))
-    );
+    let res = block_on(admin_client.create_partitions(&[], &opts));
+    assert_eq!(res, Err(KafkaError::AdminOp(RDKafkaError::OperationTimedOut)));
 
-    let res = admin_client.delete_topics(&[], &opts).wait();
-    assert_eq!(
-        res,
-        Err(KafkaError::AdminOp(RDKafkaError::OperationTimedOut))
-    );
+    let res = block_on(admin_client.delete_topics(&[], &opts));
+    assert_eq!(res, Err(KafkaError::AdminOp(RDKafkaError::OperationTimedOut)));
 
-    let res = admin_client.describe_configs(&[], &opts).wait();
-    assert_eq!(
-        res.err(),
-        Some(KafkaError::AdminOp(RDKafkaError::OperationTimedOut))
-    );
+    let res = block_on(admin_client.describe_configs(&[], &opts));
+    assert_eq!(res.err(), Some(KafkaError::AdminOp(RDKafkaError::OperationTimedOut)));
 
-    let res = admin_client.alter_configs(&[], &opts).wait();
-    assert_eq!(
-        res,
-        Err(KafkaError::AdminOp(RDKafkaError::OperationTimedOut))
-    );
+    let res = block_on(admin_client.alter_configs(&[], &opts));
+    assert_eq!(res, Err(KafkaError::AdminOp(RDKafkaError::OperationTimedOut)));
 }

--- a/tests/test_high_producers.rs
+++ b/tests/test_high_producers.rs
@@ -3,7 +3,7 @@ extern crate futures;
 extern crate rand;
 extern crate rdkafka;
 
-use futures::Future;
+use futures::executor::block_on;
 
 use rdkafka::config::ClientConfig;
 use rdkafka::message::{Headers, Message, OwnedHeaders};
@@ -35,7 +35,7 @@ fn test_future_producer_send_fail() {
         10000,
     );
 
-    match future.wait() {
+    match block_on(future) {
         Ok(Err((kafka_error, owned_message))) => {
             assert_eq!(kafka_error.description(), "Message production error");
             assert_eq!(owned_message.topic(), "topic");

--- a/tests/test_metadata.rs
+++ b/tests/test_metadata.rs
@@ -4,16 +4,18 @@ extern crate futures;
 extern crate rand;
 extern crate rdkafka;
 
-use futures::*;
+use futures::StreamExt;
+use futures::executor::{block_on, block_on_stream};
 
-use rdkafka::config::ClientConfig;
 use rdkafka::consumer::{Consumer, StreamConsumer};
 use rdkafka::topic_partition_list::TopicPartitionList;
+use rdkafka::config::ClientConfig;
 
 use std::time::Duration;
 
 mod utils;
 use crate::utils::*;
+
 
 fn create_consumer(group_id: &str) -> StreamConsumer {
     ClientConfig::new()
@@ -30,25 +32,20 @@ fn create_consumer(group_id: &str) -> StreamConsumer {
 
 #[test]
 fn test_metadata() {
-    let _r = env_logger::try_init();
+    let _r = env_logger::init();
 
     let topic_name = rand_test_topic();
-    populate_topic(&topic_name, 1, &value_fn, &key_fn, Some(0), None);
-    populate_topic(&topic_name, 1, &value_fn, &key_fn, Some(1), None);
-    populate_topic(&topic_name, 1, &value_fn, &key_fn, Some(2), None);
+    block_on(populate_topic(&topic_name, 1, &value_fn, &key_fn, Some(0), None));
+    block_on(populate_topic(&topic_name, 1, &value_fn, &key_fn, Some(1), None));
+    block_on(populate_topic(&topic_name, 1, &value_fn, &key_fn, Some(2), None));
     let consumer = create_consumer(&rand_test_group());
 
-    let metadata = consumer
-        .fetch_metadata(None, Duration::from_secs(5))
-        .unwrap();
+    let metadata = consumer.fetch_metadata(None, Duration::from_secs(5)).unwrap();
     let orig_broker_id = metadata.orig_broker_id();
     // The orig_broker_id may be -1 if librdkafka's bootstrap "broker" handles
     // the request.
     if orig_broker_id != -1 && orig_broker_id != 0 {
-        panic!(
-            "metadata.orig_broker_id = {}, not 0 or 1 as expected",
-            orig_broker_id
-        )
+        panic!("metadata.orig_broker_id = {}, not 0 or 1 as expected", orig_broker_id)
     }
     assert!(!metadata.orig_broker_name().is_empty());
 
@@ -58,15 +55,10 @@ fn test_metadata() {
     assert!(!broker_metadata[0].host().is_empty());
     assert_eq!(broker_metadata[0].port(), 9092);
 
-    let topic_metadata = metadata
-        .topics()
-        .iter()
-        .find(|m| m.name() == topic_name)
-        .unwrap();
+    let topic_metadata = metadata.topics().iter()
+        .find(|m| m.name() == topic_name).unwrap();
 
-    let mut ids = topic_metadata
-        .partitions()
-        .iter()
+    let mut ids = topic_metadata.partitions().iter()
         .map(|p| {
             assert_eq!(p.error(), None);
             p.id()
@@ -83,22 +75,21 @@ fn test_metadata() {
     assert_eq!(topic_metadata.partitions()[0].replicas(), &[0]);
     assert_eq!(topic_metadata.partitions()[0].isr(), &[0]);
 
-    let metadata_one_topic = consumer
-        .fetch_metadata(Some(&topic_name), Duration::from_secs(5))
+    let metadata_one_topic = consumer.fetch_metadata(Some(&topic_name), Duration::from_secs(5))
         .unwrap();
     assert_eq!(metadata_one_topic.topics().len(), 1);
 }
 
 #[test]
 fn test_subscription() {
-    let _r = env_logger::try_init();
+    let _r = env_logger::init();
 
     let topic_name = rand_test_topic();
-    populate_topic(&topic_name, 10, &value_fn, &key_fn, None, None);
+    block_on(populate_topic(&topic_name, 10, &value_fn, &key_fn, None, None));
     let consumer = create_consumer(&rand_test_group());
     consumer.subscribe(&[topic_name.as_str()]).unwrap();
 
-    let _consumer_future = consumer.start().take(10).wait();
+    let _consumer_future = block_on_stream(consumer.start()).take(10);
 
     let mut tpl = TopicPartitionList::new();
     tpl.add_topic_unassigned(&topic_name);
@@ -107,57 +98,36 @@ fn test_subscription() {
 
 #[test]
 fn test_group_membership() {
-    let _r = env_logger::try_init();
+    let _r = env_logger::init();
 
     let topic_name = rand_test_topic();
     let group_name = rand_test_group();
-    populate_topic(&topic_name, 1, &value_fn, &key_fn, Some(0), None);
-    populate_topic(&topic_name, 1, &value_fn, &key_fn, Some(1), None);
-    populate_topic(&topic_name, 1, &value_fn, &key_fn, Some(2), None);
+    block_on(populate_topic(&topic_name, 1, &value_fn, &key_fn, Some(0), None));
+    block_on(populate_topic(&topic_name, 1, &value_fn, &key_fn, Some(1), None));
+    block_on(populate_topic(&topic_name, 1, &value_fn, &key_fn, Some(2), None));
     let consumer = create_consumer(&group_name);
     consumer.subscribe(&[topic_name.as_str()]).unwrap();
 
     // Make sure the consumer joins the group
-    let _consumer_future = consumer.start().take(1).for_each(|_| Ok(())).wait();
+    let _ = block_on_stream(consumer.start().take(1)).collect::<Vec<_>>();
 
-    let group_list = consumer
-        .fetch_group_list(None, Duration::from_secs(5))
-        .unwrap();
+    let group_list = consumer.fetch_group_list(None, Duration::from_secs(5)).unwrap();
 
     // Print all the data, valgrind will check memory access
     for group in group_list.groups().iter() {
-        println!(
-            "{} {} {} {}",
-            group.name(),
-            group.state(),
-            group.protocol(),
-            group.protocol_type()
-        );
+        println!("{} {} {} {}", group.name(), group.state(), group.protocol(), group.protocol_type());
         for member in group.members() {
-            println!(
-                "  {} {} {}",
-                member.id(),
-                member.client_id(),
-                member.client_host()
-            );
+            println!("  {} {} {}", member.id(), member.client_id(), member.client_host());
         }
     }
 
-    let group_list2 = consumer
-        .fetch_group_list(Some(&group_name), Duration::from_secs(5))
+    let group_list2 = consumer.fetch_group_list(Some(&group_name), Duration::from_secs(5))
         .unwrap();
     assert_eq!(group_list2.groups().len(), 1);
 
-    let consumer_group = group_list2
-        .groups()
-        .iter()
-        .find(|&g| g.name() == group_name)
-        .unwrap();
+    let consumer_group = group_list2.groups().iter().find(|&g| g.name() == group_name).unwrap();
     assert_eq!(consumer_group.members().len(), 1);
 
     let consumer_member = &consumer_group.members()[0];
-    assert_eq!(
-        consumer_member.client_id(),
-        "rdkafka_integration_test_client"
-    );
+    assert_eq!(consumer_member.client_id(), "rdkafka_integration_test_client");
 }

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -4,7 +4,6 @@ extern crate rand;
 extern crate rdkafka;
 extern crate regex;
 
-use futures::*;
 use rand::Rng;
 use regex::Regex;
 
@@ -90,7 +89,7 @@ impl ClientContext for TestContext {
 /// Produce the specified count of messages to the topic and partition specified. A map
 /// of (partition, offset) -> message id will be returned. It panics if any error is encountered
 /// while populating the topic.
-pub fn populate_topic<P, K, J, Q>(
+pub async fn populate_topic<P, K, J, Q>(
     topic_name: &str,
     count: i32,
     value_fn: &P,
@@ -136,7 +135,7 @@ where
 
     let mut message_map = HashMap::new();
     for (id, future) in futures {
-        match future.wait() {
+        match future.await {
             Ok(Ok((partition, offset))) => message_map.insert((partition, offset), id),
             Ok(Err((kafka_error, _message))) => panic!("Delivery failed: {}", kafka_error),
             Err(e) => panic!("Waiting for future failed: {}", e),
@@ -156,12 +155,13 @@ pub fn key_fn(id: i32) -> String {
 
 #[cfg(test)]
 mod tests {
+    use futures::executor::block_on;
     use super::*;
 
     #[test]
     fn test_populate_topic() {
         let topic_name = rand_test_topic();
-        let message_map = populate_topic(&topic_name, 100, &value_fn, &key_fn, Some(0), None);
+        let message_map = block_on(populate_topic(&topic_name, 100, &value_fn, &key_fn, Some(0), None));
 
         let total_messages = message_map
             .iter()


### PR DESCRIPTION
This PR moves the project over from futures 0.1 to the newly stabilized std::future, using tokio 0.2 (alpha) and futures-preview 0.3. It won't compile on stable until Rust 1.39 at the earliest since it uses `async`/`await`, so it'll obviously bump up the minimum Rust version too. It may be possible to remove the `async`/`await` which I think would allow it to compile on 1.36.0.

Tests are passing and examples working on nightly.

I guess this won't want to be merged until things stabilize a little more, but thought it might be useful when that time comes!