### PR TITLE
Complete conversion to Rust 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ rdkafka-sys = { path = "rdkafka-sys", version = "1.2.1", default-features = fals
 futures = "0.3.0"
 libc = "0.2.0"
 log = "0.4.8"
-serde = "1.0.0"
+serde = { version = "1.0.0", features = ["derive"] }
 serde_derive = "1.0.0"
 serde_json = "1.0.0"
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,7 +4,7 @@
 
 * Upgrade to the async/await ecosystem, including `std::future::Future`, v0.3
   of the futures crate, and v0.2 of Tokio. The minimum supported Rust version
-  is now Rust 1.39. Special thanks to [@sd2k] and [@dbcfd]. ([#186])
+  is now Rust 1.39. Special thanks to [@sd2k] and [@dbcfd]. ([#187])
 
   The main difference is that functions that previously returned
   ```rust
@@ -22,7 +22,7 @@
   Functions that return `future::Stream`s have had the analogous transformation
   applied.
 
-[#186]: https://github.com/fede1024/rust-rdkafka/pull/183
+[#187]: https://github.com/fede1024/rust-rdkafka/pull/187
 
 [@sd2k]: https://github.com/sd2k
 [@dbcfd]: https://github.com/dbcfd

--- a/examples/asynchronous_processing.rs
+++ b/examples/asynchronous_processing.rs
@@ -1,13 +1,9 @@
-#[macro_use]
-extern crate log;
-extern crate clap;
-extern crate futures;
-extern crate rand;
-extern crate rdkafka;
-extern crate tokio;
+use std::thread;
+use std::time::Duration;
 
 use clap::{App, Arg};
 use futures::{future, TryStreamExt};
+use log::{info, warn};
 
 use rdkafka::config::ClientConfig;
 use rdkafka::consumer::stream_consumer::StreamConsumer;
@@ -16,11 +12,9 @@ use rdkafka::message::OwnedMessage;
 use rdkafka::producer::{FutureProducer, FutureRecord};
 use rdkafka::Message;
 
-use std::thread;
-use std::time::Duration;
+use crate::example_utils::setup_logger;
 
 mod example_utils;
-use crate::example_utils::setup_logger;
 
 // Emulates an expensive, synchronous computation.
 fn expensive_computation<'a>(msg: OwnedMessage) -> String {

--- a/examples/at_least_once.rs
+++ b/examples/at_least_once.rs
@@ -1,26 +1,20 @@
-/// This example shows how to achieve at-least-once message delivery semantics. This stream
-/// processing code will simply read from an input topic, and duplicate the content to any number of
-/// output topics. In case of failure (client or server side), messages might be duplicated,
-/// but they won't be lost.
-///
-/// The key point is committing the offset only once the message has been fully processed.
-/// Note that this technique only works when messages are processed in order. If a message with
-/// offset `i+n` is processed and committed before message `i`, in case of failure messages in
-/// the interval `[i, i+n)` might be lost.
-///
-/// For a simpler example of consumers and producers, check the `simple_consumer` and
-/// `simple_producer` files in the example folder.
-///
-#[macro_use]
-extern crate log;
-extern crate clap;
-extern crate futures;
-extern crate rdkafka;
-extern crate rdkafka_sys;
+//! This example shows how to achieve at-least-once message delivery semantics. This stream
+//! processing code will simply read from an input topic, and duplicate the content to any number of
+//! output topics. In case of failure (client or server side), messages might be duplicated,
+//! but they won't be lost.
+//!
+//! The key point is committing the offset only once the message has been fully processed.
+//! Note that this technique only works when messages are processed in order. If a message with
+//! offset `i+n` is processed and committed before message `i`, in case of failure messages in
+//! the interval `[i, i+n)` might be lost.
+//!
+//! For a simpler example of consumers and producers, check the `simple_consumer` and
+//! `simple_producer` files in the example folder.
 
 use clap::{App, Arg};
 use futures::future;
 use futures::stream::StreamExt;
+use log::{info, warn};
 
 use rdkafka::client::ClientContext;
 use rdkafka::config::{ClientConfig, RDKafkaLogLevel};
@@ -31,8 +25,9 @@ use rdkafka::producer::{FutureProducer, FutureRecord};
 use rdkafka::util::get_rdkafka_version;
 use rdkafka::Message;
 
-mod example_utils;
 use crate::example_utils::setup_logger;
+
+mod example_utils;
 
 // A simple context to customize the consumer behavior and print a log line every time
 // offsets are committed

--- a/examples/example_utils.rs
+++ b/examples/example_utils.rs
@@ -1,14 +1,10 @@
-extern crate chrono;
-extern crate env_logger;
-extern crate log;
-
-use self::chrono::prelude::*;
-
-use self::env_logger::fmt::Formatter;
-use self::env_logger::Builder;
-use self::log::{LevelFilter, Record};
 use std::io::Write;
 use std::thread;
+
+use chrono::prelude::*;
+use env_logger::fmt::Formatter;
+use env_logger::Builder;
+use log::{LevelFilter, Record};
 
 pub fn setup_logger(log_thread: bool, rust_log: Option<&str>) {
     let output_format = move |formatter: &mut Formatter, record: &Record| {

--- a/examples/metadata.rs
+++ b/examples/metadata.rs
@@ -1,18 +1,14 @@
-#[macro_use]
-extern crate log;
-#[macro_use]
-extern crate clap;
-extern crate rdkafka;
+use std::time::Duration;
 
-use clap::{App, Arg};
+use clap::{value_t, App, Arg};
+use log::trace;
 
 use rdkafka::config::ClientConfig;
 use rdkafka::consumer::{BaseConsumer, Consumer};
 
-use std::time::Duration;
+use crate::example_utils::setup_logger;
 
 mod example_utils;
-use crate::example_utils::setup_logger;
 
 fn print_metadata(brokers: &str, topic: Option<&str>, timeout: Duration, fetch_offsets: bool) {
     let consumer: BaseConsumer = ClientConfig::new()

--- a/examples/simple_consumer.rs
+++ b/examples/simple_consumer.rs
@@ -1,12 +1,6 @@
-#[macro_use]
-extern crate log;
-extern crate clap;
-extern crate futures;
-extern crate rdkafka;
-extern crate rdkafka_sys;
-
 use clap::{App, Arg};
 use futures::StreamExt;
+use log::{info, warn};
 
 use rdkafka::client::ClientContext;
 use rdkafka::config::{ClientConfig, RDKafkaLogLevel};
@@ -16,8 +10,9 @@ use rdkafka::error::KafkaResult;
 use rdkafka::message::{Headers, Message};
 use rdkafka::util::get_rdkafka_version;
 
-mod example_utils;
 use crate::example_utils::setup_logger;
+
+mod example_utils;
 
 // A context can be used to change the behavior of producers and consumers by adding callbacks
 // that will be executed by librdkafka.

--- a/examples/simple_producer.rs
+++ b/examples/simple_producer.rs
@@ -1,19 +1,15 @@
-#[macro_use]
-extern crate log;
-extern crate clap;
-extern crate futures;
-extern crate rdkafka;
-
-use clap::{App, Arg};
+use clap::{value_t, App, Arg};
 use futures::*;
+use log::info;
 
 use rdkafka::config::ClientConfig;
+use rdkafka::message::OwnedHeaders;
 use rdkafka::producer::{FutureProducer, FutureRecord};
 use rdkafka::util::get_rdkafka_version;
 
-mod example_utils;
 use crate::example_utils::setup_logger;
-use rdkafka::message::OwnedHeaders;
+
+mod example_utils;
 
 async fn produce(brokers: &str, topic_name: &str) {
     let producer: FutureProducer = ClientConfig::new()

--- a/rdkafka-sys/tests/version_check.rs
+++ b/rdkafka-sys/tests/version_check.rs
@@ -1,5 +1,3 @@
-extern crate rdkafka_sys as rdsys;
-
 use std::ffi::CStr;
 
 const PKG_VERSION: &'static str = env!("CARGO_PKG_VERSION");
@@ -13,7 +11,7 @@ fn remove_pre(version: &str) -> &str {
 
 #[test]
 fn check_version() {
-    let version_str_c = unsafe { CStr::from_ptr(rdsys::rd_kafka_version_str()) };
+    let version_str_c = unsafe { CStr::from_ptr(rdkafka_sys::rd_kafka_version_str()) };
     let rdsys_version = version_str_c.to_string_lossy();
     println!("librdkafka version: {}", rdsys_version);
 

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -4,18 +4,6 @@
 //!
 //! [`AdminClient`]: struct.AdminClient.html
 
-use crate::rdsys;
-use crate::rdsys::types::*;
-
-use crate::client::{Client, ClientContext, DefaultClientContext, NativeQueue};
-use crate::config::{ClientConfig, FromClientConfig, FromClientConfigAndContext};
-use crate::error::{IsError, KafkaError, KafkaResult};
-use crate::util::{cstr_to_owned, AsCArray, ErrBuf, IntoOpaque, Timeout, WrappedCPointer};
-
-use futures::channel::oneshot;
-use futures::future::{self, Either};
-use futures::FutureExt;
-
 use std::collections::HashMap;
 use std::ffi::{CStr, CString};
 use std::future::Future;
@@ -26,6 +14,18 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
+
+use futures::channel::oneshot;
+use futures::future::{self, Either, FutureExt};
+use log::{trace, warn};
+
+use rdkafka_sys as rdsys;
+use rdkafka_sys::types::*;
+
+use crate::client::{Client, ClientContext, DefaultClientContext, NativeQueue};
+use crate::config::{ClientConfig, FromClientConfig, FromClientConfigAndContext};
+use crate::error::{IsError, KafkaError, KafkaResult};
+use crate::util::{cstr_to_owned, AsCArray, ErrBuf, IntoOpaque, Timeout, WrappedCPointer};
 
 //
 // ********** ADMIN CLIENT **********

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,6 +1,4 @@
 //! Common client functionalities.
-use crate::rdsys;
-use crate::rdsys::types::*;
 
 use std::ffi::{CStr, CString};
 use std::mem;
@@ -10,7 +8,11 @@ use std::ptr;
 use std::slice;
 use std::string::ToString;
 
+use log::{debug, error, info, trace, warn};
 use serde_json;
+
+use rdkafka_sys as rdsys;
+use rdkafka_sys::types::*;
 
 use crate::config::{ClientConfig, NativeClientConfig, RDKafkaLogLevel};
 use crate::error::{IsError, KafkaError, KafkaResult};

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,17 +18,18 @@
 //! - `statistics.interval.ms` (0 - disabled): how often the statistic callback specified in the `Context` will be called.
 //!
 
-use crate::rdsys;
-use crate::rdsys::types::*;
-use log::Level;
+use std::collections::HashMap;
+use std::ffi::CString;
+use std::mem;
+
+use log::{log_enabled, trace, Level};
+
+use rdkafka_sys as rdsys;
+use rdkafka_sys::types::*;
 
 use crate::client::ClientContext;
 use crate::error::{IsError, KafkaError, KafkaResult};
 use crate::util::ErrBuf;
-
-use std::collections::HashMap;
-use std::ffi::CString;
-use std::mem;
 
 /// The log levels supported by librdkafka.
 #[derive(Copy, Clone, Debug)]

--- a/src/consumer/base_consumer.rs
+++ b/src/consumer/base_consumer.rs
@@ -1,6 +1,14 @@
 //! Low level consumer wrapper.
-use crate::rdsys;
-use crate::rdsys::types::*;
+
+use std::cmp;
+use std::mem;
+use std::os::raw::c_void;
+use std::ptr;
+
+use log::trace;
+
+use rdkafka_sys as rdsys;
+use rdkafka_sys::types::*;
 
 use crate::client::{Client, NativeClient, NativeQueue};
 use crate::config::{ClientConfig, FromClientConfig, FromClientConfigAndContext};
@@ -11,11 +19,6 @@ use crate::message::{BorrowedMessage, Message};
 use crate::metadata::Metadata;
 use crate::topic_partition_list::{Offset, TopicPartitionList};
 use crate::util::{cstr_to_owned, Timeout};
-
-use std::cmp;
-use std::mem;
-use std::os::raw::c_void;
-use std::ptr;
 
 pub(crate) unsafe extern "C" fn native_commit_cb<C: ConsumerContext>(
     _conf: *mut RDKafka,
@@ -176,7 +179,6 @@ impl<C: ConsumerContext> BaseConsumer<C> {
     /// All these are equivalent and will receive messages without timing out.
     ///
     /// ```rust,no_run
-    /// # extern crate rdkafka;
     /// # let consumer: rdkafka::consumer::BaseConsumer<_> = rdkafka::ClientConfig::new()
     /// #    .create()
     /// #    .unwrap();
@@ -188,7 +190,6 @@ impl<C: ConsumerContext> BaseConsumer<C> {
     /// ```
     ///
     /// ```rust,no_run
-    /// # extern crate rdkafka;
     /// # let consumer: rdkafka::consumer::BaseConsumer<_> = rdkafka::ClientConfig::new()
     /// #    .create()
     /// #    .unwrap();
@@ -199,7 +200,6 @@ impl<C: ConsumerContext> BaseConsumer<C> {
     /// ```
     ///
     /// ```rust,no_run
-    /// # extern crate rdkafka;
     /// # let consumer: rdkafka::consumer::BaseConsumer<_> = rdkafka::ClientConfig::new()
     /// #    .create()
     /// #    .unwrap();

--- a/src/consumer/mod.rs
+++ b/src/consumer/mod.rs
@@ -1,25 +1,27 @@
 //! Base trait and common functionality for all consumers.
-pub mod base_consumer;
-pub mod stream_consumer;
 
-// Re-export
-pub use self::base_consumer::BaseConsumer;
-pub use self::stream_consumer::{MessageStream, StreamConsumer};
+use std::ptr;
+use std::time::Duration;
 
-use crate::rdsys;
-use crate::rdsys::types::*;
+use log::{error, trace};
+
+use rdkafka_sys as rdsys;
+use rdkafka_sys::types::*;
 
 use crate::client::{ClientContext, NativeClient};
 use crate::error::KafkaResult;
 use crate::groups::GroupList;
 use crate::message::BorrowedMessage;
 use crate::metadata::Metadata;
+use crate::topic_partition_list::{Offset, TopicPartitionList};
 use crate::util::{cstr_to_owned, Timeout};
 
-use std::ptr;
-use std::time::Duration;
+pub mod base_consumer;
+pub mod stream_consumer;
 
-use crate::topic_partition_list::{Offset, TopicPartitionList};
+// Re-exports.
+pub use self::base_consumer::BaseConsumer;
+pub use self::stream_consumer::{MessageStream, StreamConsumer};
 
 /// Rebalance information.
 #[derive(Clone, Debug)]

--- a/src/consumer/stream_consumer.rs
+++ b/src/consumer/stream_consumer.rs
@@ -1,18 +1,5 @@
 //! Stream-based consumer implementation.
 
-use crate::rdsys;
-use crate::rdsys::types::*;
-
-use crate::config::{ClientConfig, FromClientConfig, FromClientConfigAndContext};
-use crate::consumer::base_consumer::BaseConsumer;
-use crate::consumer::{Consumer, ConsumerContext, DefaultConsumerContext};
-use crate::error::{KafkaError, KafkaResult};
-use crate::message::BorrowedMessage;
-use crate::util::Timeout;
-
-use futures::channel::mpsc;
-use futures::{SinkExt, Stream, StreamExt};
-
 use std::pin::Pin;
 use std::ptr;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -20,6 +7,20 @@ use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
+
+use futures::channel::mpsc;
+use futures::{SinkExt, Stream, StreamExt};
+use log::{debug, trace, warn};
+
+use rdkafka_sys as rdsys;
+use rdkafka_sys::types::*;
+
+use crate::config::{ClientConfig, FromClientConfig, FromClientConfigAndContext};
+use crate::consumer::base_consumer::BaseConsumer;
+use crate::consumer::{Consumer, ConsumerContext, DefaultConsumerContext};
+use crate::error::{KafkaError, KafkaResult};
+use crate::message::BorrowedMessage;
+use crate::util::Timeout;
 
 /// Default channel size for the stream consumer. The number of context switches
 /// seems to decrease exponentially as the channel size is increased, and it stabilizes when

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,10 +1,12 @@
 //! Error manipulations.
-use crate::rdsys::types::*;
 
 use std::{error, ffi, fmt};
 
+use rdkafka_sys as rdsys;
+use rdkafka_sys::types::*;
+
 // Re-export rdkafka error
-pub use crate::rdsys::types::RDKafkaError;
+pub use rdsys::types::RDKafkaError;
 
 /// Kafka result.
 pub type KafkaResult<T> = Result<T, KafkaError>;

--- a/src/groups.rs
+++ b/src/groups.rs
@@ -1,10 +1,11 @@
 //! Group membership API.
-use crate::rdsys;
-use crate::rdsys::types::*;
 
 use std::ffi::CStr;
 use std::fmt;
 use std::slice;
+
+use rdkafka_sys as rdsys;
+use rdkafka_sys::types::*;
 
 /// Group member information container.
 pub struct GroupMemberInfo(RDKafkaGroupMemberInfo);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,22 +209,7 @@
 
 #![warn(missing_docs)]
 
-//>alloc_system
-
-//use std::alloc::System;
-//#[global_allocator]
-//static A: System = System;
-
-#[macro_use]
-extern crate log;
-#[macro_use]
-extern crate serde_derive;
-extern crate futures;
-extern crate serde_json;
-
-extern crate rdkafka_sys as rdsys;
-
-pub use crate::rdsys::types;
+pub use rdkafka_sys::types;
 
 pub mod admin;
 pub mod client;

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,6 +1,4 @@
 //! Store and manipulate Kafka messages.
-use crate::rdsys;
-use crate::rdsys::types::*;
 
 use std::ffi::{CStr, CString};
 use std::fmt;
@@ -10,10 +8,13 @@ use std::ptr;
 use std::str;
 use std::time::SystemTime;
 
-use crate::util;
+use log::trace;
+
+use rdkafka_sys as rdsys;
+use rdkafka_sys::types::*;
 
 use crate::error::{IsError, KafkaError, KafkaResult};
-use crate::util::millis_to_epoch;
+use crate::util::{self, millis_to_epoch};
 
 /// Timestamp of a message
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -1,9 +1,10 @@
 //! Cluster metadata.
+
 use std::ffi::CStr;
 use std::slice;
 
-use crate::rdsys;
-use crate::rdsys::types::*;
+use rdkafka_sys as rdsys;
+use rdkafka_sys::types::*;
 
 use crate::error::IsError;
 

--- a/src/producer/base_producer.rs
+++ b/src/producer/base_producer.rs
@@ -34,16 +34,6 @@
 //! If this error is returned, the producer should wait and try again.
 //!
 
-use crate::rdsys;
-use crate::rdsys::rd_kafka_vtype_t::*;
-use crate::rdsys::types::*;
-
-use crate::client::{Client, ClientContext};
-use crate::config::{ClientConfig, FromClientConfig, FromClientConfigAndContext};
-use crate::error::{IsError, KafkaError, KafkaResult};
-use crate::message::{BorrowedMessage, OwnedHeaders, ToBytes};
-use crate::util::{IntoOpaque, Timeout};
-
 use std::ffi::CString;
 use std::mem;
 use std::os::raw::c_void;
@@ -52,6 +42,18 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
+
+use log::{trace, warn};
+
+use rdkafka_sys as rdsys;
+use rdkafka_sys::rd_kafka_vtype_t::*;
+use rdkafka_sys::types::*;
+
+use crate::client::{Client, ClientContext};
+use crate::config::{ClientConfig, FromClientConfig, FromClientConfigAndContext};
+use crate::error::{IsError, KafkaError, KafkaResult};
+use crate::message::{BorrowedMessage, OwnedHeaders, ToBytes};
+use crate::util::{IntoOpaque, Timeout};
 
 pub use crate::message::DeliveryResult;
 

--- a/src/producer/future_producer.rs
+++ b/src/producer/future_producer.rs
@@ -3,6 +3,15 @@
 //! A high level producer that returns a Future for every produced message.
 // TODO: extend docs
 
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use std::time::{Duration, Instant};
+
+use futures::channel::oneshot;
+use futures::FutureExt;
+
 use crate::client::{ClientContext, DefaultClientContext};
 use crate::config::{ClientConfig, FromClientConfig, FromClientConfigAndContext, RDKafkaLogLevel};
 use crate::error::{KafkaError, KafkaResult, RDKafkaError};
@@ -10,15 +19,6 @@ use crate::message::{Message, OwnedHeaders, OwnedMessage, Timestamp, ToBytes};
 use crate::producer::{BaseRecord, DeliveryResult, ProducerContext, ThreadedProducer};
 use crate::statistics::Statistics;
 use crate::util::{IntoOpaque, Timeout};
-
-use futures::channel::oneshot;
-use futures::FutureExt;
-
-use std::future::Future;
-use std::pin::Pin;
-use std::sync::Arc;
-use std::task::{Context, Poll};
-use std::time::{Duration, Instant};
 
 //
 // ********** FUTURE PRODUCER **********

--- a/src/statistics.rs
+++ b/src/statistics.rs
@@ -3,6 +3,8 @@
 
 use std::collections::HashMap;
 
+use serde::Deserialize;
+
 /// Statistics from librdkafka. Refer to the [librdkafka documentation](https://github.com/edenhill/librdkafka/wiki/Statistics)
 /// for details.
 #[derive(Deserialize, Debug)]

--- a/src/topic_partition_list.rs
+++ b/src/topic_partition_list.rs
@@ -1,15 +1,18 @@
 //! A data structure representing topic, partitions and offsets, compatible with the
 //! `RDKafkaTopicPartitionList` exported by `rdkafka-sys`.
-use crate::rdsys;
-use crate::rdsys::types::*;
-
-use crate::error::{IsError, KafkaError, KafkaResult};
 
 use std::collections::HashMap;
 use std::ffi::{CStr, CString};
 use std::fmt;
 use std::ptr;
 use std::slice;
+
+use log::trace;
+
+use rdkafka_sys as rdsys;
+use rdkafka_sys::types::*;
+
+use crate::error::{IsError, KafkaError, KafkaResult};
 
 const PARTITION_UNASSIGNED: i32 = -1;
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,5 +1,4 @@
 //! Utility functions
-use crate::rdsys;
 
 use std::ffi::CStr;
 use std::os::raw::c_char;
@@ -8,6 +7,8 @@ use std::ptr;
 use std::slice;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use rdkafka_sys as rdsys;
 
 /// Return a tuple representing the version of `librdkafka` in
 /// hexadecimal and string format.

--- a/tests/test_admin.rs
+++ b/tests/test_admin.rs
@@ -1,8 +1,8 @@
 //! Test administrative commands using the admin API.
 
-use backoff::{ExponentialBackoff, Operation};
-
 use std::time::Duration;
+
+use backoff::{ExponentialBackoff, Operation};
 
 use rdkafka::admin::{
     AdminClient, AdminOptions, AlterConfig, ConfigEntry, ConfigSource, NewPartitions, NewTopic,
@@ -14,8 +14,9 @@ use rdkafka::error::{KafkaError, RDKafkaError};
 use rdkafka::metadata::Metadata;
 use rdkafka::ClientConfig;
 
-mod utils;
 use crate::utils::*;
+
+mod utils;
 
 fn create_config() -> ClientConfig {
     let mut config = ClientConfig::new();

--- a/tests/test_consumers.rs
+++ b/tests/test_consumers.rs
@@ -1,11 +1,12 @@
 //! Test data consumption using low level and high level consumers.
-extern crate env_logger;
-extern crate futures;
-extern crate rand;
-extern crate rdkafka;
-extern crate rdkafka_sys;
 
-use futures::*;
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use futures::{future, StreamExt};
 
 use rdkafka::consumer::{BaseConsumer, CommitMode, Consumer, ConsumerContext, StreamConsumer};
 use rdkafka::error::{KafkaError, KafkaResult};
@@ -13,14 +14,9 @@ use rdkafka::topic_partition_list::{Offset, TopicPartitionList};
 use rdkafka::util::current_time_millis;
 use rdkafka::{ClientConfig, ClientContext, Message, Statistics, Timestamp};
 
-mod utils;
 use crate::utils::*;
 
-use std::collections::HashMap;
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::Arc;
-use std::thread;
-use std::time::{Duration, Instant};
+mod utils;
 
 struct TestContext {
     _n: i64, // Add data for memory access validation

--- a/tests/test_high_producers.rs
+++ b/tests/test_high_producers.rs
@@ -1,14 +1,11 @@
 //! Test data production using high level producers.
-extern crate futures;
-extern crate rand;
-extern crate rdkafka;
+
+use std::error::Error;
 
 use rdkafka::config::ClientConfig;
 use rdkafka::message::{Headers, Message, OwnedHeaders};
 use rdkafka::producer::future_producer::FutureRecord;
 use rdkafka::producer::FutureProducer;
-
-use std::error::Error;
 
 #[tokio::test]
 async fn test_future_producer_send_fail() {

--- a/tests/test_low_producers.rs
+++ b/tests/test_low_producers.rs
@@ -1,7 +1,10 @@
 //! Test data production using low level producers.
-extern crate futures;
-extern crate rand;
-extern crate rdkafka;
+
+use std::collections::{HashMap, HashSet};
+use std::error::Error;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::Duration;
 
 use rdkafka::config::ClientConfig;
 use rdkafka::error::{KafkaError, RDKafkaError};
@@ -12,15 +15,9 @@ use rdkafka::producer::{
 use rdkafka::util::current_time_millis;
 use rdkafka::{ClientContext, Statistics};
 
-#[macro_use]
-mod utils;
 use crate::utils::*;
 
-use std::collections::{HashMap, HashSet};
-use std::error::Error;
-use std::sync::Arc;
-use std::sync::Mutex;
-use std::time::Duration;
+mod utils;
 
 struct PrintingContext {
     _n: i64, // Add data for memory access validation

--- a/tests/test_metadata.rs
+++ b/tests/test_metadata.rs
@@ -1,8 +1,6 @@
 //! Test metadata fetch, group membership, consumer metadata.
-extern crate env_logger;
-extern crate futures;
-extern crate rand;
-extern crate rdkafka;
+
+use std::time::Duration;
 
 use futures::*;
 
@@ -10,10 +8,9 @@ use rdkafka::config::ClientConfig;
 use rdkafka::consumer::{Consumer, StreamConsumer};
 use rdkafka::topic_partition_list::TopicPartitionList;
 
-use std::time::Duration;
+use crate::utils::*;
 
 mod utils;
-use crate::utils::*;
 
 fn create_consumer(group_id: &str) -> StreamConsumer {
     ClientConfig::new()

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -1,8 +1,4 @@
 #![allow(dead_code)]
-extern crate futures;
-extern crate rand;
-extern crate rdkafka;
-extern crate regex;
 
 use rand::Rng;
 use regex::Regex;


### PR DESCRIPTION
Some of the cleanups in #166 removed adapted some Rust 2015-style code for Rust 2018. Apply those adaptations here, to decrease the scope of #166.