### PR TITLE
Bump bindgen to 0.51.1 in rdkafka-sys

### DIFF
--- a/rdkafka-sys/Cargo.toml
+++ b/rdkafka-sys/Cargo.toml
@@ -16,7 +16,7 @@ zstd-sys = { version = "1.3", features = [] }
 openssl-sys = { version = "~ 0.9.0", optional = true }
 
 [build-dependencies]
-bindgen = "0.49.2"
+bindgen = "0.51.1"
 num_cpus = "0.2.0"
 pkg-config = "0.3.9"
 cmake = { version = "^0.1", optional = true }


### PR DESCRIPTION
Fixes #148.

The issue in #148 only seems to happen on recent nightly compilers. This PR compiles both on stable (1.37.0) and nightly.