### PR TITLE
Support CMake build on MSVC

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,13 @@ jobs:
     rust: stable
   - os: osx
     rust: stable
+  - os: windows
+    arch: amd64
+    rust: stable
+    env: FEATURES=cmake_build
 
 script:
-  - if [[ "$RDKAFKA_RUN_TESTS" ]]; then ./test_suite.sh; else cargo build --verbose; fi
+  - if [[ "$RDKAFKA_RUN_TESTS" ]]; then ./test_suite.sh; else cargo build --verbose --features "$FEATURES"; fi
 
 notifications:
   webhooks:

--- a/rdkafka-sys/build.rs
+++ b/rdkafka-sys/build.rs
@@ -167,6 +167,15 @@ fn build_librdkafka() {
         config.define("CMAKE_SYSTEM_NAME", system_name);
     }
     let dst = config.build();
+    #[cfg(target_env = "msvc")]
+    {
+        let profile = match &env::var("PROFILE").expect("Cannot determine build profile")[..] {
+            "release" | "bench" => "Release",
+            _ => "Debug"
+        };
+        println!("cargo:rustc-link-search=native={}/build/src/{}", dst.display(), profile);
+    }
+    #[cfg(not(target_env = "msvc"))]
     println!("cargo:rustc-link-search=native={}/build/src", dst.display());
     println!("cargo:rustc-link-lib=static=rdkafka");
 }


### PR DESCRIPTION
Builds on Windows with MSVC environment produce the library located at `build/src/Release` or `build/src/Debug`, instead of just `build/src` for other environments.

This PR explicitly handles this case. The choice between `Release` and `Debug` happens using the same logic as in `cmake` crate, see [these lines](https://docs.rs/cmake/0.1.26/src/cmake/lib.rs.html#329-333).