### PR TITLE
Plumb message_queue_nonempty callback

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -10,7 +10,7 @@ use crate::rdsys::types::*;
 use crate::client::{Client, ClientContext, DefaultClientContext, NativeQueue};
 use crate::config::{ClientConfig, FromClientConfig, FromClientConfigAndContext};
 use crate::error::{IsError, KafkaError, KafkaResult};
-use crate::util::{cstr_to_owned, timeout_to_ms, AsCArray, ErrBuf, IntoOpaque, WrappedCPointer};
+use crate::util::{cstr_to_owned, AsCArray, ErrBuf, IntoOpaque, Timeout, WrappedCPointer};
 
 use futures::future::{self, Either};
 use futures::{Async, Canceled, Complete, Future, Oneshot, Poll};
@@ -395,8 +395,8 @@ unsafe impl Send for NativeEvent {}
 
 /// Options for an admin API request.
 pub struct AdminOptions {
-    request_timeout: Option<Duration>,
-    operation_timeout: Option<Duration>,
+    request_timeout: Option<Timeout>,
+    operation_timeout: Option<Timeout>,
     validate_only: bool,
     broker_id: Option<i32>,
 }
@@ -416,8 +416,8 @@ impl AdminOptions {
     /// transmission, operation time on broker, and response.
     ///
     /// Defaults to the `socket.timeout.ms` configuration parameter.
-    pub fn request_timeout<T: Into<Option<Duration>>>(mut self, timeout: T) -> Self {
-        self.request_timeout = timeout.into();
+    pub fn request_timeout<T: Into<Timeout>>(mut self, timeout: Option<T>) -> Self {
+        self.request_timeout = timeout.map(Into::into);
         self
     }
 
@@ -430,8 +430,8 @@ impl AdminOptions {
     ///
     /// Only the CreateTopics, DeleteTopics, and CreatePartitions API calls
     /// respect this option.
-    pub fn operation_timeout<T: Into<Option<Duration>>>(mut self, timeout: T) -> Self {
-        self.operation_timeout = timeout.into();
+    pub fn operation_timeout<T: Into<Timeout>>(mut self, timeout: Option<T>) -> Self {
+        self.operation_timeout = timeout.map(Into::into);
         self
     }
 
@@ -469,7 +469,7 @@ impl AdminOptions {
             let res = unsafe {
                 rdsys::rd_kafka_AdminOptions_set_request_timeout(
                     native_opts.ptr(),
-                    timeout_to_ms(timeout),
+                    timeout.as_millis(),
                     err_buf.as_mut_ptr(),
                     err_buf.len(),
                 )
@@ -481,7 +481,7 @@ impl AdminOptions {
             let res = unsafe {
                 rdsys::rd_kafka_AdminOptions_set_operation_timeout(
                     native_opts.ptr(),
-                    timeout_to_ms(timeout),
+                    timeout.as_millis(),
                     err_buf.as_mut_ptr(),
                     err_buf.len(),
                 )

--- a/src/client.rs
+++ b/src/client.rs
@@ -9,7 +9,6 @@ use std::os::raw::c_void;
 use std::ptr;
 use std::slice;
 use std::string::ToString;
-use std::time::Duration;
 
 use serde_json;
 
@@ -18,7 +17,7 @@ use crate::error::{IsError, KafkaError, KafkaResult};
 use crate::groups::GroupList;
 use crate::metadata::Metadata;
 use crate::statistics::Statistics;
-use crate::util::{timeout_to_ms, ErrBuf};
+use crate::util::{ErrBuf, Timeout};
 
 /// Client-level context
 ///
@@ -35,21 +34,11 @@ pub trait ClientContext: Send + Sync {
             RDKafkaLogLevel::Emerg
             | RDKafkaLogLevel::Alert
             | RDKafkaLogLevel::Critical
-            | RDKafkaLogLevel::Error => {
-                error!(target: "librdkafka", "librdkafka: {} {}", fac, log_message)
-            }
-            RDKafkaLogLevel::Warning => {
-                warn!(target: "librdkafka", "librdkafka: {} {}", fac, log_message)
-            }
-            RDKafkaLogLevel::Notice => {
-                info!(target: "librdkafka", "librdkafka: {} {}", fac, log_message)
-            }
-            RDKafkaLogLevel::Info => {
-                info!(target: "librdkafka", "librdkafka: {} {}", fac, log_message)
-            }
-            RDKafkaLogLevel::Debug => {
-                debug!(target: "librdkafka", "librdkafka: {} {}", fac, log_message)
-            }
+            | RDKafkaLogLevel::Error => error!(target: "librdkafka", "librdkafka: {} {}", fac, log_message),
+            RDKafkaLogLevel::Warning => warn!(target: "librdkafka", "librdkafka: {} {}", fac, log_message),
+            RDKafkaLogLevel::Notice => info!(target: "librdkafka", "librdkafka: {} {}", fac, log_message),
+            RDKafkaLogLevel::Info => info!(target: "librdkafka", "librdkafka: {} {}", fac, log_message),
+            RDKafkaLogLevel::Debug => debug!(target: "librdkafka", "librdkafka: {} {}", fac, log_message),
         }
     }
 
@@ -182,7 +171,7 @@ impl<C: ClientContext> Client<C> {
 
     /// Returns the metadata information for the specified topic, or for all topics in the cluster
     /// if no topic is specified.
-    pub fn fetch_metadata<T: Into<Option<Duration>>>(
+    pub fn fetch_metadata<T: Into<Timeout>>(
         &self,
         topic: Option<&str>,
         timeout: T,
@@ -202,7 +191,7 @@ impl<C: ClientContext> Client<C> {
                     .map(|t| t.ptr())
                     .unwrap_or_else(NativeTopic::null),
                 &mut metadata_ptr as *mut *const RDKafkaMetadata,
-                timeout_to_ms(timeout),
+                timeout.into().as_millis(),
             )
         };
         trace!("Metadata fetch completed");
@@ -214,7 +203,7 @@ impl<C: ClientContext> Client<C> {
     }
 
     /// Returns high and low watermark for the specified topic and partition.
-    pub fn fetch_watermarks<T: Into<Option<Duration>>>(
+    pub fn fetch_watermarks<T: Into<Timeout>>(
         &self,
         topic: &str,
         partition: i32,
@@ -230,7 +219,7 @@ impl<C: ClientContext> Client<C> {
                 partition,
                 &mut low as *mut i64,
                 &mut high as *mut i64,
-                timeout_to_ms(timeout),
+                timeout.into().as_millis(),
             )
         };
         if ret.is_error() {
@@ -241,7 +230,7 @@ impl<C: ClientContext> Client<C> {
 
     /// Returns the group membership information for the given group. If no group is
     /// specified, all groups will be returned.
-    pub fn fetch_group_list<T: Into<Option<Duration>>>(
+    pub fn fetch_group_list<T: Into<Timeout>>(
         &self,
         group: Option<&str>,
         timeout: T,
@@ -260,7 +249,7 @@ impl<C: ClientContext> Client<C> {
                 self.native_ptr(),
                 group_c_ptr,
                 &mut group_list_ptr as *mut *const RDKafkaGroupList,
-                timeout_to_ms(timeout),
+                timeout.into().as_millis(),
             )
         };
         trace!("Group list fetch completed");
@@ -345,8 +334,8 @@ impl NativeQueue {
         self.ptr
     }
 
-    pub fn poll<T: Into<Option<Duration>>>(&self, t: T) -> *mut RDKafkaEvent {
-        unsafe { rdsys::rd_kafka_queue_poll(self.ptr, timeout_to_ms(t)) }
+    pub fn poll<T: Into<Timeout>>(&self, t: T) -> *mut RDKafkaEvent {
+        unsafe { rdsys::rd_kafka_queue_poll(self.ptr, t.into().as_millis()) }
     }
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -278,6 +278,17 @@ impl<C: ClientContext> Client<C> {
     pub(crate) fn new_native_queue(&self) -> NativeQueue {
         unsafe { NativeQueue::from_ptr(rdsys::rd_kafka_queue_new(self.native_ptr())) }
     }
+
+    pub(crate) fn consumer_queue(&self) -> Option<NativeQueue> {
+        unsafe {
+            let ptr = rdsys::rd_kafka_queue_get_consumer(self.native_ptr());
+            if ptr.is_null() {
+                None
+            } else {
+                Some(NativeQueue::from_ptr(ptr))
+            }
+        }
+    }
 }
 
 pub(crate) struct NativeTopic {

--- a/src/consumer/base_consumer.rs
+++ b/src/consumer/base_consumer.rs
@@ -12,6 +12,7 @@ use crate::metadata::Metadata;
 use crate::topic_partition_list::{Offset, TopicPartitionList};
 use crate::util::{cstr_to_owned, Timeout};
 
+use std::cmp;
 use std::mem;
 use std::os::raw::c_void;
 use std::ptr;
@@ -58,6 +59,7 @@ unsafe extern "C" fn native_rebalance_cb<C: ConsumerContext>(
 /// to make progress on rebalance, callbacks and to receive messages.
 pub struct BaseConsumer<C: ConsumerContext = DefaultConsumerContext> {
     client: Client<C>,
+    main_queue_min_poll_interval: Timeout,
 }
 
 impl FromClientConfig for BaseConsumer {
@@ -80,27 +82,37 @@ impl<C: ConsumerContext> FromClientConfigAndContext<C> for BaseConsumer<C> {
                 Some(native_commit_cb::<C>),
             );
         }
+        let main_queue_min_poll_interval = context.main_queue_min_poll_interval();
         let client = Client::new(
             config,
             native_config,
             RDKafkaType::RD_KAFKA_CONSUMER,
             context,
         )?;
-        unsafe { rdsys::rd_kafka_poll_set_consumer(client.native_ptr()) };
-        Ok(BaseConsumer { client })
+        Ok(BaseConsumer {
+            client,
+            main_queue_min_poll_interval,
+        })
     }
 }
 
 impl<C: ConsumerContext> BaseConsumer<C> {
     /// Polls the consumer for messages and returns a pointer to the native rdkafka-sys struct.
     /// This method is for internal use only. Use poll instead.
-    pub(crate) fn poll_raw(&self, timeout_ms: i32) -> Option<*mut RDKafkaMessage> {
-        let message_ptr =
-            unsafe { rdsys::rd_kafka_consumer_poll(self.client.native_ptr(), timeout_ms) };
-        if message_ptr.is_null() {
-            None
-        } else {
-            Some(message_ptr)
+    pub(crate) fn poll_raw(&self, mut timeout: Timeout) -> Option<*mut RDKafkaMessage> {
+        loop {
+            unsafe { rdsys::rd_kafka_poll(self.client.native_ptr(), 0) };
+            let op_timeout = cmp::min(timeout, self.main_queue_min_poll_interval);
+            let message_ptr = unsafe {
+                rdsys::rd_kafka_consumer_poll(self.client.native_ptr(), op_timeout.as_millis())
+            };
+            if !message_ptr.is_null() {
+                break Some(message_ptr);
+            }
+            if op_timeout >= timeout {
+                break None;
+            }
+            timeout -= op_timeout;
         }
     }
 
@@ -118,7 +130,7 @@ impl<C: ConsumerContext> BaseConsumer<C> {
     ///
     /// The returned message lives in the memory of the consumer and cannot outlive it.
     pub fn poll<T: Into<Timeout>>(&self, timeout: T) -> Option<KafkaResult<BorrowedMessage>> {
-        self.poll_raw(timeout.into().as_millis())
+        self.poll_raw(timeout.into())
             .map(|ptr| unsafe { BorrowedMessage::from_consumer(ptr, self) })
     }
 

--- a/src/consumer/base_consumer.rs
+++ b/src/consumer/base_consumer.rs
@@ -2,7 +2,7 @@
 use crate::rdsys;
 use crate::rdsys::types::*;
 
-use crate::client::{Client, NativeClient};
+use crate::client::{Client, NativeClient, NativeQueue};
 use crate::config::{ClientConfig, FromClientConfig, FromClientConfigAndContext};
 use crate::consumer::{CommitMode, Consumer, ConsumerContext, DefaultConsumerContext};
 use crate::error::{IsError, KafkaError, KafkaResult};
@@ -55,11 +55,25 @@ unsafe extern "C" fn native_rebalance_cb<C: ConsumerContext>(
     tpl.leak() // Do not free native topic partition list
 }
 
+/// Native message queue nonempty callback. This callback will run whenever the
+/// consumer's message queue switches from empty to nonempty.
+unsafe extern "C" fn native_message_queue_nonempty_cb<C: ConsumerContext>(
+    _: *mut RDKafka,
+    opaque_ptr: *mut c_void,
+) {
+    let context = Box::from_raw(opaque_ptr as *mut C);
+
+    (*context).message_queue_nonempty_callback();
+
+    mem::forget(context); // Do not free the context
+}
+
 /// Low level wrapper around the librdkafka consumer. This consumer requires to be periodically polled
 /// to make progress on rebalance, callbacks and to receive messages.
 pub struct BaseConsumer<C: ConsumerContext = DefaultConsumerContext> {
     client: Client<C>,
     main_queue_min_poll_interval: Timeout,
+    _queue: Option<NativeQueue>,
 }
 
 impl FromClientConfig for BaseConsumer {
@@ -89,14 +103,31 @@ impl<C: ConsumerContext> FromClientConfigAndContext<C> for BaseConsumer<C> {
             RDKafkaType::RD_KAFKA_CONSUMER,
             context,
         )?;
+        let queue = client.consumer_queue();
+        unsafe {
+            if let Some(queue) = &queue {
+                let context_ptr = client.context() as *const C as *mut c_void;
+                rdsys::rd_kafka_queue_cb_event_enable(
+                    queue.ptr(),
+                    Some(native_message_queue_nonempty_cb::<C>),
+                    context_ptr,
+                );
+            }
+        }
         Ok(BaseConsumer {
             client,
             main_queue_min_poll_interval,
+            _queue: queue,
         })
     }
 }
 
 impl<C: ConsumerContext> BaseConsumer<C> {
+    /// Returns the context used to create this consumer.
+    pub fn context(&self) -> &C {
+        self.client.context()
+    }
+
     /// Polls the consumer for messages and returns a pointer to the native rdkafka-sys struct.
     /// This method is for internal use only. Use poll instead.
     pub(crate) fn poll_raw(&self, mut timeout: Timeout) -> Option<*mut RDKafkaMessage> {

--- a/src/consumer/mod.rs
+++ b/src/consumer/mod.rs
@@ -107,6 +107,10 @@ pub trait ConsumerContext: ClientContext {
     fn main_queue_min_poll_interval(&self) -> Timeout {
         Timeout::After(Duration::from_secs(1))
     }
+
+    /// Message queue nonempty callback. This method will run when the
+    /// consumer's message queue switches from empty to nonempty.
+    fn message_queue_nonempty_callback(&self) {}
 }
 
 /// An empty consumer context that can be user when no context is needed.

--- a/src/consumer/mod.rs
+++ b/src/consumer/mod.rs
@@ -17,6 +17,7 @@ use crate::metadata::Metadata;
 use crate::util::{cstr_to_owned, Timeout};
 
 use std::ptr;
+use std::time::Duration;
 
 use crate::topic_partition_list::{Offset, TopicPartitionList};
 
@@ -88,6 +89,24 @@ pub trait ConsumerContext: ClientContext {
     /// offset store.
     #[allow(unused_variables)]
     fn commit_callback(&self, result: KafkaResult<()>, offsets: *mut RDKafkaTopicPartitionList) {}
+
+    /// Returns the minimum interval at which to poll the main queue, which
+    /// services the logging, stats, and error callbacks.
+    ///
+    /// The main queue is polled once whenever [`Consumer.poll`] is called. If
+    /// `Consumer.poll` is called with a timeout that is larger than this
+    /// interval, then the main queue will be polled at that interval while the
+    /// consumer queue is blocked.
+    ///
+    /// For example, if the main queue's minimum poll interval is 200ms and
+    /// `Consumer.poll` is called with a timeout of 1s, then `Consumer.poll` may
+    /// block for up to 1s waiting for a message, but it will poll the main
+    /// queue every 200ms while it is waiting.
+    ///
+    /// By default, the minimum poll interval for the main queue is 1s.
+    fn main_queue_min_poll_interval(&self) -> Timeout {
+        Timeout::After(Duration::from_secs(1))
+    }
 }
 
 /// An empty consumer context that can be user when no context is needed.

--- a/src/consumer/mod.rs
+++ b/src/consumer/mod.rs
@@ -14,10 +14,9 @@ use crate::error::KafkaResult;
 use crate::groups::GroupList;
 use crate::message::BorrowedMessage;
 use crate::metadata::Metadata;
-use crate::util::cstr_to_owned;
+use crate::util::{cstr_to_owned, Timeout};
 
 use std::ptr;
-use std::time::Duration;
 
 use crate::topic_partition_list::{Offset, TopicPartitionList};
 
@@ -142,10 +141,13 @@ pub trait Consumer<C: ConsumerContext = DefaultConsumerContext> {
     /// Seek to `offset` for the specified `topic` and `partition`. After a
     /// successful call to `seek`, the next poll of the consumer will return the
     /// message with `offset`.
-    fn seek<T>(&self, topic: &str, partition: i32, offset: Offset, timeout: T) -> KafkaResult<()>
-    where
-        T: Into<Option<Duration>>,
-    {
+    fn seek<T: Into<Timeout>>(
+        &self,
+        topic: &str,
+        partition: i32,
+        offset: Offset,
+        timeout: T,
+    ) -> KafkaResult<()> {
         self.get_base_consumer()
             .seek(topic, partition, offset, timeout)
     }
@@ -200,7 +202,7 @@ pub trait Consumer<C: ConsumerContext = DefaultConsumerContext> {
     /// Retrieve committed offsets for topics and partitions.
     fn committed<T>(&self, timeout: T) -> KafkaResult<TopicPartitionList>
     where
-        T: Into<Option<Duration>>,
+        T: Into<Timeout>,
         Self: Sized,
     {
         self.get_base_consumer().committed(timeout)
@@ -213,7 +215,7 @@ pub trait Consumer<C: ConsumerContext = DefaultConsumerContext> {
         timeout: T,
     ) -> KafkaResult<TopicPartitionList>
     where
-        T: Into<Option<Duration>>,
+        T: Into<Timeout>,
     {
         self.get_base_consumer().committed_offsets(tpl, timeout)
     }
@@ -225,7 +227,7 @@ pub trait Consumer<C: ConsumerContext = DefaultConsumerContext> {
         timeout: T,
     ) -> KafkaResult<TopicPartitionList>
     where
-        T: Into<Option<Duration>>,
+        T: Into<Timeout>,
         Self: Sized,
     {
         self.get_base_consumer()
@@ -239,7 +241,7 @@ pub trait Consumer<C: ConsumerContext = DefaultConsumerContext> {
         timeout: T,
     ) -> KafkaResult<TopicPartitionList>
     where
-        T: Into<Option<Duration>>,
+        T: Into<Timeout>,
         Self: Sized,
     {
         self.get_base_consumer()
@@ -255,7 +257,7 @@ pub trait Consumer<C: ConsumerContext = DefaultConsumerContext> {
     /// if no topic is specified.
     fn fetch_metadata<T>(&self, topic: Option<&str>, timeout: T) -> KafkaResult<Metadata>
     where
-        T: Into<Option<Duration>>,
+        T: Into<Timeout>,
         Self: Sized,
     {
         self.get_base_consumer().fetch_metadata(topic, timeout)
@@ -269,7 +271,7 @@ pub trait Consumer<C: ConsumerContext = DefaultConsumerContext> {
         timeout: T,
     ) -> KafkaResult<(i64, i64)>
     where
-        T: Into<Option<Duration>>,
+        T: Into<Timeout>,
         Self: Sized,
     {
         self.get_base_consumer()
@@ -280,7 +282,7 @@ pub trait Consumer<C: ConsumerContext = DefaultConsumerContext> {
     /// specified, all groups will be returned.
     fn fetch_group_list<T>(&self, group: Option<&str>, timeout: T) -> KafkaResult<GroupList>
     where
-        T: Into<Option<Duration>>,
+        T: Into<Timeout>,
         Self: Sized,
     {
         self.get_base_consumer().fetch_group_list(group, timeout)

--- a/src/consumer/stream_consumer.rs
+++ b/src/consumer/stream_consumer.rs
@@ -9,7 +9,7 @@ use crate::consumer::base_consumer::BaseConsumer;
 use crate::consumer::{Consumer, ConsumerContext, DefaultConsumerContext};
 use crate::error::{KafkaError, KafkaResult};
 use crate::message::BorrowedMessage;
-use crate::util::duration_to_millis;
+use crate::util::Timeout;
 
 use std::ptr;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -116,10 +116,9 @@ fn poll_loop<C: ConsumerContext>(
 ) {
     trace!("Polling thread loop started");
     let mut curr_sender = sender;
-    let poll_interval_ms = duration_to_millis(poll_interval) as i32;
     while !should_stop.load(Ordering::Relaxed) {
         trace!("Polling base consumer");
-        let future_sender = match consumer.poll_raw(poll_interval_ms) {
+        let future_sender = match consumer.poll_raw(Timeout::After(poll_interval)) {
             None => {
                 if send_none {
                     curr_sender.send(None)

--- a/src/error.rs
+++ b/src/error.rs
@@ -115,9 +115,7 @@ impl fmt::Debug for KafkaError {
             KafkaError::PauseResume(ref err) => {
                 write!(f, "KafkaError (Pause/resume error: {})", err)
             }
-            KafkaError::Seek(ref err) => {
-                write!(f, "KafkaError (Seek error: {})", err)
-            }
+            KafkaError::Seek(ref err) => write!(f, "KafkaError (Seek error: {})", err),
             KafkaError::SetPartitionOffset(err) => {
                 write!(f, "KafkaError (Set partition offset error: {})", err)
             }

--- a/src/producer/base_producer.rs
+++ b/src/producer/base_producer.rs
@@ -42,7 +42,7 @@ use crate::client::{Client, ClientContext};
 use crate::config::{ClientConfig, FromClientConfig, FromClientConfigAndContext};
 use crate::error::{IsError, KafkaError, KafkaResult};
 use crate::message::{BorrowedMessage, OwnedHeaders, ToBytes};
-use crate::util::{timeout_to_ms, IntoOpaque};
+use crate::util::{IntoOpaque, Timeout};
 
 use std::ffi::CString;
 use std::mem;
@@ -294,8 +294,8 @@ impl<C: ProducerContext> BaseProducer<C> {
 
     /// Polls the producer. Regular calls to `poll` are required to process the events
     /// and execute the message delivery callbacks. Returns the number of events served.
-    pub fn poll<T: Into<Option<Duration>>>(&self, timeout: T) -> i32 {
-        unsafe { rdsys::rd_kafka_poll(self.native_ptr(), timeout_to_ms(timeout)) }
+    pub fn poll<T: Into<Timeout>>(&self, timeout: T) -> i32 {
+        unsafe { rdsys::rd_kafka_poll(self.native_ptr(), timeout.into().as_millis()) }
     }
 
     /// Returns a pointer to the native Kafka client.
@@ -375,8 +375,8 @@ impl<C: ProducerContext> BaseProducer<C> {
 
     /// Flushes the producer. Should be called before termination. This method will call `poll()`
     /// internally.
-    pub fn flush<T: Into<Option<Duration>>>(&self, timeout: T) {
-        unsafe { rdsys::rd_kafka_flush(self.native_ptr(), timeout_to_ms(timeout)) };
+    pub fn flush<T: Into<Timeout>>(&self, timeout: T) {
+        unsafe { rdsys::rd_kafka_flush(self.native_ptr(), timeout.into().as_millis()) };
     }
 
     /// Returns the number of messages waiting to be sent, or sent but not acknowledged yet.
@@ -490,12 +490,12 @@ impl<C: ProducerContext + 'static> ThreadedProducer<C> {
 
     /// Polls the internal producer. This is not normally required since the `ThreadedProducer` had
     /// a thread dedicated to calling `poll` regularly.
-    pub fn poll<T: Into<Option<Duration>>>(&self, timeout: T) {
+    pub fn poll<T: Into<Timeout>>(&self, timeout: T) {
         self.producer.poll(timeout);
     }
 
     /// Flushes the producer. Should be called before termination.
-    pub fn flush<T: Into<Option<Duration>>>(&self, timeout: T) {
+    pub fn flush<T: Into<Timeout>>(&self, timeout: T) {
         self.producer.flush(timeout);
     }
 

--- a/src/producer/future_producer.rs
+++ b/src/producer/future_producer.rs
@@ -9,7 +9,7 @@ use crate::error::{KafkaError, KafkaResult, RDKafkaError};
 use crate::message::{Message, OwnedHeaders, OwnedMessage, Timestamp, ToBytes};
 use crate::producer::{BaseRecord, DeliveryResult, ProducerContext, ThreadedProducer};
 use crate::statistics::Statistics;
-use crate::util::IntoOpaque;
+use crate::util::{IntoOpaque, Timeout};
 
 use futures::{self, Canceled, Complete, Future, Oneshot, Poll};
 
@@ -276,12 +276,12 @@ impl<C: ClientContext + 'static> FutureProducer<C> {
 
     /// Polls the internal producer. This is not normally required since the `ThreadedProducer` had
     /// a thread dedicated to calling `poll` regularly.
-    pub fn poll<T: Into<Option<Duration>>>(&self, timeout: T) {
+    pub fn poll<T: Into<Timeout>>(&self, timeout: T) {
         self.producer.poll(timeout);
     }
 
     /// Flushes the producer. Should be called before termination.
-    pub fn flush<T: Into<Option<Duration>>>(&self, timeout: T) {
+    pub fn flush<T: Into<Timeout>>(&self, timeout: T) {
         self.producer.flush(timeout);
     }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -36,6 +36,16 @@ impl Timeout {
     }
 }
 
+impl std::ops::SubAssign for Timeout {
+    fn sub_assign(&mut self, other: Self) {
+        match (self, other) {
+            (Timeout::After(lhs), Timeout::After(rhs)) => *lhs -= rhs,
+            (Timeout::Never, Timeout::After(_)) => (),
+            _ => panic!("subtraction of Timeout::Never is ill-defined"),
+        }
+    }
+}
+
 impl From<Duration> for Timeout {
     fn from(d: Duration) -> Timeout {
         Timeout::After(d)

--- a/tests/test_admin.rs
+++ b/tests/test_admin.rs
@@ -81,7 +81,7 @@ fn verify_delete(topic: &str) {
 #[test]
 fn test_topics() {
     let admin_client = create_admin_client();
-    let opts = AdminOptions::new().operation_timeout(Duration::from_secs(1));
+    let opts = AdminOptions::new().operation_timeout(Some(Duration::from_secs(1)));
 
     // Verify that topics are created as specified, and that they can later
     // be deleted.
@@ -386,7 +386,7 @@ fn test_event_errors() {
         .set("bootstrap.servers", "noexist")
         .create::<AdminClient<DefaultClientContext>>()
         .expect("admin client creation failed");
-    let opts = AdminOptions::new().request_timeout(Duration::from_nanos(1));
+    let opts = AdminOptions::new().request_timeout(Some(Duration::from_nanos(1)));
 
     let res = admin_client.create_topics(&[], &opts).wait();
     assert_eq!(

--- a/tests/test_consumers.rs
+++ b/tests/test_consumers.rs
@@ -170,7 +170,9 @@ fn test_produce_consume_seek() {
         }
     }
 
-    consumer.seek(&topic_name, 0, Offset::Offset(1), None).unwrap();
+    consumer
+        .seek(&topic_name, 0, Offset::Offset(1), None)
+        .unwrap();
 
     for (i, message) in consumer.iter().take(3).enumerate() {
         match message {

--- a/tests/test_consumers.rs
+++ b/tests/test_consumers.rs
@@ -17,10 +17,14 @@ mod utils;
 use crate::utils::*;
 
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::thread;
 use std::time::{Duration, Instant};
 
 struct TestContext {
     _n: i64, // Add data for memory access validation
+    wakeups: Arc<AtomicUsize>,
 }
 
 impl ClientContext for TestContext {
@@ -38,6 +42,10 @@ impl ConsumerContext for TestContext {
         _offsets: *mut rdkafka_sys::RDKafkaTopicPartitionList,
     ) {
         println!("Committing offsets: {:?}", result);
+    }
+
+    fn message_queue_nonempty_callback(&self) {
+        self.wakeups.fetch_add(1, Ordering::SeqCst);
     }
 }
 
@@ -69,7 +77,10 @@ fn create_stream_consumer(
     group_id: &str,
     config_overrides: Option<HashMap<&str, &str>>,
 ) -> StreamConsumer<TestContext> {
-    let cons_context = TestContext { _n: 64 };
+    let cons_context = TestContext {
+        _n: 64,
+        wakeups: Arc::new(AtomicUsize::new(0)),
+    };
     create_stream_consumer_with_context(group_id, config_overrides, cons_context)
 }
 
@@ -88,7 +99,10 @@ fn create_base_consumer(
     config_overrides: Option<HashMap<&str, &str>>,
 ) -> BaseConsumer<TestContext> {
     consumer_config(group_id, config_overrides)
-        .create_with_context(TestContext { _n: 64 })
+        .create_with_context(TestContext {
+            _n: 64,
+            wakeups: Arc::new(AtomicUsize::new(0)),
+        })
         .expect("Consumer creation failed")
 }
 
@@ -471,4 +485,75 @@ fn test_pause_resume_consumer_iter() {
     }
 
     ensure_empty(&consumer, "There should be no messages left");
+}
+
+// All produced messages should be consumed.
+#[test]
+fn test_produce_consume_message_queue_nonempty_callback() {
+    let _r = env_logger::try_init();
+
+    let topic_name = rand_test_topic();
+
+    let consumer: BaseConsumer<_> = consumer_config(&rand_test_group(), None)
+        .create_with_context(TestContext {
+            _n: 64,
+            wakeups: Arc::new(AtomicUsize::new(0)),
+        })
+        .expect("Consumer creation failed");
+    consumer.subscribe(&[topic_name.as_str()]).unwrap();
+
+    let wakeups = consumer.context().wakeups.clone();
+    let wait_for_wakeups = |target| {
+        let start = Instant::now();
+        let timeout = Duration::from_secs(15);
+        loop {
+            let w = wakeups.load(Ordering::SeqCst);
+            if w == target {
+                break;
+            } else if w > target {
+                panic!("wakeups {} exceeds target {}", w, target);
+            }
+            thread::sleep(Duration::from_millis(100));
+            if start.elapsed() > timeout {
+                panic!("timeout exceeded while waiting for wakeup");
+            }
+        }
+    };
+
+    // Initiate connection.
+    assert!(consumer.poll(Duration::from_secs(0)).is_none());
+
+    // Expect one initial rebalance callback.
+    wait_for_wakeups(1);
+
+    // Expect no additional wakeups for 1s.
+    std::thread::sleep(Duration::from_secs(1));
+    assert_eq!(wakeups.load(Ordering::SeqCst), 1);
+
+    // Verify there are no messages waiting.
+    assert!(consumer.poll(Duration::from_secs(0)).is_none());
+
+    // Populate the topic, and expect a wakeup notifying us of the new messages.
+    populate_topic(&topic_name, 2, &value_fn, &key_fn, None, None);
+    wait_for_wakeups(2);
+
+    // Read one of the messages.
+    assert!(consumer.poll(Duration::from_secs(0)).is_some());
+
+    // Add more messages to the topic. Expect no additional wakeups, as the
+    // queue is not fully drained, for 1s.
+    populate_topic(&topic_name, 2, &value_fn, &key_fn, None, None);
+    std::thread::sleep(Duration::from_secs(1));
+    assert_eq!(wakeups.load(Ordering::SeqCst), 2);
+
+    // Drain the consumer.
+    assert_eq!(consumer.iter().take(3).count(), 3);
+
+    // Expect no additional wakeups for 1s.
+    std::thread::sleep(Duration::from_secs(1));
+    assert_eq!(wakeups.load(Ordering::SeqCst), 2);
+
+    // Add another message, and expect a wakeup.
+    populate_topic(&topic_name, 1, &value_fn, &key_fn, None, None);
+    wait_for_wakeups(3);
 }


### PR DESCRIPTION
This makes it possible to receive a notification via a Rust callback when there are new messages available. The bulk of the implementation is in the last two commits; the first commit is just preparatory work.