### PR TITLE
Avoid use of undefined std::process::Command behavior

### DIFF
--- a/rdkafka-sys/build.rs
+++ b/rdkafka-sys/build.rs
@@ -15,8 +15,21 @@ macro_rules! println_stderr(
     } }
 );
 
-fn run_command_or_fail(dir: &str, cmd: &str, args: &[&str]) {
-    println_stderr!("Running command: \"{} {}\" in dir: {}", cmd, args.join(" "), dir);
+fn run_command_or_fail<P>(dir: &str, cmd: P, args: &[&str])
+where
+    P: AsRef<Path>,
+{
+    let cmd = cmd.as_ref();
+    let cmd = if cmd.components().count() > 1 && cmd.is_relative() {
+        // If `cmd` is a relative path (and not a bare command that should be
+        // looked up in PATH), absolutize it relative to `dir`, as otherwise the
+        // behavior of std::process::Command is undefined.
+        // https://github.com/rust-lang/rust/issues/37868
+        PathBuf::from(dir).join(cmd).canonicalize().expect("canonicalization failed")
+    } else {
+        PathBuf::from(cmd)
+    };
+    println_stderr!("Running command: \"{} {}\" in dir: {}", cmd.display(), args.join(" "), dir);
     let ret = Command::new(cmd).current_dir(dir).args(args).status();
     match ret.map(|status| (status.success(), status.code())) {
         Ok((true, _)) => { return },


### PR DESCRIPTION
std::process::Command is known to be unpredictable when a relative path
is used together with `current_dir`, and outright fails on macOS
Catalina [0]. Absolutize paths before passing them to
std::process::Command to stay within the documented constraints of the
API.

[0]: https://github.com/rust-lang/rust/issues/37868

Supersedes #160.