### PR TITLE
Add `ssl_vendored` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ default = []
 # Enable ssl and sasl support
 ssl = ["rdkafka-sys/ssl"]
 sasl = ["rdkafka-sys/sasl", "ssl"]
+ssl_vendored = ["ssl", "rdkafka-sys/ssl_vendored"]
 
 # Use dynamic linking instead of static. Will fail if librdkafka is not installed.
 dynamic_linking = ["rdkafka-sys/dynamic_linking"]

--- a/rdkafka-sys/Cargo.toml
+++ b/rdkafka-sys/Cargo.toml
@@ -32,6 +32,7 @@ default = []
 # Enable ssl and sasl support
 ssl = ["openssl-sys"]
 sasl = ["ssl"]
+ssl_vendored = ["ssl", "openssl-sys/vendored"]
 
 # Use dynamic linking instead of static. Will fail if librdkafka is not installed.
 dynamic_linking = []

--- a/rdkafka-sys/build.rs
+++ b/rdkafka-sys/build.rs
@@ -45,6 +45,12 @@ fn main() {
         .next()
         .expect("Crate version is not valid");
 
+    if env::var("DEP_OPENSSL_VENDORED").is_ok() {
+        let openssl_root = env::var("DEP_OPENSSL_ROOT").expect("DEP_OPENSSL_ROOT is not set");
+        env::set_var("CFLAGS", format!("-I{}/include", openssl_root));
+        env::set_var("LDFLAGS", format!("-L{}/lib", openssl_root));
+    }
+
     if env::var("CARGO_FEATURE_DYNAMIC_LINKING").is_ok() {
         eprintln!("librdkafka will be linked dynamically");
         let pkg_probe = pkg_config::Config::new()

--- a/rdkafka-sys/build.rs
+++ b/rdkafka-sys/build.rs
@@ -47,6 +47,7 @@ fn main() {
 
     if env::var("DEP_OPENSSL_VENDORED").is_ok() {
         let openssl_root = env::var("DEP_OPENSSL_ROOT").expect("DEP_OPENSSL_ROOT is not set");
+        env::set_var("OPENSSL_ROOT_DIR", &openssl_root);
         env::set_var("CFLAGS", format!("-I{}/include", openssl_root));
         env::set_var("LDFLAGS", format!("-L{}/lib", openssl_root));
     }


### PR DESCRIPTION
This PR adds new feature `ssl_vendored`. It allows to use `vendored` feature from `openssl-sys` crate in order to not depend on system-wide SSL installation.

Some context about environment variables exported by build scripts of dependencies can be found [here](https://kornel.ski/rust-sys-crate#headers).