### PR TITLE
Upgrade to async/await ecosystem

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 
 [dependencies]
 rdkafka-sys = { path = "rdkafka-sys", version = "1.2.1", default-features = false }
-futures = "0.1.21"
+futures = "0.3.0"
 libc = "0.2.0"
 log = "0.4.8"
 serde = "1.0.0"
@@ -26,7 +26,7 @@ clap = "2.18.0"
 env_logger = "0.7.1"
 rand = "0.3.15"
 regex = "1.1.6"
-tokio = "0.1.7"
+tokio = { version = "0.2", features = ["blocking", "macros", "rt-core", "time"] }
 
 # These features are re-exports of the features that the rdkafka-sys crate
 # provides. See the rdkafka-sys documentation for details.

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,33 @@
 # Changelog
 
-<a name="0.2120"></a>
+## Unreleased
+
+* Upgrade to the async/await ecosystem, including `std::future::Future`, v0.3
+  of the futures crate, and v0.2 of Tokio. The minimum supported Rust version
+  is now Rust 1.39. Special thanks to [@sd2k] and [@dbcfd]. ([#186])
+
+  The main difference is that functions that previously returned
+  ```rust
+  futures01::Future<Item = T, Error = E>
+  ```
+  now return:
+  ```rust
+  std::future::Future<Output = Result<T, E>>
+  ```
+  In the special case when the error was `()`, the new signature is further
+  simplified to:
+  ```rust
+  std::future::Future<Output = T>
+  ```
+  Functions that return `future::Stream`s have had the analogous transformation
+  applied.
+
+[#186]: https://github.com/fede1024/rust-rdkafka/pull/183
+
+[@sd2k]: https://github.com/sd2k
+[@dbcfd]: https://github.com/dbcfd
+
+<a name="0.22.0"></a>
 ## 0.22.0 (2019-12-01)
 
 * Add a client for Kafka's Admin API, which allows actions like creating and

--- a/examples/asynchronous_processing.rs
+++ b/examples/asynchronous_processing.rs
@@ -7,8 +7,7 @@ extern crate rdkafka;
 extern crate tokio;
 
 use clap::{App, Arg};
-use futures::{lazy, Future, Stream};
-use tokio::runtime::current_thread;
+use futures::{future, TryStreamExt};
 
 use rdkafka::config::ClientConfig;
 use rdkafka::consumer::stream_consumer::StreamConsumer;
@@ -43,10 +42,10 @@ fn expensive_computation<'a>(msg: OwnedMessage) -> String {
 //   2) filter out eventual Kafka errors.
 //   3) send the message to a thread pool for processing.
 //   4) produce the result to the output topic.
-// Moving each message from one stage of the pipeline to next one is handled by the event loop,
-// that runs on a single thread. The expensive CPU-bound computation is handled by the `ThreadPool`,
-// without blocking the event loop.
-fn run_async_processor(brokers: &str, group_id: &str, input_topic: &str, output_topic: &str) {
+// `tokio::spawn` is used to handle IO-bound tasks in parallel (e.g., producing
+// the messages), while `tokio::task::spawn_blocking` is used to handle the
+// simulated CPU-bound task.
+async fn run_async_processor(brokers: &str, group_id: &str, input_topic: &str, output_topic: &str) {
     // Create the `StreamConsumer`, to receive the messages from the topic in form of a `Stream`.
     let consumer: StreamConsumer = ClientConfig::new()
         .set("group.id", group_id)
@@ -68,70 +67,45 @@ fn run_async_processor(brokers: &str, group_id: &str, input_topic: &str, output_
         .create()
         .expect("Producer creation error");
 
-    // Create the runtime where the expensive computation will be performed.
-    let mut thread_pool = tokio::runtime::Builder::new()
-        .name_prefix("pool-")
-        .core_threads(4)
-        .build()
-        .unwrap();
-
-    // Use the current thread as IO thread to drive consumer and producer.
-    let mut io_thread = current_thread::Runtime::new().unwrap();
-    let io_thread_handle = io_thread.handle();
-
     // Create the outer pipeline on the message stream.
-    let stream_processor = consumer
-        .start()
-        .filter_map(|result| {
-            // Filter out errors
-            match result {
-                Ok(msg) => Some(msg),
-                Err(kafka_error) => {
-                    warn!("Error while receiving from Kafka: {:?}", kafka_error);
-                    None
-                }
+    let stream_processor = consumer.start().try_for_each(|borrowed_message| {
+        // Process each message
+        info!("Message received: {}", borrowed_message.offset());
+        // Borrowed messages can't outlive the consumer they are received from, so they need to
+        // be owned in order to be sent to a separate thread.
+        let owned_message = borrowed_message.detach();
+        let output_topic = output_topic.to_string();
+        let producer = producer.clone();
+        tokio::spawn(async move {
+            // The body of this block will be executed on the main thread pool,
+            // but we perform `expensive_computation` on a separate thread pool
+            // for CPU-intensive tasks via `tokio::task::spawn_blocking`.
+            let computation_result =
+                tokio::task::spawn_blocking(|| expensive_computation(owned_message))
+                    .await
+                    .expect("failed to wait for expensive computation");
+            let produce_future = producer.send(
+                FutureRecord::to(&output_topic)
+                    .key("some key")
+                    .payload(&computation_result),
+                0,
+            );
+            match produce_future.await {
+                Ok(Ok(delivery)) => println!("Sent: {:?}", delivery),
+                Ok(Err((e, _))) => println!("Error: {:?}", e),
+                Err(_) => println!("Future cancelled"),
             }
-        })
-        .for_each(move |borrowed_message| {
-            // Process each message
-            info!("Message received: {}", borrowed_message.offset());
-            // Borrowed messages can't outlive the consumer they are received from, so they need to
-            // be owned in order to be sent to a separate thread.
-            let owned_message = borrowed_message.detach();
-            let output_topic = output_topic.to_string();
-            let producer = producer.clone();
-            let io_thread_handle = io_thread_handle.clone();
-            let message_future = lazy(move || {
-                // The body of this closure will be executed in the thread pool.
-                let computation_result = expensive_computation(owned_message);
-                let producer_future = producer
-                    .send(
-                        FutureRecord::to(&output_topic)
-                            .key("some key")
-                            .payload(&computation_result),
-                        0,
-                    )
-                    .then(|result| {
-                        match result {
-                            Ok(Ok(delivery)) => println!("Sent: {:?}", delivery),
-                            Ok(Err((e, _))) => println!("Error: {:?}", e),
-                            Err(_) => println!("Future cancelled"),
-                        }
-                        Ok(())
-                    });
-                let _ = io_thread_handle.spawn(producer_future);
-                Ok(())
-            });
-            thread_pool.spawn(message_future);
-            Ok(())
         });
+        future::ready(Ok(()))
+    });
 
     info!("Starting event loop");
-    let _ = io_thread.block_on(stream_processor);
+    stream_processor.await.expect("stream processing failed");
     info!("Stream processing terminated");
 }
 
-fn main() {
+#[tokio::main]
+async fn main() {
     let matches = App::new("Async example")
         .version(option_env!("CARGO_PKG_VERSION").unwrap_or(""))
         .about("Asynchronous computation example")
@@ -180,5 +154,5 @@ fn main() {
     let input_topic = matches.value_of("input-topic").unwrap();
     let output_topic = matches.value_of("output-topic").unwrap();
 
-    run_async_processor(brokers, group_id, input_topic, output_topic);
+    run_async_processor(brokers, group_id, input_topic, output_topic).await
 }

--- a/examples/simple_producer.rs
+++ b/examples/simple_producer.rs
@@ -15,7 +15,7 @@ mod example_utils;
 use crate::example_utils::setup_logger;
 use rdkafka::message::OwnedHeaders;
 
-fn produce(brokers: &str, topic_name: &str) {
+async fn produce(brokers: &str, topic_name: &str) {
     let producer: FutureProducer = ClientConfig::new()
         .set("bootstrap.servers", brokers)
         .set("message.timeout.ms", "5000")
@@ -46,11 +46,12 @@ fn produce(brokers: &str, topic_name: &str) {
 
     // This loop will wait until all delivery statuses have been received received.
     for future in futures {
-        info!("Future completed. Result: {:?}", future.wait());
+        info!("Future completed. Result: {:?}", future.await);
     }
 }
 
-fn main() {
+#[tokio::main]
+async fn main() {
     let matches = App::new("producer example")
         .version(option_env!("CARGO_PKG_VERSION").unwrap_or(""))
         .about("Simple command line producer")
@@ -86,5 +87,5 @@ fn main() {
     let topic = matches.value_of("topic").unwrap();
     let brokers = matches.value_of("brokers").unwrap();
 
-    produce(brokers, topic);
+    produce(brokers, topic).await;
 }

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -12,14 +12,18 @@ use crate::config::{ClientConfig, FromClientConfig, FromClientConfigAndContext};
 use crate::error::{IsError, KafkaError, KafkaResult};
 use crate::util::{cstr_to_owned, AsCArray, ErrBuf, IntoOpaque, Timeout, WrappedCPointer};
 
+use futures::channel::oneshot;
 use futures::future::{self, Either};
-use futures::{Async, Canceled, Complete, Future, Oneshot, Poll};
+use futures::FutureExt;
 
 use std::collections::HashMap;
 use std::ffi::{CStr, CString};
+use std::future::Future;
 use std::mem;
+use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use std::task::{Context, Poll};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
@@ -48,13 +52,13 @@ impl<C: ClientContext> AdminClient<C> {
         &self,
         topics: I,
         opts: &AdminOptions,
-    ) -> impl Future<Item = Vec<TopicResult>, Error = KafkaError>
+    ) -> impl Future<Output = KafkaResult<Vec<TopicResult>>>
     where
         I: IntoIterator<Item = &'a NewTopic<'a>>,
     {
         match self.create_topics_inner(topics, opts) {
-            Ok(rx) => Either::A(CreateTopicsFuture { rx }),
-            Err(err) => Either::B(future::err(err)),
+            Ok(rx) => Either::Left(CreateTopicsFuture { rx }),
+            Err(err) => Either::Right(future::err(err)),
         }
     }
 
@@ -62,7 +66,7 @@ impl<C: ClientContext> AdminClient<C> {
         &self,
         topics: I,
         opts: &AdminOptions,
-    ) -> KafkaResult<Oneshot<NativeEvent>>
+    ) -> KafkaResult<oneshot::Receiver<NativeEvent>>
     where
         I: IntoIterator<Item = &'a NewTopic<'a>>,
     {
@@ -93,10 +97,10 @@ impl<C: ClientContext> AdminClient<C> {
         &self,
         topic_names: &[&str],
         opts: &AdminOptions,
-    ) -> impl Future<Item = Vec<TopicResult>, Error = KafkaError> {
+    ) -> impl Future<Output = KafkaResult<Vec<TopicResult>>> {
         match self.delete_topics_inner(topic_names, opts) {
-            Ok(rx) => Either::A(DeleteTopicsFuture { rx }),
-            Err(err) => Either::B(future::err(err)),
+            Ok(rx) => Either::Left(DeleteTopicsFuture { rx }),
+            Err(err) => Either::Right(future::err(err)),
         }
     }
 
@@ -104,7 +108,7 @@ impl<C: ClientContext> AdminClient<C> {
         &self,
         topic_names: &[&str],
         opts: &AdminOptions,
-    ) -> KafkaResult<Oneshot<NativeEvent>> {
+    ) -> KafkaResult<oneshot::Receiver<NativeEvent>> {
         let mut native_topics = Vec::new();
         let mut err_buf = ErrBuf::new();
         for tn in topic_names {
@@ -138,13 +142,13 @@ impl<C: ClientContext> AdminClient<C> {
         &self,
         partitions: I,
         opts: &AdminOptions,
-    ) -> impl Future<Item = Vec<TopicResult>, Error = KafkaError>
+    ) -> impl Future<Output = KafkaResult<Vec<TopicResult>>>
     where
         I: IntoIterator<Item = &'a NewPartitions<'a>>,
     {
         match self.create_partitions_inner(partitions, opts) {
-            Ok(rx) => Either::A(CreatePartitionsFuture { rx }),
-            Err(err) => Either::B(future::err(err)),
+            Ok(rx) => Either::Left(CreatePartitionsFuture { rx }),
+            Err(err) => Either::Right(future::err(err)),
         }
     }
 
@@ -152,7 +156,7 @@ impl<C: ClientContext> AdminClient<C> {
         &self,
         partitions: I,
         opts: &AdminOptions,
-    ) -> KafkaResult<Oneshot<NativeEvent>>
+    ) -> KafkaResult<oneshot::Receiver<NativeEvent>>
     where
         I: IntoIterator<Item = &'a NewPartitions<'a>>,
     {
@@ -183,13 +187,13 @@ impl<C: ClientContext> AdminClient<C> {
         &self,
         configs: I,
         opts: &AdminOptions,
-    ) -> impl Future<Item = Vec<ConfigResourceResult>, Error = KafkaError>
+    ) -> impl Future<Output = KafkaResult<Vec<ConfigResourceResult>>>
     where
         I: IntoIterator<Item = &'a ResourceSpecifier<'a>>,
     {
         match self.describe_configs_inner(configs, opts) {
-            Ok(rx) => Either::A(DescribeConfigsFuture { rx }),
-            Err(err) => Either::B(future::err(err)),
+            Ok(rx) => Either::Left(DescribeConfigsFuture { rx }),
+            Err(err) => Either::Right(future::err(err)),
         }
     }
 
@@ -197,7 +201,7 @@ impl<C: ClientContext> AdminClient<C> {
         &self,
         configs: I,
         opts: &AdminOptions,
-    ) -> KafkaResult<Oneshot<NativeEvent>>
+    ) -> KafkaResult<oneshot::Receiver<NativeEvent>>
     where
         I: IntoIterator<Item = &'a ResourceSpecifier<'a>>,
     {
@@ -247,13 +251,13 @@ impl<C: ClientContext> AdminClient<C> {
         &self,
         configs: I,
         opts: &AdminOptions,
-    ) -> impl Future<Item = Vec<AlterConfigsResult>, Error = KafkaError>
+    ) -> impl Future<Output = KafkaResult<Vec<AlterConfigsResult>>>
     where
         I: IntoIterator<Item = &'a AlterConfig<'a>>,
     {
         match self.alter_configs_inner(configs, opts) {
-            Ok(rx) => Either::A(AlterConfigsFuture { rx }),
-            Err(err) => Either::B(future::err(err)),
+            Ok(rx) => Either::Left(AlterConfigsFuture { rx }),
+            Err(err) => Either::Right(future::err(err)),
         }
     }
 
@@ -261,7 +265,7 @@ impl<C: ClientContext> AdminClient<C> {
         &self,
         configs: I,
         opts: &AdminOptions,
-    ) -> KafkaResult<Oneshot<NativeEvent>>
+    ) -> KafkaResult<oneshot::Receiver<NativeEvent>>
     where
         I: IntoIterator<Item = &'a AlterConfig<'a>>,
     {
@@ -344,7 +348,7 @@ fn start_poll_thread(queue: Arc<NativeQueue>, should_stop: Arc<AtomicBool>) -> J
                     continue;
                 }
                 let event = unsafe { NativeEvent::from_ptr(event) };
-                let tx: Box<Complete<NativeEvent>> =
+                let tx: Box<oneshot::Sender<NativeEvent>> =
                     unsafe { IntoOpaque::from_ptr(rdsys::rd_kafka_event_opaque(event.ptr())) };
                 let _ = tx.send(event);
             }
@@ -457,7 +461,7 @@ impl AdminOptions {
         &self,
         client: *mut RDKafka,
         err_buf: &mut ErrBuf,
-    ) -> KafkaResult<(NativeAdminOptions, Oneshot<NativeEvent>)> {
+    ) -> KafkaResult<(NativeAdminOptions, oneshot::Receiver<NativeEvent>)> {
         let native_opts = unsafe {
             NativeAdminOptions::from_ptr(rdsys::rd_kafka_AdminOptions_new(
                 client,
@@ -513,7 +517,7 @@ impl AdminOptions {
             check_rdkafka_invalid_arg(res, err_buf)?;
         }
 
-        let (tx, rx) = futures::oneshot();
+        let (tx, rx) = oneshot::channel();
         let tx = Box::new(tx);
         unsafe {
             rdsys::rd_kafka_AdminOptions_set_opaque(native_opts.ptr, IntoOpaque::as_ptr(&tx))
@@ -734,31 +738,30 @@ impl Drop for NativeNewTopic {
 }
 
 struct CreateTopicsFuture {
-    rx: Oneshot<NativeEvent>,
+    rx: oneshot::Receiver<NativeEvent>,
 }
 
 impl Future for CreateTopicsFuture {
-    type Item = Vec<TopicResult>;
-    type Error = KafkaError;
+    type Output = KafkaResult<Vec<TopicResult>>;
 
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        match self.rx.poll() {
-            Ok(Async::Ready(event)) => {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+        match self.rx.poll_unpin(cx) {
+            Poll::Ready(Ok(event)) => {
                 event.check_error()?;
                 let res = unsafe { rdsys::rd_kafka_event_CreateTopics_result(event.ptr()) };
                 if res.is_null() {
                     let typ = unsafe { rdsys::rd_kafka_event_type(event.ptr()) };
-                    return Err(KafkaError::AdminOpCreation(format!(
+                    return Poll::Ready(Err(KafkaError::AdminOpCreation(format!(
                         "create topics request received response of incorrect type ({})",
                         typ
-                    )));
+                    ))));
                 }
                 let mut n = 0;
                 let topics = unsafe { rdsys::rd_kafka_CreateTopics_result_topics(res, &mut n) };
-                Ok(Async::Ready(build_topic_results(topics, n)))
+                Poll::Ready(Ok(build_topic_results(topics, n)))
             }
-            Ok(Async::NotReady) => Ok(Async::NotReady),
-            Err(Canceled) => Err(KafkaError::Canceled),
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(Err(oneshot::Canceled)) => Poll::Ready(Err(KafkaError::Canceled)),
         }
     }
 }
@@ -797,31 +800,30 @@ impl Drop for NativeDeleteTopic {
 }
 
 struct DeleteTopicsFuture {
-    rx: Oneshot<NativeEvent>,
+    rx: oneshot::Receiver<NativeEvent>,
 }
 
 impl Future for DeleteTopicsFuture {
-    type Item = Vec<TopicResult>;
-    type Error = KafkaError;
+    type Output = KafkaResult<Vec<TopicResult>>;
 
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        match self.rx.poll() {
-            Ok(Async::Ready(event)) => {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+        match self.rx.poll_unpin(cx) {
+            Poll::Ready(Ok(event)) => {
                 event.check_error()?;
                 let res = unsafe { rdsys::rd_kafka_event_DeleteTopics_result(event.ptr()) };
                 if res.is_null() {
                     let typ = unsafe { rdsys::rd_kafka_event_type(event.ptr()) };
-                    return Err(KafkaError::AdminOpCreation(format!(
+                    return Poll::Ready(Err(KafkaError::AdminOpCreation(format!(
                         "delete topics request received response of incorrect type ({})",
                         typ
-                    )));
+                    ))));
                 }
                 let mut n = 0;
                 let topics = unsafe { rdsys::rd_kafka_DeleteTopics_result_topics(res, &mut n) };
-                Ok(Async::Ready(build_topic_results(topics, n)))
+                Poll::Ready(Ok(build_topic_results(topics, n)))
             }
-            Ok(Async::NotReady) => Ok(Async::NotReady),
-            Err(Canceled) => Err(KafkaError::Canceled),
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(Err(oneshot::Canceled)) => Poll::Ready(Err(KafkaError::Canceled)),
         }
     }
 }
@@ -941,31 +943,30 @@ impl Drop for NativeNewPartitions {
 }
 
 struct CreatePartitionsFuture {
-    rx: Oneshot<NativeEvent>,
+    rx: oneshot::Receiver<NativeEvent>,
 }
 
 impl Future for CreatePartitionsFuture {
-    type Item = Vec<TopicResult>;
-    type Error = KafkaError;
+    type Output = KafkaResult<Vec<TopicResult>>;
 
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        match self.rx.poll() {
-            Ok(Async::Ready(event)) => {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+        match self.rx.poll_unpin(cx) {
+            Poll::Ready(Ok(event)) => {
                 event.check_error()?;
                 let res = unsafe { rdsys::rd_kafka_event_CreatePartitions_result(event.ptr()) };
                 if res.is_null() {
                     let typ = unsafe { rdsys::rd_kafka_event_type(event.ptr()) };
-                    return Err(KafkaError::AdminOpCreation(format!(
+                    return Poll::Ready(Err(KafkaError::AdminOpCreation(format!(
                         "create partitions request received response of incorrect type ({})",
                         typ
-                    )));
+                    ))));
                 }
                 let mut n = 0;
                 let topics = unsafe { rdsys::rd_kafka_CreatePartitions_result_topics(res, &mut n) };
-                Ok(Async::Ready(build_topic_results(topics, n)))
+                Poll::Ready(Ok(build_topic_results(topics, n)))
             }
-            Ok(Async::NotReady) => Ok(Async::NotReady),
-            Err(Canceled) => Err(KafkaError::Canceled),
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(Err(oneshot::Canceled)) => Poll::Ready(Err(KafkaError::Canceled)),
         }
     }
 }
@@ -1143,24 +1144,23 @@ fn extract_config_source(config_source: RDKafkaConfigSource) -> KafkaResult<Conf
 }
 
 struct DescribeConfigsFuture {
-    rx: Oneshot<NativeEvent>,
+    rx: oneshot::Receiver<NativeEvent>,
 }
 
 impl Future for DescribeConfigsFuture {
-    type Item = Vec<ConfigResourceResult>;
-    type Error = KafkaError;
+    type Output = KafkaResult<Vec<ConfigResourceResult>>;
 
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        match self.rx.poll() {
-            Ok(Async::Ready(event)) => {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+        match self.rx.poll_unpin(cx) {
+            Poll::Ready(Ok(event)) => {
                 event.check_error()?;
                 let res = unsafe { rdsys::rd_kafka_event_DescribeConfigs_result(event.ptr()) };
                 if res.is_null() {
                     let typ = unsafe { rdsys::rd_kafka_event_type(event.ptr()) };
-                    return Err(KafkaError::AdminOpCreation(format!(
+                    return Poll::Ready(Err(KafkaError::AdminOpCreation(format!(
                         "describe configs request received response of incorrect type ({})",
                         typ
-                    )));
+                    ))));
                 }
                 let mut n = 0;
                 let resources =
@@ -1206,10 +1206,10 @@ impl Future for DescribeConfigsFuture {
                         entries: entries_out,
                     }))
                 }
-                Ok(Async::Ready(out))
+                Poll::Ready(Ok(out))
             }
-            Ok(Async::NotReady) => Ok(Async::NotReady),
-            Err(Canceled) => Err(KafkaError::Canceled),
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(Err(oneshot::Canceled)) => Poll::Ready(Err(KafkaError::Canceled)),
         }
     }
 }
@@ -1282,24 +1282,23 @@ impl<'a> AlterConfig<'a> {
 }
 
 struct AlterConfigsFuture {
-    rx: Oneshot<NativeEvent>,
+    rx: oneshot::Receiver<NativeEvent>,
 }
 
 impl Future for AlterConfigsFuture {
-    type Item = Vec<AlterConfigsResult>;
-    type Error = KafkaError;
+    type Output = KafkaResult<Vec<AlterConfigsResult>>;
 
-    fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        match self.rx.poll() {
-            Ok(Async::Ready(event)) => {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+        match self.rx.poll_unpin(cx) {
+            Poll::Ready(Ok(event)) => {
                 event.check_error()?;
                 let res = unsafe { rdsys::rd_kafka_event_AlterConfigs_result(event.ptr()) };
                 if res.is_null() {
                     let typ = unsafe { rdsys::rd_kafka_event_type(event.ptr()) };
-                    return Err(KafkaError::AdminOpCreation(format!(
+                    return Poll::Ready(Err(KafkaError::AdminOpCreation(format!(
                         "alter configs request received response of incorrect type ({})",
                         typ
-                    )));
+                    ))));
                 }
                 let mut n = 0;
                 let resources =
@@ -1310,10 +1309,10 @@ impl Future for AlterConfigsFuture {
                     let specifier = extract_config_specifier(resource)?;
                     out.push(Ok(specifier));
                 }
-                Ok(Async::Ready(out))
+                Poll::Ready(Ok(out))
             }
-            Ok(Async::NotReady) => Ok(Async::NotReady),
-            Err(Canceled) => Err(KafkaError::Canceled),
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(Err(oneshot::Canceled)) => Poll::Ready(Err(KafkaError::Canceled)),
         }
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -34,11 +34,21 @@ pub trait ClientContext: Send + Sync {
             RDKafkaLogLevel::Emerg
             | RDKafkaLogLevel::Alert
             | RDKafkaLogLevel::Critical
-            | RDKafkaLogLevel::Error => error!(target: "librdkafka", "librdkafka: {} {}", fac, log_message),
-            RDKafkaLogLevel::Warning => warn!(target: "librdkafka", "librdkafka: {} {}", fac, log_message),
-            RDKafkaLogLevel::Notice => info!(target: "librdkafka", "librdkafka: {} {}", fac, log_message),
-            RDKafkaLogLevel::Info => info!(target: "librdkafka", "librdkafka: {} {}", fac, log_message),
-            RDKafkaLogLevel::Debug => debug!(target: "librdkafka", "librdkafka: {} {}", fac, log_message),
+            | RDKafkaLogLevel::Error => {
+                error!(target: "librdkafka", "librdkafka: {} {}", fac, log_message)
+            }
+            RDKafkaLogLevel::Warning => {
+                warn!(target: "librdkafka", "librdkafka: {} {}", fac, log_message)
+            }
+            RDKafkaLogLevel::Notice => {
+                info!(target: "librdkafka", "librdkafka: {} {}", fac, log_message)
+            }
+            RDKafkaLogLevel::Info => {
+                info!(target: "librdkafka", "librdkafka: {} {}", fac, log_message)
+            }
+            RDKafkaLogLevel::Debug => {
+                debug!(target: "librdkafka", "librdkafka: {} {}", fac, log_message)
+            }
         }
     }
 

--- a/tests/test_high_producers.rs
+++ b/tests/test_high_producers.rs
@@ -3,8 +3,6 @@ extern crate futures;
 extern crate rand;
 extern crate rdkafka;
 
-use futures::Future;
-
 use rdkafka::config::ClientConfig;
 use rdkafka::message::{Headers, Message, OwnedHeaders};
 use rdkafka::producer::future_producer::FutureRecord;
@@ -12,8 +10,8 @@ use rdkafka::producer::FutureProducer;
 
 use std::error::Error;
 
-#[test]
-fn test_future_producer_send_fail() {
+#[tokio::test]
+async fn test_future_producer_send_fail() {
     let producer = ClientConfig::new()
         .set("bootstrap.servers", "localhost")
         .set("message.timeout.ms", "5000")
@@ -34,7 +32,7 @@ fn test_future_producer_send_fail() {
         10000,
     );
 
-    match future.wait() {
+    match future.await {
         Ok(Err((kafka_error, owned_message))) => {
             assert_eq!(kafka_error.description(), "Message production error");
             assert_eq!(owned_message.topic(), "topic");

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -4,7 +4,6 @@ extern crate rand;
 extern crate rdkafka;
 extern crate regex;
 
-use futures::*;
 use rand::Rng;
 use regex::Regex;
 
@@ -90,7 +89,7 @@ impl ClientContext for TestContext {
 /// Produce the specified count of messages to the topic and partition specified. A map
 /// of (partition, offset) -> message id will be returned. It panics if any error is encountered
 /// while populating the topic.
-pub fn populate_topic<P, K, J, Q>(
+pub async fn populate_topic<P, K, J, Q>(
     topic_name: &str,
     count: i32,
     value_fn: &P,
@@ -135,7 +134,7 @@ where
 
     let mut message_map = HashMap::new();
     for (id, future) in futures {
-        match future.wait() {
+        match future.await {
             Ok(Ok((partition, offset))) => message_map.insert((partition, offset), id),
             Ok(Err((kafka_error, _message))) => panic!("Delivery failed: {}", kafka_error),
             Err(e) => panic!("Waiting for future failed: {}", e),
@@ -157,10 +156,10 @@ pub fn key_fn(id: i32) -> String {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_populate_topic() {
+    #[tokio::test]
+    async fn test_populate_topic() {
         let topic_name = rand_test_topic();
-        let message_map = populate_topic(&topic_name, 100, &value_fn, &key_fn, Some(0), None);
+        let message_map = populate_topic(&topic_name, 100, &value_fn, &key_fn, Some(0), None).await;
 
         let total_messages = message_map
             .iter()


### PR DESCRIPTION
Upgrade to the new async/await ecosystem, which includes
std::future::Future, futures 0.3, tokio 0.2, and the new async/await
keywords.

This will bump the MSRV to Rust 1.39.

Co-authored-by: Ben Sully &lt;ben@bsull.io>
Co-authored-by: Danny Browning &lt;bdbrowning2@gmail.com>