### PR TITLE
rdkafka-sys: bump zstd-sys for build fix

### DIFF
--- a/rdkafka-sys/Cargo.toml
+++ b/rdkafka-sys/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["external-ffi-bindings"]
 [dependencies]
 libc = "0.2.65"
 libz-sys = "1.0"
-zstd-sys = { version = "1.3", features = [], optional = true }
+zstd-sys = { version = "1.4.15", features = [], optional = true }
 openssl-sys = { version = "~ 0.9.0", optional = true }
 lz4-sys = { version = "1.8.3", optional = true }
 


### PR DESCRIPTION
Bump to a version of zstd-sys that properly copies all public header
files into DEP_ZSTD_ROOT. The old version of zstd-sys was not exposing
the zstd_errors.h header file.

Details: https://github.com/gyscos/zstd-rs/pull/68