### PR TITLE
Implement Send + Sync on BorrowedMessage

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -362,6 +362,9 @@ impl<'a> Drop for BorrowedMessage<'a> {
     }
 }
 
+unsafe impl<'a> Send for BorrowedMessage<'a> {}
+unsafe impl<'a> Sync for BorrowedMessage<'a> {}
+
 //
 // ********** OWNED MESSAGE **********
 //


### PR DESCRIPTION
librdkafka is entirely thread safe, and guarantees that the memory
referenced by a BorrowedMessage will remain valid as long as the
consumer remains valid. Since BorrowedMessage has a reference to the
consumer inside, Rust will enforce this invariant, and it is therefore
safe to mark BorrowedMessage as Send + Sync.

Also update the asynchronous_processing example to make use of this new
feature. The example now allows spawning multiple workers, which
requires tokio::spawn, which turn requires that the generated future
implement Send, which finally requires the adjustment made in this
patch.

Fix #85.
Fix #189.