### PR TITLE
Fix arm build again

### DIFF
--- a/rdkafka-sys/Cargo.toml
+++ b/rdkafka-sys/Cargo.toml
@@ -16,7 +16,7 @@ zstd-sys = { version = "1.3", features = [] }
 openssl-sys = { version = "~ 0.9.0", optional = true }
 
 [build-dependencies]
-bindgen = "0.49.2"
+bindgen = "0.51.1"
 num_cpus = "0.2.0"
 pkg-config = "0.3.9"
 cmake = { version = "^0.1", optional = true }

--- a/src/consumer/base_consumer.rs
+++ b/src/consumer/base_consumer.rs
@@ -176,7 +176,7 @@ impl<C: ConsumerContext> Consumer<C> for BaseConsumer<C> {
         }
         let ret_code = unsafe { rdsys::rd_kafka_subscribe(self.client.native_ptr(), tpl.ptr()) };
         if ret_code.is_error() {
-            let error = unsafe { cstr_to_owned(rdsys::rd_kafka_err2str(ret_code) as *const i8) };
+            let error = unsafe { cstr_to_owned(rdsys::rd_kafka_err2str(ret_code)) };
             return Err(KafkaError::Subscription(error));
         };
         Ok(())
@@ -189,7 +189,7 @@ impl<C: ConsumerContext> Consumer<C> for BaseConsumer<C> {
     fn assign(&self, assignment: &TopicPartitionList) -> KafkaResult<()> {
         let ret_code = unsafe { rdsys::rd_kafka_assign(self.client.native_ptr(), assignment.ptr()) };
         if ret_code.is_error() {
-            let error = unsafe { cstr_to_owned(rdsys::rd_kafka_err2str(ret_code) as *const i8) };
+            let error = unsafe { cstr_to_owned(rdsys::rd_kafka_err2str(ret_code)) };
             return Err(KafkaError::Subscription(error));
         };
         Ok(())

--- a/src/consumer/mod.rs
+++ b/src/consumer/mod.rs
@@ -51,7 +51,7 @@ pub trait ConsumerContext: ClientContext {
             }
             RDKafkaRespErr::RD_KAFKA_RESP_ERR__REVOKE_PARTITIONS => Rebalance::Revoke,
             _ => {
-                let error = unsafe { cstr_to_owned(rdsys::rd_kafka_err2str(err) as *const i8) };
+                let error = unsafe { cstr_to_owned(rdsys::rd_kafka_err2str(err)) };
                 error!("Error rebalancing: {}", error);
                 Rebalance::Error(error)
             }

--- a/src/util.rs
+++ b/src/util.rs
@@ -102,12 +102,12 @@ impl<T: Send + Sync> IntoOpaque for Box<T> {
 
 // TODO: check if the implementation returns a copy of the data and update the documentation
 /// Converts a byte array representing a C string into a String.
-pub unsafe fn bytes_cstr_to_owned(bytes_cstr: &[i8]) -> String {
+pub unsafe fn bytes_cstr_to_owned(bytes_cstr: &[c_char]) -> String {
     CStr::from_ptr(bytes_cstr.as_ptr() as *const c_char).to_string_lossy().into_owned()
 }
 
 /// Converts a C string into a String.
-pub unsafe fn cstr_to_owned(cstr: *const i8) -> String {
+pub unsafe fn cstr_to_owned(cstr: *const c_char) -> String {
     CStr::from_ptr(cstr as *const c_char).to_string_lossy().into_owned()
 }
 
@@ -122,7 +122,7 @@ impl ErrBuf {
         ErrBuf { buf: [0; ErrBuf::MAX_ERR_LEN] }
     }
 
-    pub fn as_mut_ptr(&mut self) -> *mut i8 {
+    pub fn as_mut_ptr(&mut self) -> *mut c_char {
         self.buf.as_mut_ptr()
     }
 


### PR DESCRIPTION
It fixes incompatibility with ARM target, tested on my aarch64 machine.
The incompatibility is due to incorrect usage of `c_char` types.
The PR is based on top of s2tk's [bump bindgen PR](https://github.com/fede1024/rust-rdkafka/pull/150). Please accept that PR before accepting this.