### PR TITLE
Remove references to deprecated produce.offset.report config

### DIFF
--- a/examples/asynchronous_processing.rs
+++ b/examples/asynchronous_processing.rs
@@ -64,7 +64,6 @@ fn run_async_processor(brokers: &str, group_id: &str, input_topic: &str, output_
     // Create the `FutureProducer` to produce asynchronously.
     let producer: FutureProducer = ClientConfig::new()
         .set("bootstrap.servers", brokers)
-        .set("produce.offset.report", "true")
         .set("message.timeout.ms", "5000")
         .create()
         .expect("Producer creation error");

--- a/examples/simple_producer.rs
+++ b/examples/simple_producer.rs
@@ -18,7 +18,6 @@ use rdkafka::message::OwnedHeaders;
 fn produce(brokers: &str, topic_name: &str) {
     let producer: FutureProducer = ClientConfig::new()
         .set("bootstrap.servers", brokers)
-        .set("produce.offset.report", "true")
         .set("message.timeout.ms", "5000")
         .create()
         .expect("Producer creation error");

--- a/src/producer/mod.rs
+++ b/src/producer/mod.rs
@@ -72,7 +72,6 @@
 //! - `request.required.acks` (1): This field indicates how many acknowledgements the leader broker must receive from ISR brokers before responding to the request: 0=Broker does not send any response/ack to client, 1=Only the leader broker will need to ack the message, -1 or all=broker will block until message is committed by all in sync replicas (ISRs) or broker's in.sync.replicas setting before sending response.
 //! - `request.timeout.ms` (5000): The ack timeout of the producer request in milliseconds. This value is only enforced by the broker and relies on request.required.acks being != 0.
 //! - `message.timeout.ms` (300000): Local message timeout. This value is only enforced locally and limits the time a produced message waits for successful delivery. A time of 0 is infinite.
-//! - `produce.offset.report` (false): Report offset of produced message back to application.
 //!
 
 pub mod base_producer;

--- a/tests/test_high_producers.rs
+++ b/tests/test_high_producers.rs
@@ -16,7 +16,6 @@ use std::error::Error;
 fn test_future_producer_send_fail() {
     let producer = ClientConfig::new()
         .set("bootstrap.servers", "localhost")
-        .set("produce.offset.report", "true")
         .set("message.timeout.ms", "5000")
         .create::<FutureProducer>()
         .expect("Failed to create producer");

--- a/tests/test_low_producers.rs
+++ b/tests/test_low_producers.rs
@@ -85,7 +85,6 @@ fn default_config(config_overrides: HashMap<&str, &str>) -> ClientConfig {
     let mut config = ClientConfig::new();
     config
         .set("bootstrap.servers", &get_bootstrap_server())
-        .set("produce.offset.report", "true")
         .set("message.timeout.ms", "5000");
 
     for (key, value) in config_overrides {

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -112,7 +112,6 @@ where
         .set("statistics.interval.ms", "500")
         .set("api.version.request", "true")
         .set("debug", "all")
-        .set("produce.offset.report", "true")
         .set("message.timeout.ms", "30000")
         .create_with_context::<TestContext, FutureProducer<_>>(prod_context)
         .expect("Producer creation error");


### PR DESCRIPTION
This is no longer necessary, as librdkafka unconditionally sends the
offset report to producers.

Fix #139.