### PR TITLE
[WIP] Async/Await: No futures executor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,6 @@ jobs:
   - os: linux
     arch: amd64
     rust: stable
-  - os: linux
-    arch: amd64
-    rust: nightly-2019-10-17
     env: RDKAFKA_RUN_TESTS=1
   - os: linux
     arch: arm64

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 
 [dependencies]
 rdkafka-sys = { path = "rdkafka-sys", version = "1.2.1" }
-futures = "0.1.21"
+futures-preview = "0.3.0-alpha.18"
 libc = "0.2.0"
 log = "0.4.8"
 serde = "1.0.0"
@@ -26,7 +26,7 @@ clap = "2.18.0"
 env_logger = "0.7.1"
 rand = "0.3.15"
 regex = "1.1.6"
-tokio = "0.1.7"
+tokio = "0.2.0-alpha.4"
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ log = "0.4.8"
 pin-project = "0.4"
 serde = { version = "1.0.0", features = ["derive"] }
 serde_json = "1.0.0"
-tokio-executor = "0.2.0-alpha.6"
+tokio-executor = "=0.2.0-alpha.6"
 
 [dev-dependencies]
 backoff = "0.1.5"
@@ -28,7 +28,7 @@ env_logger = "0.7.1"
 lazy_static = "1.4.0"
 rand = "0.3.15"
 regex = "1.1.6"
-tokio = "0.2.0-alpha.6"
+tokio = "=0.2.0-alpha.6"
 
 [features]
 default = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,21 +12,23 @@ edition = "2018"
 
 [dependencies]
 rdkafka-sys = { path = "rdkafka-sys", version = "1.2.1" }
-futures-preview = "0.3.0-alpha.18"
+futures = "0.3"
 libc = "0.2.0"
 log = "0.4.8"
-serde = "1.0.0"
-serde_derive = "1.0.0"
+pin-project = "0.4"
+serde = { version = "1.0.0", features = ["derive"] }
 serde_json = "1.0.0"
+tokio-executor = "0.2.0-alpha.6"
 
 [dev-dependencies]
 backoff = "0.1.5"
 chrono = "0.4.0"
 clap = "2.18.0"
 env_logger = "0.7.1"
+lazy_static = "1.4.0"
 rand = "0.3.15"
 regex = "1.1.6"
-tokio = "0.2.0-alpha.4"
+tokio = "0.2.0-alpha.6"
 
 [features]
 default = []

--- a/examples/asynchronous_processing.rs
+++ b/examples/asynchronous_processing.rs
@@ -1,27 +1,21 @@
-#[macro_use] extern crate log;
-extern crate clap;
-extern crate futures;
-extern crate rand;
-extern crate rdkafka;
-extern crate tokio;
-
 use clap::{App, Arg};
 use futures::{FutureExt, StreamExt};
-use futures::future::{lazy, ready};
-use tokio::runtime::current_thread;
+use futures::future::ready;
+use log::*;
 
-use rdkafka::Message;
-use rdkafka::consumer::Consumer;
-use rdkafka::consumer::stream_consumer::StreamConsumer;
 use rdkafka::config::ClientConfig;
-use rdkafka::message::OwnedMessage;
-use rdkafka::producer::{FutureProducer, FutureRecord};
+use rdkafka::consumer::StreamConsumer;
+use rdkafka::consumer::Consumer;
+use rdkafka::Message;
+use rdkafka::async_support::*;
 
 use std::thread;
 use std::time::Duration;
 
+use tokio_executor::blocking::{run as block_on};
+
 mod example_utils;
-use crate::example_utils::setup_logger;
+use example_utils::setup_logger;
 
 
 // Emulates an expensive, synchronous computation.
@@ -44,8 +38,7 @@ fn expensive_computation<'a>(msg: OwnedMessage) -> String {
 // Moving each message from one stage of the pipeline to next one is handled by the event loop,
 // that runs on a single thread. The expensive CPU-bound computation is handled by the `ThreadPool`,
 // without blocking the event loop.
-fn run_async_processor(brokers: &str, group_id: &str, input_topic: &str, output_topic: &str) {
-
+async fn run_async_processor(brokers: &str, group_id: &str, input_topic: &str, output_topic: &str) {
     // Create the `StreamConsumer`, to receive the messages from the topic in form of a `Stream`.
     let consumer: StreamConsumer = ClientConfig::new()
         .set("group.id", group_id)
@@ -66,17 +59,6 @@ fn run_async_processor(brokers: &str, group_id: &str, input_topic: &str, output_
         .create()
         .expect("Producer creation error");
 
-    // Create the runtime where the expensive computation will be performed.
-    let thread_pool = tokio::runtime::Builder::new()
-        .name_prefix("pool-")
-        .core_threads(4)
-        .build()
-        .unwrap();
-
-    // Use the current thread as IO thread to drive consumer and producer.
-    let mut io_thread = current_thread::Runtime::new().unwrap();
-    let io_thread_handle = io_thread.handle();
-
     // Create the outer pipeline on the message stream.
     let stream_processor = consumer.start()
         .filter_map(|result| {  // Filter out errors
@@ -94,10 +76,9 @@ fn run_async_processor(brokers: &str, group_id: &str, input_topic: &str, output_
             let owned_message = borrowed_message.detach();
             let output_topic = output_topic.to_string();
             let producer = producer.clone();
-            let io_thread_handle = io_thread_handle.clone();
-            let message_future = lazy(move |_| {
+            let message_future = async move {
                 // The body of this closure will be executed in the thread pool.
-                let computation_result = expensive_computation(owned_message);
+                let computation_result = block_on(move || expensive_computation(owned_message)).await;
                 let producer_future = producer.send(
                     FutureRecord::to(&output_topic)
                         .key("some key")
@@ -109,19 +90,19 @@ fn run_async_processor(brokers: &str, group_id: &str, input_topic: &str, output_
                         }
                         ready(())
                     });
-                let _ = io_thread_handle.spawn(producer_future);
-                ()
-            });
-            thread_pool.spawn(message_future);
+                producer_future.await
+            };
+            tokio::spawn(message_future);
             ready(())
         });
 
     info!("Starting event loop");
-    let _ = io_thread.block_on(stream_processor);
+    stream_processor.await;
     info!("Stream processing terminated");
 }
 
-fn main() {
+#[tokio::main]
+async fn main() {
     let matches = App::new("Async example")
         .version(option_env!("CARGO_PKG_VERSION").unwrap_or(""))
         .about("Asynchronous computation example")
@@ -160,5 +141,5 @@ fn main() {
     let input_topic = matches.value_of("input-topic").unwrap();
     let output_topic = matches.value_of("output-topic").unwrap();
 
-    run_async_processor(brokers, group_id, input_topic, output_topic);
+    run_async_processor(brokers, group_id, input_topic, output_topic).await
 }

--- a/examples/at_least_once.rs
+++ b/examples/at_least_once.rs
@@ -11,18 +11,17 @@
 /// For a simpler example of consumers and producers, check the `simple_consumer` and
 /// `simple_producer` files in the example folder.
 ///
-#[macro_use]
-extern crate log;
+#[macro_use] extern crate log;
 extern crate clap;
 extern crate futures;
 extern crate rdkafka;
 extern crate rdkafka_sys;
 
 use clap::{App, Arg};
+use futures::executor::{block_on, block_on_stream};
 use futures::future::join_all;
-use futures::stream::Stream;
-use futures::Future;
 
+use rdkafka::Message;
 use rdkafka::client::ClientContext;
 use rdkafka::config::{ClientConfig, RDKafkaLogLevel};
 use rdkafka::consumer::stream_consumer::StreamConsumer;
@@ -30,10 +29,10 @@ use rdkafka::consumer::{Consumer, ConsumerContext};
 use rdkafka::error::KafkaResult;
 use rdkafka::producer::{FutureProducer, FutureRecord};
 use rdkafka::util::get_rdkafka_version;
-use rdkafka::Message;
 
 mod example_utils;
 use crate::example_utils::setup_logger;
+
 
 // A simple context to customize the consumer behavior and print a log line every time
 // offsets are committed
@@ -42,11 +41,7 @@ struct LoggingConsumerContext;
 impl ClientContext for LoggingConsumerContext {}
 
 impl ConsumerContext for LoggingConsumerContext {
-    fn commit_callback(
-        &self,
-        result: KafkaResult<()>,
-        _offsets: *mut rdkafka_sys::RDKafkaTopicPartitionList,
-    ) {
+    fn commit_callback(&self, result: KafkaResult<()>, _offsets: *mut rdkafka_sys::RDKafkaTopicPartitionList) {
         match result {
             Ok(_) => info!("Offsets committed successfully"),
             Err(e) => warn!("Error while committing offsets: {}", e),
@@ -74,9 +69,7 @@ fn create_consumer(brokers: &str, group_id: &str, topic: &str) -> LoggingConsume
         .create_with_context(context)
         .expect("Consumer creation failed");
 
-    consumer
-        .subscribe(&[topic])
-        .expect("Can't subscribe to specified topic");
+    consumer.subscribe(&[topic]).expect("Can't subscribe to specified topic");
 
     consumer
 }
@@ -84,7 +77,7 @@ fn create_consumer(brokers: &str, group_id: &str, topic: &str) -> LoggingConsume
 fn create_producer(brokers: &str) -> FutureProducer {
     ClientConfig::new()
         .set("bootstrap.servers", brokers)
-        .set("queue.buffering.max.ms", "0") // Do not buffer
+        .set("queue.buffering.max.ms", "0")  // Do not buffer
         .create()
         .expect("Producer creation failed")
 }
@@ -93,43 +86,33 @@ fn main() {
     let matches = App::new("at-least-once")
         .version(option_env!("CARGO_PKG_VERSION").unwrap_or(""))
         .about("At-least-once delivery example")
-        .arg(
-            Arg::with_name("brokers")
-                .short("b")
-                .long("brokers")
-                .help("Broker list in kafka format")
-                .takes_value(true)
-                .default_value("localhost:9092"),
-        )
-        .arg(
-            Arg::with_name("group-id")
-                .short("g")
-                .long("group-id")
-                .help("Consumer group id")
-                .takes_value(true)
-                .default_value("example_consumer_group_id"),
-        )
-        .arg(
-            Arg::with_name("log-conf")
-                .long("log-conf")
-                .help("Configure the logging format (example: 'rdkafka=trace')")
-                .takes_value(true),
-        )
-        .arg(
-            Arg::with_name("input-topic")
-                .long("input-topic")
-                .help("Input topic name")
-                .takes_value(true)
-                .required(true),
-        )
-        .arg(
-            Arg::with_name("output-topics")
-                .long("output-topics")
-                .help("Output topics names")
-                .takes_value(true)
-                .multiple(true)
-                .required(true),
-        )
+        .arg(Arg::with_name("brokers")
+             .short("b")
+             .long("brokers")
+             .help("Broker list in kafka format")
+             .takes_value(true)
+             .default_value("localhost:9092"))
+        .arg(Arg::with_name("group-id")
+             .short("g")
+             .long("group-id")
+             .help("Consumer group id")
+             .takes_value(true)
+             .default_value("example_consumer_group_id"))
+        .arg(Arg::with_name("log-conf")
+             .long("log-conf")
+             .help("Configure the logging format (example: 'rdkafka=trace')")
+             .takes_value(true))
+        .arg(Arg::with_name("input-topic")
+             .long("input-topic")
+             .help("Input topic name")
+             .takes_value(true)
+             .required(true))
+        .arg(Arg::with_name("output-topics")
+            .long("output-topics")
+            .help("Output topics names")
+            .takes_value(true)
+            .multiple(true)
+            .required(true))
         .get_matches();
 
     setup_logger(true, matches.value_of("log-conf"));
@@ -138,39 +121,34 @@ fn main() {
     info!("rd_kafka_version: {}", version);
 
     let input_topic = matches.value_of("input-topic").unwrap();
-    let output_topics = matches
-        .values_of("output-topics")
-        .unwrap()
-        .collect::<Vec<&str>>();
+    let output_topics = matches.values_of("output-topics").unwrap().collect::<Vec<&str>>();
     let brokers = matches.value_of("brokers").unwrap();
     let group_id = matches.value_of("group-id").unwrap();
 
     let consumer = create_consumer(brokers, group_id, input_topic);
     let producer = create_producer(brokers);
 
-    for message in consumer.start().wait() {
+    for message in block_on_stream(consumer.start()) {
         match message {
-            Err(()) => {
-                warn!("Error while reading from stream");
-            }
-            Ok(Err(e)) => {
+            Err(e) => {
                 warn!("Kafka error: {}", e);
             }
-            Ok(Ok(m)) => {
+            Ok(m) => {
                 // Send a copy to the message to every output topic in parallel, and wait for the
                 // delivery report to be received.
-                join_all(output_topics.iter().map(|output_topic| {
-                    let mut record = FutureRecord::to(output_topic);
-                    if let Some(p) = m.payload() {
-                        record = record.payload(p);
-                    }
-                    if let Some(k) = m.key() {
-                        record = record.key(k);
-                    }
-                    producer.send(record, 1000)
-                }))
-                .wait()
-                .expect("Message delivery failed for some topic");
+                block_on(join_all(
+                    output_topics.iter()
+                        .map(|output_topic| {
+                            let mut record = FutureRecord::to(output_topic);
+                            if let Some(p) = m.payload() {
+                                record = record.payload(p);
+                            }
+                            if let Some(k) = m.key() {
+                                record = record.key(k);
+                            }
+                            producer.send(record, 1000)
+                        }))).into_iter().collect::<Result<Vec<_>, _>>()
+                    .expect("Message delivery failed for some topic");
                 // Now that the message is completely processed, add it's position to the offset
                 // store. The actual offset will be committed every 5 seconds.
                 if let Err(e) = consumer.store_offset(&m) {

--- a/examples/example_utils.rs
+++ b/examples/example_utils.rs
@@ -1,12 +1,8 @@
-extern crate chrono;
-extern crate env_logger;
-extern crate log;
+use chrono::prelude::*;
 
-use self::chrono::prelude::*;
-
-use self::env_logger::fmt::Formatter;
-use self::env_logger::Builder;
-use self::log::{LevelFilter, Record};
+use env_logger::fmt::Formatter;
+use env_logger::Builder;
+use log::{LevelFilter, Record};
 use std::io::Write;
 use std::thread;
 

--- a/examples/metadata.rs
+++ b/examples/metadata.rs
@@ -1,18 +1,14 @@
-#[macro_use]
-extern crate log;
-#[macro_use]
-extern crate clap;
-extern crate rdkafka;
-
-use clap::{App, Arg};
+use clap::{App, Arg, value_t};
+use log::*;
 
 use rdkafka::config::ClientConfig;
 use rdkafka::consumer::{BaseConsumer, Consumer};
 
 use std::time::Duration;
 
+#[macro_use]
 mod example_utils;
-use crate::example_utils::setup_logger;
+use example_utils::setup_logger;
 
 fn print_metadata(brokers: &str, topic: Option<&str>, timeout: Duration, fetch_offsets: bool) {
     let consumer: BaseConsumer = ClientConfig::new()

--- a/examples/simple_consumer.rs
+++ b/examples/simple_consumer.rs
@@ -6,7 +6,7 @@ extern crate rdkafka;
 extern crate rdkafka_sys;
 
 use clap::{App, Arg};
-use futures::stream::Stream;
+use futures::executor::block_on_stream;
 
 use rdkafka::client::ClientContext;
 use rdkafka::config::{ClientConfig, RDKafkaLogLevel};
@@ -70,11 +70,10 @@ fn consume_and_print(brokers: &str, group_id: &str, topics: &[&str]) {
     // such as complex computations on a thread pool or asynchronous IO.
     let message_stream = consumer.start();
 
-    for message in message_stream.wait() {
+    for message in block_on_stream(message_stream) {
         match message {
-            Err(_) => warn!("Error while reading from stream."),
-            Ok(Err(e)) => warn!("Kafka error: {}", e),
-            Ok(Ok(m)) => {
+            Err(e) => warn!("Kafka error: {}", e),
+            Ok(m) => {
                 let payload = match m.payload_view::<str>() {
                     None => "",
                     Some(Ok(s)) => s,

--- a/examples/simple_producer.rs
+++ b/examples/simple_producer.rs
@@ -6,6 +6,7 @@ extern crate rdkafka;
 
 use clap::{App, Arg};
 use futures::*;
+use futures::executor::block_on;
 
 use rdkafka::config::ClientConfig;
 use rdkafka::producer::{FutureProducer, FutureRecord};
@@ -47,7 +48,7 @@ fn produce(brokers: &str, topic_name: &str) {
 
     // This loop will wait until all delivery statuses have been received received.
     for future in futures {
-        info!("Future completed. Result: {:?}", future.wait());
+        info!("Future completed. Result: {:?}", block_on(future));
     }
 }
 

--- a/rdkafka-sys/Cargo.toml
+++ b/rdkafka-sys/Cargo.toml
@@ -18,6 +18,7 @@ openssl-sys = { version = "~ 0.9.0", optional = true }
 lz4-sys = { version = "1.8.3", optional = true }
 
 [build-dependencies]
+bindgen = "0.51.1"
 num_cpus = "0.2.0"
 pkg-config = "0.3.9"
 cmake = { version = "^0.1", optional = true }

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -14,10 +14,9 @@ use crate::util::{cstr_to_owned, timeout_to_ms, AsCArray, ErrBuf, IntoOpaque, Wr
 
 use futures::channel::oneshot::{Canceled, Receiver, Sender, channel};
 use futures::future::{self, Either, Future, FutureExt};
-
+use log::*;
 use std::collections::HashMap;
 use std::ffi::{CStr, CString};
-use std::mem;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -518,9 +517,9 @@ impl AdminOptions {
         let (tx, rx) = channel();
         let tx = Box::new(tx);
         unsafe {
-            rdsys::rd_kafka_AdminOptions_set_opaque(native_opts.ptr, IntoOpaque::as_ptr(&tx))
+            rdsys::rd_kafka_AdminOptions_set_opaque(native_opts.ptr, IntoOpaque::as_ptr(&tx));
+            std::mem::forget(tx);
         };
-        mem::forget(tx);
 
         Ok((native_opts, rx))
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -2,6 +2,7 @@
 use crate::rdsys;
 use crate::rdsys::types::*;
 
+use log::*;
 use std::ffi::{CStr, CString};
 use std::mem;
 use std::os::raw::c_char;
@@ -71,6 +72,7 @@ impl ClientContext for DefaultClientContext {}
 
 /// A native rdkafka-sys client. This struct shouldn't be used directly. Use higher level `Client`
 /// or producers and consumers.
+#[derive(Clone)]
 pub struct NativeClient {
     ptr: *mut RDKafka,
 }
@@ -104,6 +106,7 @@ impl Drop for NativeClient {
 /// A low level rdkafka client. This client shouldn't be used directly. The producer and consumer modules
 /// provide different producer and consumer implementations based on top of `Client` that can be
 /// used instead.
+#[derive(Clone)]
 pub struct Client<C: ClientContext = DefaultClientContext> {
     native: NativeClient,
     context: Box<C>,

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,12 +20,12 @@
 
 use crate::rdsys;
 use crate::rdsys::types::*;
-use log::Level;
 
 use crate::client::ClientContext;
 use crate::error::{IsError, KafkaError, KafkaResult};
 use crate::util::ErrBuf;
 
+use log::*;
 use std::collections::HashMap;
 use std::ffi::CString;
 use std::mem;
@@ -144,6 +144,7 @@ impl ClientConfig {
         let conf = unsafe { rdsys::rd_kafka_conf_new() };
         let mut err_buf = ErrBuf::new();
         for (key, value) in &self.conf_map {
+            trace!("Adding config value {}={}", key, value);
             let key_c = CString::new(key.to_string())?;
             let value_c = CString::new(value.to_string())?;
             let ret = unsafe {

--- a/src/consumer/base_consumer.rs
+++ b/src/consumer/base_consumer.rs
@@ -13,6 +13,7 @@ use crate::topic_partition_list::Offset::Offset;
 use crate::topic_partition_list::TopicPartitionList;
 use crate::util::{cstr_to_owned, timeout_to_ms};
 
+use log::*;
 use std::mem;
 use std::os::raw::c_void;
 use std::ptr;
@@ -59,6 +60,7 @@ unsafe extern "C" fn native_rebalance_cb<C: ConsumerContext>(
 
 /// Low level wrapper around the librdkafka consumer. This consumer requires to be periodically polled
 /// to make progress on rebalance, callbacks and to receive messages.
+#[derive(Clone)]
 pub struct BaseConsumer<C: ConsumerContext = DefaultConsumerContext> {
     client: Client<C>,
 }
@@ -125,7 +127,7 @@ impl<C: ConsumerContext> BaseConsumer<C> {
         timeout: T,
     ) -> Option<KafkaResult<BorrowedMessage>> {
         self.poll_raw(timeout_to_ms(timeout))
-            .map(|ptr| unsafe { BorrowedMessage::from_consumer(ptr, self) })
+            .map(|ptr| unsafe { BorrowedMessage::from_consumer(ptr) })
     }
 
     /// Returns an iterator over the available messages.

--- a/src/consumer/message_stream.rs
+++ b/src/consumer/message_stream.rs
@@ -1,0 +1,162 @@
+use crate::rdsys;
+use crate::rdsys::types::*;
+use futures::Stream;
+
+use crate::consumer::{ConsumerContext, BaseConsumer};
+use crate::error::{KafkaError, KafkaResult};
+use crate::message::BorrowedMessage;
+use crate::util::duration_to_millis;
+
+use log::*;
+use pin_project::pin_project;
+use std::future::Future;
+use std::pin::Pin;
+use std::ptr;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use std::time::Duration;
+use tokio_executor::blocking::{run as block_on, Blocking};
+
+/// A small wrapper for a message pointer. This wrapper is only used to
+/// pass a message between the polling thread and the thread consuming the stream,
+/// and to transform it from pointer to `BorrowedMessage` with a lifetime that derives from the
+/// lifetime of the stream consumer. In general is not safe to pass a struct with an internal
+/// reference across threads. However the `StreamConsumer` guarantees that the polling thread
+/// is terminated before the consumer is actually dropped, ensuring that the messages
+/// are safe to be used for their entire lifetime.
+struct PolledMessagePtr {
+    message_ptr: *mut RDKafkaMessage,
+}
+
+impl PolledMessagePtr {
+    /// Creates a new PolledPtr from a message pointer. It takes the ownership of the message.
+    fn new(message_ptr: *mut RDKafkaMessage) -> PolledMessagePtr {
+        trace!("New polled ptr {:?}", message_ptr);
+        PolledMessagePtr { message_ptr }
+    }
+
+    /// Transforms the `PolledMessagePtr` into a message whose lifetime will be bound to the
+    /// lifetime of the provided consumer. If the librdkafka message represents an error, the error
+    /// will be returned instead.
+    fn into_message<'a>(
+        mut self,
+    ) -> KafkaResult<BorrowedMessage<'a>> {
+        let msg = unsafe { BorrowedMessage::from_consumer(self.message_ptr) };
+        self.message_ptr = ptr::null_mut();
+        msg
+    }
+}
+
+impl Drop for PolledMessagePtr {
+    /// If the `PolledMessagePtr` is hasn't been transformed into a message and the pointer is
+    /// still available, it will free the underlying resources.
+    fn drop(&mut self) {
+        if !self.message_ptr.is_null() {
+            trace!("Destroy PolledPtr {:?}", self.message_ptr);
+            unsafe { rdsys::rd_kafka_message_destroy(self.message_ptr) };
+        }
+    }
+}
+
+/// Allow message pointer to be moved across threads.
+unsafe impl Send for PolledMessagePtr {}
+
+// A Kafka consumer implementing Stream.
+///
+/// It can be used to receive messages as they are consumed from Kafka. Note: there might be
+/// buffering between the actual Kafka consumer and the receiving end of this stream, so it is not
+/// advised to use automatic commit, as some messages might have been consumed by the internal Kafka
+/// consumer but not processed. Manual offset storing should be used, see the `store_offset`
+/// function on `Consumer`.
+#[pin_project]
+pub struct MessageStream<'a, C: ConsumerContext + 'static> {
+    consumer: Arc<BaseConsumer<C>>,
+    should_stop: Arc<AtomicBool>,
+    poll_interval_ms: i32,
+    send_none: bool,
+    #[pin]
+    pending: Option<Blocking<PollConsumerResult>>,
+    phantom: &'a std::marker::PhantomData<C>,
+}
+
+enum PollConsumerResult {
+    Continue,
+    Ready(Option<PolledMessagePtr>),
+}
+
+impl<'a, C: ConsumerContext + 'static> MessageStream<'a, C> {
+    /// Create a new message stream from a base consumer
+    pub fn new(
+        consumer: Arc<BaseConsumer<C>>,
+        should_stop: Arc<AtomicBool>,
+        poll_interval: Duration,
+        send_none: bool,
+    ) -> Self {
+        let poll_interval_ms = duration_to_millis(poll_interval) as i32;
+        Self {
+            consumer: consumer,
+            should_stop: should_stop,
+            poll_interval_ms: poll_interval_ms,
+            send_none: send_none,
+            pending: None,
+            phantom: &std::marker::PhantomData,
+        }
+    }
+
+    /// Close the message stream
+    pub async fn close(&self) {
+        self.should_stop.store(true, Ordering::Relaxed);
+    }
+}
+
+impl<'a, C: ConsumerContext + 'a> Stream for MessageStream<'a, C> {
+    type Item = KafkaResult<BorrowedMessage<'a>>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
+        let mut this = self.project();
+        let mut pending: Pin<&mut Option<Blocking<PollConsumerResult>>> = this.pending.as_mut();
+        debug!("Polling stream for next message");
+        loop {
+            if this.should_stop.load(Ordering::Relaxed) {
+                info!("Stopping");
+                return Poll::Ready(None);
+            } else {
+                if let Some(to_poll) = pending.as_mut().as_pin_mut() {
+                    debug!("Seeing if poll result is ready");
+                    if let PollConsumerResult::Ready(res) = futures::ready!(to_poll.poll(cx)) {
+                        debug!("Poll result ready");
+                        pending.set(None);
+                        let ret = match res {
+                            None => {
+                                debug!("No message polled, but forwarding none as requested");
+                                Poll::Ready(Some(Err(KafkaError::NoMessageReceived)))
+                            },
+                            Some(polled_ptr) => Poll::Ready(Some(polled_ptr.into_message())),
+                        };
+                        return ret;
+                    }
+                }
+                debug!("Requesting next poll result");
+                let consumer = Arc::clone(&this.consumer);
+                let poll_interval_ms = *this.poll_interval_ms;
+                let send_none = *this.send_none;
+                let f = block_on(move || {
+                    match consumer.poll_raw(poll_interval_ms) {
+                        None => {
+                            if send_none {
+                                PollConsumerResult::Ready(None)
+                            } else {
+                                PollConsumerResult::Continue
+                            }
+                        }
+                        Some(m_ptr) => {
+                            PollConsumerResult::Ready(Some(PolledMessagePtr::new(m_ptr)))
+                        },
+                    }
+                });
+                pending.replace(f);
+            }
+        }
+    }
+}

--- a/src/consumer/mod.rs
+++ b/src/consumer/mod.rs
@@ -1,10 +1,12 @@
 //! Base trait and common functionality for all consumers.
-pub mod base_consumer;
-pub mod stream_consumer;
+mod base_consumer;
+mod message_stream;
+mod stream_consumer;
 
 // Re-export
-pub use self::base_consumer::BaseConsumer;
-pub use self::stream_consumer::{MessageStream, StreamConsumer};
+pub use base_consumer::BaseConsumer;
+pub use message_stream::MessageStream;
+pub use stream_consumer::StreamConsumer;
 
 use crate::rdsys;
 use crate::rdsys::types::*;
@@ -16,6 +18,7 @@ use crate::message::BorrowedMessage;
 use crate::metadata::Metadata;
 use crate::util::cstr_to_owned;
 
+use log::*;
 use std::ptr;
 use std::time::Duration;
 

--- a/src/consumer/stream_consumer.rs
+++ b/src/consumer/stream_consumer.rs
@@ -1,147 +1,13 @@
 //! Stream-based consumer implementation.
-use crate::rdsys;
-use crate::rdsys::types::*;
-use futures::channel::mpsc;
-use futures::executor::block_on;
-use futures::{Poll, SinkExt, Stream, StreamExt};
-
 use crate::config::{ClientConfig, FromClientConfig, FromClientConfigAndContext};
 use crate::consumer::base_consumer::BaseConsumer;
-use crate::consumer::{Consumer, ConsumerContext, DefaultConsumerContext};
-use crate::error::{KafkaError, KafkaResult};
-use crate::message::BorrowedMessage;
-use crate::util::duration_to_millis;
+use crate::consumer::{Consumer, ConsumerContext, DefaultConsumerContext, MessageStream};
+use crate::error::KafkaResult;
 
-use std::pin::Pin;
-use std::ptr;
+use log::*;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Mutex};
-use std::task::Context;
-use std::thread::{self, JoinHandle};
+use std::sync::Arc;
 use std::time::Duration;
-
-/// Default channel size for the stream consumer. The number of context switches
-/// seems to decrease exponentially as the channel size is increased, and it stabilizes when
-/// the channel size reaches 10 or so.
-const CONSUMER_CHANNEL_SIZE: usize = 10;
-
-/// A small wrapper for a message pointer. This wrapper is only used to
-/// pass a message between the polling thread and the thread consuming the stream,
-/// and to transform it from pointer to `BorrowedMessage` with a lifetime that derives from the
-/// lifetime of the stream consumer. In general is not safe to pass a struct with an internal
-/// reference across threads. However the `StreamConsumer` guarantees that the polling thread
-/// is terminated before the consumer is actually dropped, ensuring that the messages
-/// are safe to be used for their entire lifetime.
-struct PolledMessagePtr {
-    message_ptr: *mut RDKafkaMessage,
-}
-
-impl PolledMessagePtr {
-    /// Creates a new PolledPtr from a message pointer. It takes the ownership of the message.
-    fn new(message_ptr: *mut RDKafkaMessage) -> PolledMessagePtr {
-        trace!("New polled ptr {:?}", message_ptr);
-        PolledMessagePtr { message_ptr }
-    }
-
-    /// Transforms the `PolledMessagePtr` into a message whose lifetime will be bound to the
-    /// lifetime of the provided consumer. If the librdkafka message represents an error, the error
-    /// will be returned instead.
-    fn into_message_of<C: ConsumerContext>(
-        mut self,
-        consumer: &StreamConsumer<C>,
-    ) -> KafkaResult<BorrowedMessage> {
-        let msg = unsafe { BorrowedMessage::from_consumer(self.message_ptr, consumer) };
-        self.message_ptr = ptr::null_mut();
-        msg
-    }
-}
-
-impl Drop for PolledMessagePtr {
-    /// If the `PolledMessagePtr` is hasn't been transformed into a message and the pointer is
-    /// still available, it will free the underlying resources.
-    fn drop(&mut self) {
-        if !self.message_ptr.is_null() {
-            trace!("Destroy PolledPtr {:?}", self.message_ptr);
-            unsafe { rdsys::rd_kafka_message_destroy(self.message_ptr) };
-        }
-    }
-}
-
-/// Allow message pointer to be moved across threads.
-unsafe impl Send for PolledMessagePtr {}
-
-/// A Kafka consumer implementing Stream.
-///
-/// It can be used to receive messages as they are consumed from Kafka. Note: there might be
-/// buffering between the actual Kafka consumer and the receiving end of this stream, so it is not
-/// advised to use automatic commit, as some messages might have been consumed by the internal Kafka
-/// consumer but not processed. Manual offset storing should be used, see the `store_offset`
-/// function on `Consumer`.
-pub struct MessageStream<'a, C: ConsumerContext + 'static> {
-    consumer: &'a StreamConsumer<C>,
-    receiver: mpsc::Receiver<Option<PolledMessagePtr>>,
-}
-
-impl<'a, C: ConsumerContext + 'static> MessageStream<'a, C> {
-    fn new(
-        consumer: &'a StreamConsumer<C>,
-        receiver: mpsc::Receiver<Option<PolledMessagePtr>>,
-    ) -> MessageStream<'a, C> {
-        MessageStream { consumer, receiver }
-    }
-}
-
-impl<'a, C: ConsumerContext + 'a> Stream for MessageStream<'a, C> {
-    type Item = KafkaResult<BorrowedMessage<'a>>;
-
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
-        self.receiver
-            .poll_next_unpin(cx)
-            .map(|ready: Option<Option<PolledMessagePtr>>| {
-                ready.map(|polled_ptr_opt: Option<PolledMessagePtr>| {
-                    polled_ptr_opt.map_or(
-                        Err(KafkaError::NoMessageReceived),
-                        |polled_ptr: PolledMessagePtr| polled_ptr.into_message_of(self.consumer),
-                    )
-                })
-            })
-    }
-}
-
-/// Internal consumer loop. This is the main body of the thread that will drive the stream consumer.
-/// If `send_none` is true, the loop will send a None into the sender every time the poll times out.
-async fn poll_loop<C: ConsumerContext>(
-    consumer: &BaseConsumer<C>,
-    sender: mpsc::Sender<Option<PolledMessagePtr>>,
-    should_stop: &AtomicBool,
-    poll_interval: Duration,
-    send_none: bool,
-) {
-    trace!("Polling thread loop started");
-    let mut curr_sender = sender;
-    let poll_interval_ms = duration_to_millis(poll_interval) as i32;
-    while !should_stop.load(Ordering::Relaxed) {
-        trace!("Polling base consumer");
-        let future_sender = match consumer.poll_raw(poll_interval_ms) {
-            None => {
-                if send_none {
-                    curr_sender.send(None)
-                } else {
-                    continue; // TODO: check stream closed
-                }
-            }
-            Some(m_ptr) => curr_sender.send(Some(PolledMessagePtr::new(m_ptr))),
-        };
-        match future_sender.await {
-            Ok(_) => {},
-            Err(e) => {
-                debug!("Sender not available: {:?}", e);
-                break;
-            }
-        };
-    }
-    trace!("Polling thread loop terminated");
-}
 
 /// A Kafka Consumer providing a `futures::Stream` interface.
 ///
@@ -152,9 +18,15 @@ async fn poll_loop<C: ConsumerContext>(
 /// `Consumer`.
 #[must_use = "Consumer polling thread will stop immediately if unused"]
 pub struct StreamConsumer<C: ConsumerContext + 'static = DefaultConsumerContext> {
-    consumer: Arc<BaseConsumer<C>>,
-    should_stop: Arc<AtomicBool>,
-    handle: Mutex<Option<JoinHandle<()>>>,
+    pub (crate) consumer: Arc<BaseConsumer<C>>,
+    pub (crate) should_stop: Arc<AtomicBool>,
+}
+
+impl<C: ConsumerContext> StreamConsumer<C> {
+    /// Expose the underlying consumer
+    pub fn consumer(&self) -> Arc<BaseConsumer<C>> {
+        self.consumer.clone()
+    }
 }
 
 impl<C: ConsumerContext> Consumer<C> for StreamConsumer<C> {
@@ -178,7 +50,6 @@ impl<C: ConsumerContext> FromClientConfigAndContext<C> for StreamConsumer<C> {
         let stream_consumer = StreamConsumer {
             consumer: Arc::new(BaseConsumer::from_config_and_context(config, context)?),
             should_stop: Arc::new(AtomicBool::new(false)),
-            handle: Mutex::new(None),
         };
         Ok(stream_consumer)
     }
@@ -196,37 +67,12 @@ impl<C: ConsumerContext> StreamConsumer<C> {
     /// `KafkaError::NoMessageReceived` every time the poll interval is reached and no message has
     /// been received.
     pub fn start_with(&self, poll_interval: Duration, no_message_error: bool) -> MessageStream<C> {
-        // TODO: verify called once
-        let (sender, receiver) = mpsc::channel(CONSUMER_CHANNEL_SIZE);
-        let consumer = self.consumer.clone();
-        let should_stop = self.should_stop.clone();
-        let handle = thread::Builder::new()
-            .name("poll".to_string())
-            .spawn(move || {
-                block_on(poll_loop(
-                    consumer.as_ref(),
-                    sender,
-                    should_stop.as_ref(),
-                    poll_interval,
-                    no_message_error,
-                ));
-            })
-            .expect("Failed to start polling thread");
-        *self.handle.lock().unwrap() = Some(handle);
-        MessageStream::new(self, receiver)
+        MessageStream::new(Arc::clone(&self.consumer), Arc::clone(&self.should_stop), poll_interval, no_message_error)
     }
 
-    /// Stops the StreamConsumer, blocking the caller until the internal consumer has been stopped.
+    /// Stops the StreamConsumer
     pub fn stop(&self) {
-        let mut handle = self.handle.lock().unwrap();
-        if let Some(handle) = handle.take() {
-            trace!("Stopping polling");
-            self.should_stop.store(true, Ordering::Relaxed);
-            match handle.join() {
-                Ok(()) => trace!("Polling stopped"),
-                Err(e) => warn!("Failure while terminating thread: {:?}", e),
-            };
-        }
+        self.should_stop.store(true, Ordering::Relaxed);
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -74,47 +74,25 @@ impl fmt::Debug for KafkaError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             KafkaError::AdminOp(err) => write!(f, "KafkaError (Admin operation error: {})", err),
-            KafkaError::AdminOpCreation(ref err) => {
-                write!(f, "KafkaError (Admin operation creation error: {})", err)
-            }
+            KafkaError::AdminOpCreation(ref err) => write!(f, "KafkaError (Admin operation creation error: {})", err),
             KafkaError::Canceled => write!(f, "KafkaError (Client dropped)"),
-            KafkaError::ClientConfig(_, ref desc, ref key, ref value) => write!(
-                f,
-                "KafkaError (Client config error: {} {} {})",
-                desc, key, value
-            ),
-            KafkaError::ClientCreation(ref err) => {
-                write!(f, "KafkaError (Client creation error: {})", err)
+            KafkaError::ClientConfig(_, ref desc, ref key, ref value) => {
+                write!(f, "KafkaError (Client config error: {} {} {})", desc, key, value)
             }
-            KafkaError::ConsumerCommit(err) => {
-                write!(f, "KafkaError (Consumer commit error: {})", err)
-            }
+            KafkaError::ClientCreation(ref err) => write!(f, "KafkaError (Client creation error: {})", err),
+            KafkaError::ConsumerCommit(err) => write!(f, "KafkaError (Consumer commit error: {})", err),
             KafkaError::Global(err) => write!(f, "KafkaError (Global error: {})", err),
-            KafkaError::GroupListFetch(err) => {
-                write!(f, "KafkaError (Group list fetch error: {})", err)
-            }
-            KafkaError::MessageConsumption(err) => {
-                write!(f, "KafkaError (Message consumption error: {})", err)
-            }
-            KafkaError::MessageProduction(err) => {
-                write!(f, "KafkaError (Message production error: {})", err)
-            }
-            KafkaError::MetadataFetch(err) => {
-                write!(f, "KafkaError (Metadata fetch error: {})", err)
-            }
-            KafkaError::NoMessageReceived => {
-                write!(f, "No message received within the given poll interval")
-            }
+            KafkaError::GroupListFetch(err) => write!(f, "KafkaError (Group list fetch error: {})", err),
+            KafkaError::MessageConsumption(err) => write!(f, "KafkaError (Message consumption error: {})", err),
+            KafkaError::MessageProduction(err) => write!(f, "KafkaError (Message production error: {})", err),
+            KafkaError::MetadataFetch(err) => write!(f, "KafkaError (Metadata fetch error: {})", err),
+            KafkaError::NoMessageReceived => write!(f, "No message received within the given poll interval"),
             KafkaError::Nul(_) => write!(f, "FFI null error"),
             KafkaError::OffsetFetch(err) => write!(f, "KafkaError (Offset fetch error: {})", err),
             KafkaError::PartitionEOF(part_n) => write!(f, "KafkaError (Partition EOF: {})", part_n),
-            KafkaError::SetPartitionOffset(err) => {
-                write!(f, "KafkaError (Set partition offset error: {})", err)
-            }
+            KafkaError::SetPartitionOffset(err) => write!(f, "KafkaError (Set partition offset error: {})", err),
             KafkaError::StoreOffset(err) => write!(f, "KafkaError (Store offset error: {})", err),
-            KafkaError::Subscription(ref err) => {
-                write!(f, "KafkaError (Subscription error: {})", err)
-            }
+            KafkaError::Subscription(ref err) => write!(f, "KafkaError (Subscription error: {})", err),
         }
     }
 }
@@ -123,9 +101,7 @@ impl fmt::Display for KafkaError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             KafkaError::AdminOp(err) => write!(f, "Admin operation error: {}", err),
-            KafkaError::AdminOpCreation(ref err) => {
-                write!(f, "Admin operation creation error: {}", err)
-            }
+            KafkaError::AdminOpCreation(ref err) => write!(f, "Admin operation creation error: {}", err),
             KafkaError::Canceled => write!(f, "KafkaError (Client dropped)"),
             KafkaError::ClientConfig(_, ref desc, ref key, ref value) => {
                 write!(f, "Client config error: {} {} {}", desc, key, value)
@@ -137,9 +113,7 @@ impl fmt::Display for KafkaError {
             KafkaError::MessageConsumption(err) => write!(f, "Message consumption error: {}", err),
             KafkaError::MessageProduction(err) => write!(f, "Message production error: {}", err),
             KafkaError::MetadataFetch(err) => write!(f, "Meta data fetch error: {}", err),
-            KafkaError::NoMessageReceived => {
-                write!(f, "No message received within the given poll interval")
-            }
+            KafkaError::NoMessageReceived => write!(f, "No message received within the given poll interval"),
             KafkaError::Nul(_) => write!(f, "FFI nul error"),
             KafkaError::OffsetFetch(err) => write!(f, "Offset fetch error: {}", err),
             KafkaError::PartitionEOF(part_n) => write!(f, "Partition EOF: {}", part_n),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -214,14 +214,7 @@
 //use std::alloc::System;
 //#[global_allocator]
 //static A: System = System;
-
-#[macro_use]
-extern crate log;
-#[macro_use]
-extern crate serde_derive;
-extern crate serde_json;
-
-extern crate rdkafka_sys as rdsys;
+use rdkafka_sys as rdsys;
 
 pub use crate::rdsys::types;
 
@@ -245,3 +238,12 @@ pub use crate::message::{Message, Timestamp};
 pub use crate::statistics::Statistics;
 pub use crate::topic_partition_list::{Offset, TopicPartitionList};
 pub use crate::util::IntoOpaque;
+
+/// Re-export of types useful when using rdkafka with async
+pub mod async_support {
+    pub use crate::error::KafkaResult;
+    pub use crate::consumer::StreamConsumer;
+    pub use crate::message::OwnedMessage;
+    pub use crate::producer::{FutureProducer, FutureRecord};
+    pub use crate::producer::future_producer::OwnedDeliveryResult;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -219,7 +219,6 @@
 extern crate log;
 #[macro_use]
 extern crate serde_derive;
-extern crate futures;
 extern crate serde_json;
 
 extern crate rdkafka_sys as rdsys;

--- a/src/message.rs
+++ b/src/message.rs
@@ -2,6 +2,7 @@
 use crate::rdsys;
 use crate::rdsys::types::*;
 
+use log::*;
 use std::ffi::{CStr, CString};
 use std::fmt;
 use std::marker::PhantomData;
@@ -214,10 +215,9 @@ impl<'a> BorrowedMessage<'a> {
     /// consumer. The lifetime of the message will be bound to the lifetime of the consumer passed
     /// as parameter. This method should only be used with messages coming from consumers. If the
     /// message contains an error, only the error is returned and the message structure is freed.
-    pub(crate) unsafe fn from_consumer<C>(
+    pub(crate) unsafe fn from_consumer<'b>(
         ptr: *mut RDKafkaMessage,
-        _consumer: &'a C,
-    ) -> KafkaResult<BorrowedMessage<'a>> {
+    ) -> KafkaResult<BorrowedMessage<'b>> {
         if (*ptr).err.is_error() {
             let err = match (*ptr).err {
                 rdsys::rd_kafka_resp_err_t::RD_KAFKA_RESP_ERR__PARTITION_EOF => {

--- a/src/producer/base_producer.rs
+++ b/src/producer/base_producer.rs
@@ -44,6 +44,7 @@ use crate::error::{IsError, KafkaError, KafkaResult};
 use crate::message::{BorrowedMessage, OwnedHeaders, ToBytes};
 use crate::util::{timeout_to_ms, IntoOpaque};
 
+use log::*;
 use std::ffi::CString;
 use std::mem;
 use std::os::raw::c_void;

--- a/src/producer/mod.rs
+++ b/src/producer/mod.rs
@@ -78,8 +78,8 @@
 pub mod base_producer;
 pub mod future_producer;
 
-pub use self::base_producer::{
+pub use base_producer::{
     BaseProducer, BaseRecord, DefaultProducerContext, DeliveryResult, ProducerContext,
     ThreadedProducer,
 };
-pub use self::future_producer::{DeliveryFuture, FutureProducer, FutureRecord};
+pub use future_producer::{FutureProducer, FutureRecord};

--- a/src/statistics.rs
+++ b/src/statistics.rs
@@ -2,6 +2,7 @@
 #![allow(missing_docs)]
 
 use std::collections::HashMap;
+use serde::Deserialize;
 
 /// Statistics from librdkafka. Refer to the [librdkafka documentation](https://github.com/edenhill/librdkafka/wiki/Statistics)
 /// for details.

--- a/src/topic_partition_list.rs
+++ b/src/topic_partition_list.rs
@@ -5,6 +5,7 @@ use crate::rdsys::types::*;
 
 use crate::error::{IsError, KafkaError, KafkaResult};
 
+use log::*;
 use std::collections::HashMap;
 use std::ffi::{CStr, CString};
 use std::fmt;

--- a/tests/test_admin.rs
+++ b/tests/test_admin.rs
@@ -1,8 +1,5 @@
 //! Test administrative commands using the admin API.
-
 use backoff::{ExponentialBackoff, Operation};
-use futures::executor::block_on;
-
 
 use std::time::Duration;
 
@@ -17,7 +14,8 @@ use rdkafka::metadata::Metadata;
 use rdkafka::ClientConfig;
 
 mod utils;
-use crate::utils::*;
+use utils::*;
+use backoff::backoff::Backoff;
 
 fn create_config() -> ClientConfig {
     let mut config = ClientConfig::new();
@@ -72,8 +70,10 @@ fn verify_delete(topic: &str) {
     .unwrap()
 }
 
-#[test]
-fn test_topics() {
+#[tokio::test]
+async fn test_topics() {
+    let _ = env_logger::try_init();
+
     let admin_client = create_admin_client();
     let opts = AdminOptions::new().operation_timeout(Duration::from_secs(1));
 
@@ -93,8 +93,9 @@ fn test_topics() {
             config: Vec::new(),
         };
 
-        let res = block_on(admin_client
-            .create_topics(&[topic1, topic2], &opts))
+        let res = admin_client
+            .create_topics(&[topic1, topic2], &opts)
+            .await
             .expect("topic creation failed");
         assert_eq!(res, &[Ok(name1.clone()), Ok(name2.clone())]);
 
@@ -109,11 +110,11 @@ fn test_topics() {
         assert_eq!(1, metadata_topic1.partitions().len());
         assert_eq!(3, metadata_topic2.partitions().len());
 
-        let res = block_on(admin_client
+        let res = admin_client
             .describe_configs(
                 &[ResourceSpecifier::Topic(&name1), ResourceSpecifier::Topic(&name2)],
                 &opts,
-            ))
+            ).await
             .expect("describe configs failed");
         let config1 = &res[0].as_ref().expect("describe configs failed on topic 1");
         let config2 = &res[1].as_ref().expect("describe configs failed on topic 2");
@@ -146,8 +147,9 @@ fn test_topics() {
         assert_eq!(Some(&&expected_entry2), config_entries2.get("max.message.bytes"));
 
         let partitions1 = NewPartitions::new(&name1, 5);
-        let res = block_on(admin_client
-            .create_partitions(&[partitions1], &opts))
+        let res = admin_client
+            .create_partitions(&[partitions1], &opts)
+            .await
             .expect("partition creation failed");
         assert_eq!(res, &[Ok(name1.clone())]);
 
@@ -165,8 +167,9 @@ fn test_topics() {
         .retry(&mut backoff)
         .unwrap();
 
-        let res = block_on(admin_client
-            .delete_topics(&[&name1, &name2], &opts))
+        let res = admin_client
+            .delete_topics(&[&name1, &name2], &opts)
+            .await
             .expect("topic deletion failed");
         assert_eq!(res, &[Ok(name1.clone()), Ok(name2.clone())]);
         verify_delete(&name1);
@@ -177,7 +180,7 @@ fn test_topics() {
     // creating topics.
     {
         let topic = NewTopic::new("ignored", 1, TopicReplication::Variable(&[&[0], &[0]]));
-        let res = block_on(admin_client.create_topics(&[topic], &opts));
+        let res = admin_client.create_topics(&[topic], &opts).await;
         assert_eq!(
             Err(KafkaError::AdminOpCreation(
                 "replication configuration for topic 'ignored' assigns 2 partition(s), \
@@ -194,8 +197,9 @@ fn test_topics() {
         let name = rand_test_topic();
         let topic = NewTopic::new(&name, 1, TopicReplication::Fixed(1));
 
-        let res = block_on(admin_client
-            .create_topics(vec![&topic], &opts))
+        let res = admin_client
+            .create_topics(vec![&topic], &opts)
+            .await
             .expect("topic creation failed");
         assert_eq!(res, &[Ok(name.clone())]);
         let _ = fetch_metadata(&name);
@@ -203,7 +207,7 @@ fn test_topics() {
         // This partition specification is obviously garbage, and so trips
         // a client-side error.
         let partitions = NewPartitions::new(&name, 2).assign(&[&[0], &[0], &[0]]);
-        let res = block_on(admin_client.create_partitions(&[partitions], &opts));
+        let res = admin_client.create_partitions(&[partitions], &opts).await;
         assert_eq!(
             res,
             Err(KafkaError::AdminOpCreation(format!(
@@ -215,8 +219,9 @@ fn test_topics() {
 
         // Only the server knows that this partition specification is garbage.
         let partitions = NewPartitions::new(&name, 2).assign(&[&[0], &[0]]);
-        let res = block_on(admin_client
-            .create_partitions(&[partitions], &opts))
+        let res = admin_client
+            .create_partitions(&[partitions], &opts)
+            .await
             .expect("partition creation failed");
         assert_eq!(res, &[Err((name, RDKafkaError::InvalidReplicaAssignment))],);
     }
@@ -224,8 +229,9 @@ fn test_topics() {
     // Verify that deleting a non-existent topic fails.
     {
         let name = rand_test_topic();
-        let res = block_on(admin_client
-            .delete_topics(&[&name], &opts))
+        let res = admin_client
+            .delete_topics(&[&name], &opts)
+            .await
             .expect("delete topics failed");
         assert_eq!(res, &[Err((name, RDKafkaError::UnknownTopicOrPartition))]);
     }
@@ -239,14 +245,16 @@ fn test_topics() {
         let topic1 = NewTopic::new(&name1, 1, TopicReplication::Fixed(1));
         let topic2 = NewTopic::new(&name2, 1, TopicReplication::Fixed(1));
 
-        let res = block_on(admin_client
-            .create_topics(vec![&topic1], &opts))
+        let res = admin_client
+            .create_topics(vec![&topic1], &opts)
+            .await
             .expect("topic creation failed");
         assert_eq!(res, &[Ok(name1.clone())]);
         let _ = fetch_metadata(&name1);
 
-        let res = block_on(admin_client
-            .create_topics(vec![&topic1, &topic2], &opts))
+        let res = admin_client
+            .create_topics(vec![&topic1, &topic2], &opts)
+            .await
             .expect("topic creation failed");
         assert_eq!(
             res,
@@ -257,14 +265,16 @@ fn test_topics() {
         );
         let _ = fetch_metadata(&name2);
 
-        let res = block_on(admin_client
-            .delete_topics(&[&name1], &opts))
+        let res = admin_client
+            .delete_topics(&[&name1], &opts)
+            .await
             .expect("topic deletion failed");
         assert_eq!(res, &[Ok(name1.clone())]);
         verify_delete(&name1);
 
-        let res = block_on(admin_client
-            .delete_topics(&[&name2, &name1], &opts))
+        let res = admin_client
+            .delete_topics(&[&name2, &name1], &opts)
+            .await
             .expect("topic deletion failed");
         assert_eq!(
             res,
@@ -276,14 +286,17 @@ fn test_topics() {
     }
 }
 
-#[test]
-fn test_configs() {
+#[tokio::test]
+async fn test_configs() {
+    let _ = env_logger::try_init();
+
     let admin_client = create_admin_client();
     let opts = AdminOptions::new();
     let broker = ResourceSpecifier::Broker(0);
 
-    let res = block_on(admin_client
-        .describe_configs(&[broker], &opts))
+    let res = admin_client
+        .describe_configs(&[broker], &opts)
+        .await
         .expect("describe configs failed");
     let config = &res[0].as_ref().expect("describe configs failed");
     let orig_val = config
@@ -294,16 +307,18 @@ fn test_configs() {
         .expect("original value missing");
 
     let config = AlterConfig::new(broker).set("log.flush.interval.messages", "1234");
-    let res = block_on(admin_client
-        .alter_configs(&[config], &opts))
+    let res = admin_client
+        .alter_configs(&[config], &opts)
+        .await
         .expect("alter configs failed");
     assert_eq!(res, &[Ok(OwnedResourceSpecifier::Broker(0))]);
 
     let mut backoff = ExponentialBackoff::default();
     backoff.max_elapsed_time = Some(Duration::from_secs(5));
-    (|| {
-        let res = block_on(admin_client
-            .describe_configs(&[broker], &opts))
+    loop {
+        let res = admin_client
+            .describe_configs(&[broker], &opts)
+            .await
             .expect("describe configs failed");
         let config = &res[0].as_ref().expect("describe configs failed");
         let entry = config.get("log.flush.interval.messages");
@@ -329,16 +344,16 @@ fn test_configs() {
             }
         };
         if entry != Some(&expected_entry) {
-            Err(format!("{:?} != {:?}", entry, Some(&expected_entry)))?
+            let next_backoff = backoff.next_backoff().expect(&format!("{:?} != {:?}", entry, Some(&expected_entry)));
+            tokio::timer::delay_for(next_backoff).await;
         }
-        Ok(())
-    })
-    .retry(&mut backoff)
-    .unwrap();
+        break
+    }
 
     let config = AlterConfig::new(broker).set("log.flush.interval.ms", &orig_val);
-    let res = block_on(admin_client
-        .alter_configs(&[config], &opts))
+    let res = admin_client
+        .alter_configs(&[config], &opts)
+        .await
         .expect("alter configs failed");
     assert_eq!(res, &[Ok(OwnedResourceSpecifier::Broker(0))]);
 }
@@ -346,8 +361,10 @@ fn test_configs() {
 // Tests whether each admin operation properly reports an error if the entire
 // request fails. The original implementations failed to check this, resulting
 // in confusing situations where a failed admin request would return Ok([]).
-#[test]
-fn test_event_errors() {
+#[tokio::test]
+async fn test_event_errors() {
+    let _ = env_logger::try_init();
+
     // Configure an admin client to target a Kafka server that doesn't exist,
     // then set an impossible timeout. This will ensure that every request fails
     // with an OperationTimedOut error, assuming, of course, that the request
@@ -358,18 +375,18 @@ fn test_event_errors() {
         .expect("admin client creation failed");
     let opts = AdminOptions::new().request_timeout(Duration::from_nanos(1));
 
-    let res = block_on(admin_client.create_topics(&[], &opts));
+    let res = admin_client.create_topics(&[], &opts).await;
     assert_eq!(res, Err(KafkaError::AdminOp(RDKafkaError::OperationTimedOut)));
 
-    let res = block_on(admin_client.create_partitions(&[], &opts));
+    let res = admin_client.create_partitions(&[], &opts).await;
     assert_eq!(res, Err(KafkaError::AdminOp(RDKafkaError::OperationTimedOut)));
 
-    let res = block_on(admin_client.delete_topics(&[], &opts));
+    let res = admin_client.delete_topics(&[], &opts).await;
     assert_eq!(res, Err(KafkaError::AdminOp(RDKafkaError::OperationTimedOut)));
 
-    let res = block_on(admin_client.describe_configs(&[], &opts));
+    let res = admin_client.describe_configs(&[], &opts).await;
     assert_eq!(res.err(), Some(KafkaError::AdminOp(RDKafkaError::OperationTimedOut)));
 
-    let res = block_on(admin_client.alter_configs(&[], &opts));
+    let res = admin_client.alter_configs(&[], &opts).await;
     assert_eq!(res, Err(KafkaError::AdminOp(RDKafkaError::OperationTimedOut)));
 }

--- a/tests/test_admin.rs
+++ b/tests/test_admin.rs
@@ -1,14 +1,14 @@
 //! Test administrative commands using the admin API.
 
 use backoff::{ExponentialBackoff, Operation};
+use futures::executor::block_on;
 
-use futures::Future;
 
 use std::time::Duration;
 
 use rdkafka::admin::{
-    AdminClient, AdminOptions, AlterConfig, ConfigEntry, ConfigSource, NewPartitions, NewTopic,
-    OwnedResourceSpecifier, ResourceSpecifier, TopicReplication,
+    AdminClient, AdminOptions, AlterConfig, ConfigEntry, ConfigSource, NewPartitions, NewTopic, OwnedResourceSpecifier,
+    ResourceSpecifier, TopicReplication,
 };
 use rdkafka::client::DefaultClientContext;
 use rdkafka::consumer::{BaseConsumer, Consumer, DefaultConsumerContext};
@@ -26,14 +26,11 @@ fn create_config() -> ClientConfig {
 }
 
 fn create_admin_client() -> AdminClient<DefaultClientContext> {
-    create_config()
-        .create()
-        .expect("admin client creation failed")
+    create_config().create().expect("admin client creation failed")
 }
 
 fn fetch_metadata(topic: &str) -> Metadata {
-    let consumer: BaseConsumer<DefaultConsumerContext> =
-        create_config().create().expect("consumer creation failed");
+    let consumer: BaseConsumer<DefaultConsumerContext> = create_config().create().expect("consumer creation failed");
     let timeout = Some(Duration::from_secs(1));
 
     let mut backoff = ExponentialBackoff::default();
@@ -56,8 +53,7 @@ fn fetch_metadata(topic: &str) -> Metadata {
 }
 
 fn verify_delete(topic: &str) {
-    let consumer: BaseConsumer<DefaultConsumerContext> =
-        create_config().create().expect("consumer creation failed");
+    let consumer: BaseConsumer<DefaultConsumerContext> = create_config().create().expect("consumer creation failed");
     let timeout = Some(Duration::from_secs(1));
 
     let mut backoff = ExponentialBackoff::default();
@@ -66,9 +62,7 @@ fn verify_delete(topic: &str) {
         // Asking about the topic specifically will recreate it (under the
         // default Kafka configuration, at least) so we have to ask for the list
         // of all topics and search through it.
-        let metadata = consumer
-            .fetch_metadata(None, timeout)
-            .map_err(|e| e.to_string())?;
+        let metadata = consumer.fetch_metadata(None, timeout).map_err(|e| e.to_string())?;
         if let Some(_) = metadata.topics().iter().find(|t| t.name() == topic) {
             Err(format!("topic {} still exists", topic))?
         }
@@ -90,8 +84,8 @@ fn test_topics() {
         let name2 = rand_test_topic();
 
         // Test both the builder API and the literal construction.
-        let topic1 =
-            NewTopic::new(&name1, 1, TopicReplication::Fixed(1)).set("max.message.bytes", "1234");
+        let topic1 = NewTopic::new(&name1, 1, TopicReplication::Fixed(1))
+            .set("max.message.bytes", "1234");
         let topic2 = NewTopic {
             name: &name2,
             num_partitions: 3,
@@ -99,9 +93,8 @@ fn test_topics() {
             config: Vec::new(),
         };
 
-        let res = admin_client
-            .create_topics(&[topic1, topic2], &opts)
-            .wait()
+        let res = block_on(admin_client
+            .create_topics(&[topic1, topic2], &opts))
             .expect("topic creation failed");
         assert_eq!(res, &[Ok(name1.clone()), Ok(name2.clone())]);
 
@@ -116,15 +109,11 @@ fn test_topics() {
         assert_eq!(1, metadata_topic1.partitions().len());
         assert_eq!(3, metadata_topic2.partitions().len());
 
-        let res = admin_client
+        let res = block_on(admin_client
             .describe_configs(
-                &[
-                    ResourceSpecifier::Topic(&name1),
-                    ResourceSpecifier::Topic(&name2),
-                ],
+                &[ResourceSpecifier::Topic(&name1), ResourceSpecifier::Topic(&name2)],
                 &opts,
-            )
-            .wait()
+            ))
             .expect("describe configs failed");
         let config1 = &res[0].as_ref().expect("describe configs failed on topic 1");
         let config2 = &res[1].as_ref().expect("describe configs failed on topic 2");
@@ -153,19 +142,12 @@ fn test_topics() {
         let config_entries2 = config2.entry_map();
         assert_eq!(config1.entries.len(), config_entries1.len());
         assert_eq!(config2.entries.len(), config_entries2.len());
-        assert_eq!(
-            Some(&&expected_entry1),
-            config_entries1.get("max.message.bytes")
-        );
-        assert_eq!(
-            Some(&&expected_entry2),
-            config_entries2.get("max.message.bytes")
-        );
+        assert_eq!(Some(&&expected_entry1), config_entries1.get("max.message.bytes"));
+        assert_eq!(Some(&&expected_entry2), config_entries2.get("max.message.bytes"));
 
         let partitions1 = NewPartitions::new(&name1, 5);
-        let res = admin_client
-            .create_partitions(&[partitions1], &opts)
-            .wait()
+        let res = block_on(admin_client
+            .create_partitions(&[partitions1], &opts))
             .expect("partition creation failed");
         assert_eq!(res, &[Ok(name1.clone())]);
 
@@ -183,9 +165,8 @@ fn test_topics() {
         .retry(&mut backoff)
         .unwrap();
 
-        let res = admin_client
-            .delete_topics(&[&name1, &name2], &opts)
-            .wait()
+        let res = block_on(admin_client
+            .delete_topics(&[&name1, &name2], &opts))
             .expect("topic deletion failed");
         assert_eq!(res, &[Ok(name1.clone()), Ok(name2.clone())]);
         verify_delete(&name1);
@@ -196,7 +177,7 @@ fn test_topics() {
     // creating topics.
     {
         let topic = NewTopic::new("ignored", 1, TopicReplication::Variable(&[&[0], &[0]]));
-        let res = admin_client.create_topics(&[topic], &opts).wait();
+        let res = block_on(admin_client.create_topics(&[topic], &opts));
         assert_eq!(
             Err(KafkaError::AdminOpCreation(
                 "replication configuration for topic 'ignored' assigns 2 partition(s), \
@@ -213,9 +194,8 @@ fn test_topics() {
         let name = rand_test_topic();
         let topic = NewTopic::new(&name, 1, TopicReplication::Fixed(1));
 
-        let res = admin_client
-            .create_topics(vec![&topic], &opts)
-            .wait()
+        let res = block_on(admin_client
+            .create_topics(vec![&topic], &opts))
             .expect("topic creation failed");
         assert_eq!(res, &[Ok(name.clone())]);
         let _ = fetch_metadata(&name);
@@ -223,7 +203,7 @@ fn test_topics() {
         // This partition specification is obviously garbage, and so trips
         // a client-side error.
         let partitions = NewPartitions::new(&name, 2).assign(&[&[0], &[0], &[0]]);
-        let res = admin_client.create_partitions(&[partitions], &opts).wait();
+        let res = block_on(admin_client.create_partitions(&[partitions], &opts));
         assert_eq!(
             res,
             Err(KafkaError::AdminOpCreation(format!(
@@ -235,9 +215,8 @@ fn test_topics() {
 
         // Only the server knows that this partition specification is garbage.
         let partitions = NewPartitions::new(&name, 2).assign(&[&[0], &[0]]);
-        let res = admin_client
-            .create_partitions(&[partitions], &opts)
-            .wait()
+        let res = block_on(admin_client
+            .create_partitions(&[partitions], &opts))
             .expect("partition creation failed");
         assert_eq!(res, &[Err((name, RDKafkaError::InvalidReplicaAssignment))],);
     }
@@ -245,9 +224,8 @@ fn test_topics() {
     // Verify that deleting a non-existent topic fails.
     {
         let name = rand_test_topic();
-        let res = admin_client
-            .delete_topics(&[&name], &opts)
-            .wait()
+        let res = block_on(admin_client
+            .delete_topics(&[&name], &opts))
             .expect("delete topics failed");
         assert_eq!(res, &[Err((name, RDKafkaError::UnknownTopicOrPartition))]);
     }
@@ -261,16 +239,14 @@ fn test_topics() {
         let topic1 = NewTopic::new(&name1, 1, TopicReplication::Fixed(1));
         let topic2 = NewTopic::new(&name2, 1, TopicReplication::Fixed(1));
 
-        let res = admin_client
-            .create_topics(vec![&topic1], &opts)
-            .wait()
+        let res = block_on(admin_client
+            .create_topics(vec![&topic1], &opts))
             .expect("topic creation failed");
         assert_eq!(res, &[Ok(name1.clone())]);
         let _ = fetch_metadata(&name1);
 
-        let res = admin_client
-            .create_topics(vec![&topic1, &topic2], &opts)
-            .wait()
+        let res = block_on(admin_client
+            .create_topics(vec![&topic1, &topic2], &opts))
             .expect("topic creation failed");
         assert_eq!(
             res,
@@ -281,16 +257,14 @@ fn test_topics() {
         );
         let _ = fetch_metadata(&name2);
 
-        let res = admin_client
-            .delete_topics(&[&name1], &opts)
-            .wait()
+        let res = block_on(admin_client
+            .delete_topics(&[&name1], &opts))
             .expect("topic deletion failed");
         assert_eq!(res, &[Ok(name1.clone())]);
         verify_delete(&name1);
 
-        let res = admin_client
-            .delete_topics(&[&name2, &name1], &opts)
-            .wait()
+        let res = block_on(admin_client
+            .delete_topics(&[&name2, &name1], &opts))
             .expect("topic deletion failed");
         assert_eq!(
             res,
@@ -308,9 +282,8 @@ fn test_configs() {
     let opts = AdminOptions::new();
     let broker = ResourceSpecifier::Broker(0);
 
-    let res = admin_client
-        .describe_configs(&[broker], &opts)
-        .wait()
+    let res = block_on(admin_client
+        .describe_configs(&[broker], &opts))
         .expect("describe configs failed");
     let config = &res[0].as_ref().expect("describe configs failed");
     let orig_val = config
@@ -321,18 +294,16 @@ fn test_configs() {
         .expect("original value missing");
 
     let config = AlterConfig::new(broker).set("log.flush.interval.messages", "1234");
-    let res = admin_client
-        .alter_configs(&[config], &opts)
-        .wait()
+    let res = block_on(admin_client
+        .alter_configs(&[config], &opts))
         .expect("alter configs failed");
     assert_eq!(res, &[Ok(OwnedResourceSpecifier::Broker(0))]);
 
     let mut backoff = ExponentialBackoff::default();
     backoff.max_elapsed_time = Some(Duration::from_secs(5));
     (|| {
-        let res = admin_client
-            .describe_configs(&[broker], &opts)
-            .wait()
+        let res = block_on(admin_client
+            .describe_configs(&[broker], &opts))
             .expect("describe configs failed");
         let config = &res[0].as_ref().expect("describe configs failed");
         let entry = config.get("log.flush.interval.messages");
@@ -366,9 +337,8 @@ fn test_configs() {
     .unwrap();
 
     let config = AlterConfig::new(broker).set("log.flush.interval.ms", &orig_val);
-    let res = admin_client
-        .alter_configs(&[config], &opts)
-        .wait()
+    let res = block_on(admin_client
+        .alter_configs(&[config], &opts))
         .expect("alter configs failed");
     assert_eq!(res, &[Ok(OwnedResourceSpecifier::Broker(0))]);
 }
@@ -388,33 +358,18 @@ fn test_event_errors() {
         .expect("admin client creation failed");
     let opts = AdminOptions::new().request_timeout(Duration::from_nanos(1));
 
-    let res = admin_client.create_topics(&[], &opts).wait();
-    assert_eq!(
-        res,
-        Err(KafkaError::AdminOp(RDKafkaError::OperationTimedOut))
-    );
+    let res = block_on(admin_client.create_topics(&[], &opts));
+    assert_eq!(res, Err(KafkaError::AdminOp(RDKafkaError::OperationTimedOut)));
 
-    let res = admin_client.create_partitions(&[], &opts).wait();
-    assert_eq!(
-        res,
-        Err(KafkaError::AdminOp(RDKafkaError::OperationTimedOut))
-    );
+    let res = block_on(admin_client.create_partitions(&[], &opts));
+    assert_eq!(res, Err(KafkaError::AdminOp(RDKafkaError::OperationTimedOut)));
 
-    let res = admin_client.delete_topics(&[], &opts).wait();
-    assert_eq!(
-        res,
-        Err(KafkaError::AdminOp(RDKafkaError::OperationTimedOut))
-    );
+    let res = block_on(admin_client.delete_topics(&[], &opts));
+    assert_eq!(res, Err(KafkaError::AdminOp(RDKafkaError::OperationTimedOut)));
 
-    let res = admin_client.describe_configs(&[], &opts).wait();
-    assert_eq!(
-        res.err(),
-        Some(KafkaError::AdminOp(RDKafkaError::OperationTimedOut))
-    );
+    let res = block_on(admin_client.describe_configs(&[], &opts));
+    assert_eq!(res.err(), Some(KafkaError::AdminOp(RDKafkaError::OperationTimedOut)));
 
-    let res = admin_client.alter_configs(&[], &opts).wait();
-    assert_eq!(
-        res,
-        Err(KafkaError::AdminOp(RDKafkaError::OperationTimedOut))
-    );
+    let res = block_on(admin_client.alter_configs(&[], &opts));
+    assert_eq!(res, Err(KafkaError::AdminOp(RDKafkaError::OperationTimedOut)));
 }

--- a/tests/test_high_producers.rs
+++ b/tests/test_high_producers.rs
@@ -1,10 +1,4 @@
 //! Test data production using high level producers.
-extern crate futures;
-extern crate rand;
-extern crate rdkafka;
-
-use futures::executor::block_on;
-
 use rdkafka::config::ClientConfig;
 use rdkafka::message::{Headers, Message, OwnedHeaders};
 use rdkafka::producer::future_producer::FutureRecord;
@@ -12,8 +6,10 @@ use rdkafka::producer::FutureProducer;
 
 use std::error::Error;
 
-#[test]
-fn test_future_producer_send_fail() {
+#[tokio::test]
+async fn test_future_producer_send_fail() {
+    let _ = env_logger::try_init();
+
     let producer = ClientConfig::new()
         .set("bootstrap.servers", "localhost")
         .set("produce.offset.report", "true")
@@ -35,7 +31,7 @@ fn test_future_producer_send_fail() {
         10000,
     );
 
-    match block_on(future) {
+    match future.await {
         Ok(Err((kafka_error, owned_message))) => {
             assert_eq!(kafka_error.description(), "Message production error");
             assert_eq!(owned_message.topic(), "topic");

--- a/tests/test_high_producers.rs
+++ b/tests/test_high_producers.rs
@@ -3,7 +3,7 @@ extern crate futures;
 extern crate rand;
 extern crate rdkafka;
 
-use futures::Future;
+use futures::executor::block_on;
 
 use rdkafka::config::ClientConfig;
 use rdkafka::message::{Headers, Message, OwnedHeaders};
@@ -35,7 +35,7 @@ fn test_future_producer_send_fail() {
         10000,
     );
 
-    match future.wait() {
+    match block_on(future) {
         Ok(Err((kafka_error, owned_message))) => {
             assert_eq!(kafka_error.description(), "Message production error");
             assert_eq!(owned_message.topic(), "topic");

--- a/tests/test_low_producers.rs
+++ b/tests/test_low_producers.rs
@@ -1,8 +1,4 @@
 //! Test data production using low level producers.
-extern crate futures;
-extern crate rand;
-extern crate rdkafka;
-
 use rdkafka::config::ClientConfig;
 use rdkafka::error::{KafkaError, RDKafkaError};
 use rdkafka::message::{Headers, Message, OwnedMessage};
@@ -14,7 +10,7 @@ use rdkafka::{ClientContext, Statistics};
 
 #[macro_use]
 mod utils;
-use crate::utils::*;
+use utils::*;
 
 use rdkafka::message::OwnedHeaders;
 use std::collections::{HashMap, HashSet};
@@ -125,6 +121,8 @@ fn threaded_producer_with_context<C: ProducerContext>(
 
 #[test]
 fn test_base_producer_queue_full() {
+    let _ = env_logger::try_init();
+
     let producer = base_producer(map!("queue.buffering.max.messages" => "10"));
     let topic_name = rand_test_topic();
 
@@ -162,6 +160,8 @@ fn test_base_producer_queue_full() {
 
 #[test]
 fn test_base_producer_timeout() {
+    let _ = env_logger::try_init();
+
     let context = CollectingContext::new();
     let producer = base_producer_with_context(
         context.clone(),
@@ -225,6 +225,8 @@ impl ProducerContext for HeaderCheckContext {
 
 #[test]
 fn test_base_producer_headers() {
+    let _ = env_logger::try_init();
+
     let ids_set = Arc::new(Mutex::new(HashSet::new()));
     let context = HeaderCheckContext {
         ids: ids_set.clone(),
@@ -256,6 +258,8 @@ fn test_base_producer_headers() {
 
 #[test]
 fn test_threaded_producer_send() {
+    let _ = env_logger::try_init();
+
     let context = CollectingContext::new();
     let producer = threaded_producer_with_context(context.clone(), HashMap::new());
     let topic_name = rand_test_topic();

--- a/tests/test_metadata.rs
+++ b/tests/test_metadata.rs
@@ -4,16 +4,18 @@ extern crate futures;
 extern crate rand;
 extern crate rdkafka;
 
-use futures::*;
+use futures::StreamExt;
+use futures::executor::{block_on, block_on_stream};
 
-use rdkafka::config::ClientConfig;
 use rdkafka::consumer::{Consumer, StreamConsumer};
 use rdkafka::topic_partition_list::TopicPartitionList;
+use rdkafka::config::ClientConfig;
 
 use std::time::Duration;
 
 mod utils;
 use crate::utils::*;
+
 
 fn create_consumer(group_id: &str) -> StreamConsumer {
     ClientConfig::new()
@@ -30,25 +32,20 @@ fn create_consumer(group_id: &str) -> StreamConsumer {
 
 #[test]
 fn test_metadata() {
-    let _r = env_logger::try_init();
+    let _r = env_logger::init();
 
     let topic_name = rand_test_topic();
-    populate_topic(&topic_name, 1, &value_fn, &key_fn, Some(0), None);
-    populate_topic(&topic_name, 1, &value_fn, &key_fn, Some(1), None);
-    populate_topic(&topic_name, 1, &value_fn, &key_fn, Some(2), None);
+    block_on(populate_topic(&topic_name, 1, &value_fn, &key_fn, Some(0), None));
+    block_on(populate_topic(&topic_name, 1, &value_fn, &key_fn, Some(1), None));
+    block_on(populate_topic(&topic_name, 1, &value_fn, &key_fn, Some(2), None));
     let consumer = create_consumer(&rand_test_group());
 
-    let metadata = consumer
-        .fetch_metadata(None, Duration::from_secs(5))
-        .unwrap();
+    let metadata = consumer.fetch_metadata(None, Duration::from_secs(5)).unwrap();
     let orig_broker_id = metadata.orig_broker_id();
     // The orig_broker_id may be -1 if librdkafka's bootstrap "broker" handles
     // the request.
     if orig_broker_id != -1 && orig_broker_id != 0 {
-        panic!(
-            "metadata.orig_broker_id = {}, not 0 or 1 as expected",
-            orig_broker_id
-        )
+        panic!("metadata.orig_broker_id = {}, not 0 or 1 as expected", orig_broker_id)
     }
     assert!(!metadata.orig_broker_name().is_empty());
 
@@ -58,15 +55,10 @@ fn test_metadata() {
     assert!(!broker_metadata[0].host().is_empty());
     assert_eq!(broker_metadata[0].port(), 9092);
 
-    let topic_metadata = metadata
-        .topics()
-        .iter()
-        .find(|m| m.name() == topic_name)
-        .unwrap();
+    let topic_metadata = metadata.topics().iter()
+        .find(|m| m.name() == topic_name).unwrap();
 
-    let mut ids = topic_metadata
-        .partitions()
-        .iter()
+    let mut ids = topic_metadata.partitions().iter()
         .map(|p| {
             assert_eq!(p.error(), None);
             p.id()
@@ -83,22 +75,21 @@ fn test_metadata() {
     assert_eq!(topic_metadata.partitions()[0].replicas(), &[0]);
     assert_eq!(topic_metadata.partitions()[0].isr(), &[0]);
 
-    let metadata_one_topic = consumer
-        .fetch_metadata(Some(&topic_name), Duration::from_secs(5))
+    let metadata_one_topic = consumer.fetch_metadata(Some(&topic_name), Duration::from_secs(5))
         .unwrap();
     assert_eq!(metadata_one_topic.topics().len(), 1);
 }
 
 #[test]
 fn test_subscription() {
-    let _r = env_logger::try_init();
+    let _r = env_logger::init();
 
     let topic_name = rand_test_topic();
-    populate_topic(&topic_name, 10, &value_fn, &key_fn, None, None);
+    block_on(populate_topic(&topic_name, 10, &value_fn, &key_fn, None, None));
     let consumer = create_consumer(&rand_test_group());
     consumer.subscribe(&[topic_name.as_str()]).unwrap();
 
-    let _consumer_future = consumer.start().take(10).wait();
+    let _consumer_future = block_on_stream(consumer.start()).take(10);
 
     let mut tpl = TopicPartitionList::new();
     tpl.add_topic_unassigned(&topic_name);
@@ -107,57 +98,36 @@ fn test_subscription() {
 
 #[test]
 fn test_group_membership() {
-    let _r = env_logger::try_init();
+    let _r = env_logger::init();
 
     let topic_name = rand_test_topic();
     let group_name = rand_test_group();
-    populate_topic(&topic_name, 1, &value_fn, &key_fn, Some(0), None);
-    populate_topic(&topic_name, 1, &value_fn, &key_fn, Some(1), None);
-    populate_topic(&topic_name, 1, &value_fn, &key_fn, Some(2), None);
+    block_on(populate_topic(&topic_name, 1, &value_fn, &key_fn, Some(0), None));
+    block_on(populate_topic(&topic_name, 1, &value_fn, &key_fn, Some(1), None));
+    block_on(populate_topic(&topic_name, 1, &value_fn, &key_fn, Some(2), None));
     let consumer = create_consumer(&group_name);
     consumer.subscribe(&[topic_name.as_str()]).unwrap();
 
     // Make sure the consumer joins the group
-    let _consumer_future = consumer.start().take(1).for_each(|_| Ok(())).wait();
+    let _ = block_on_stream(consumer.start().take(1)).collect::<Vec<_>>();
 
-    let group_list = consumer
-        .fetch_group_list(None, Duration::from_secs(5))
-        .unwrap();
+    let group_list = consumer.fetch_group_list(None, Duration::from_secs(5)).unwrap();
 
     // Print all the data, valgrind will check memory access
     for group in group_list.groups().iter() {
-        println!(
-            "{} {} {} {}",
-            group.name(),
-            group.state(),
-            group.protocol(),
-            group.protocol_type()
-        );
+        println!("{} {} {} {}", group.name(), group.state(), group.protocol(), group.protocol_type());
         for member in group.members() {
-            println!(
-                "  {} {} {}",
-                member.id(),
-                member.client_id(),
-                member.client_host()
-            );
+            println!("  {} {} {}", member.id(), member.client_id(), member.client_host());
         }
     }
 
-    let group_list2 = consumer
-        .fetch_group_list(Some(&group_name), Duration::from_secs(5))
+    let group_list2 = consumer.fetch_group_list(Some(&group_name), Duration::from_secs(5))
         .unwrap();
     assert_eq!(group_list2.groups().len(), 1);
 
-    let consumer_group = group_list2
-        .groups()
-        .iter()
-        .find(|&g| g.name() == group_name)
-        .unwrap();
+    let consumer_group = group_list2.groups().iter().find(|&g| g.name() == group_name).unwrap();
     assert_eq!(consumer_group.members().len(), 1);
 
     let consumer_member = &consumer_group.members()[0];
-    assert_eq!(
-        consumer_member.client_id(),
-        "rdkafka_integration_test_client"
-    );
+    assert_eq!(consumer_member.client_id(), "rdkafka_integration_test_client");
 }

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -4,7 +4,6 @@ extern crate rand;
 extern crate rdkafka;
 extern crate regex;
 
-use futures::*;
 use rand::Rng;
 use regex::Regex;
 
@@ -90,7 +89,7 @@ impl ClientContext for TestContext {
 /// Produce the specified count of messages to the topic and partition specified. A map
 /// of (partition, offset) -> message id will be returned. It panics if any error is encountered
 /// while populating the topic.
-pub fn populate_topic<P, K, J, Q>(
+pub async fn populate_topic<P, K, J, Q>(
     topic_name: &str,
     count: i32,
     value_fn: &P,
@@ -136,7 +135,7 @@ where
 
     let mut message_map = HashMap::new();
     for (id, future) in futures {
-        match future.wait() {
+        match future.await {
             Ok(Ok((partition, offset))) => message_map.insert((partition, offset), id),
             Ok(Err((kafka_error, _message))) => panic!("Delivery failed: {}", kafka_error),
             Err(e) => panic!("Waiting for future failed: {}", e),
@@ -156,12 +155,13 @@ pub fn key_fn(id: i32) -> String {
 
 #[cfg(test)]
 mod tests {
+    use futures::executor::block_on;
     use super::*;
 
     #[test]
     fn test_populate_topic() {
         let topic_name = rand_test_topic();
-        let message_map = populate_topic(&topic_name, 100, &value_fn, &key_fn, Some(0), None);
+        let message_map = block_on(populate_topic(&topic_name, 100, &value_fn, &key_fn, Some(0), None));
 
         let total_messages = message_map
             .iter()


### PR DESCRIPTION
This builds on the work of #143 

Futures executor is meant mainly for testing and not production usage. This PR makes things more async friendly, getting rid of additional spawns and blocking. When necessary tokio is used for execution and blocking.