### PR TITLE
Fix build on macOS Catalina

### DIFF
--- a/rdkafka-sys/build.rs
+++ b/rdkafka-sys/build.rs
@@ -109,7 +109,7 @@ fn build_librdkafka() {
     }
 
     println!("Configuring librdkafka");
-    run_command_or_fail("librdkafka", "./configure", configure_flags.as_slice());
+    run_command_or_fail("librdkafka", "sh", &[&["-c", "./configure"], configure_flags.as_slice()].concat());
 
     println!("Compiling librdkafka");
     make_librdkafka();


### PR DESCRIPTION
This PR fixes #159, as the problem seems to be related to the change of the default shell from `bash` to `zsh` in Catalina.