### PR TITLE
Don't create an extra thread when running message stream

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ rdkafka-sys = { path = "rdkafka-sys", version = "1.2.1", default-features = fals
 futures = "0.3.0"
 libc = "0.2.0"
 log = "0.4.8"
+pin-project = "0.4"
 serde = { version = "1.0.0", features = ["derive"] }
-serde_derive = "1.0.0"
 serde_json = "1.0.0"
 
 [dev-dependencies]

--- a/src/consumer/base_consumer.rs
+++ b/src/consumer/base_consumer.rs
@@ -5,8 +5,7 @@ use std::mem;
 use std::os::raw::c_void;
 use std::ptr;
 
-use futures::channel::oneshot::Sender;
-use log::{error, trace};
+use log::trace;
 
 use rdkafka_sys as rdsys;
 use rdkafka_sys::types::*;
@@ -126,55 +125,10 @@ impl<C: ConsumerContext> FromClientConfigAndContext<C> for BaseConsumer<C> {
     }
 }
 
-pub(crate) struct MessageBox(*mut rdsys::rd_kafka_message_t);
-
-unsafe impl Send for MessageBox {}
-unsafe impl Sync for MessageBox {}
-
-impl MessageBox {
-    pub fn into_inner(self) -> *mut rdsys::rd_kafka_message_t {
-        self.0
-    }
-}
-
-extern "C" fn queue_callback(
-    rkmessage: *mut rdsys::rd_kafka_message_t,
-    commit_opaque: *mut ::std::os::raw::c_void,
-) {
-    if commit_opaque != std::ptr::null_mut() {
-        let sender = commit_opaque as *mut Sender<Option<MessageBox>>;
-        unsafe {
-            let sender = Box::from_raw(sender);
-            if let Err(_) = sender.send(Some(MessageBox(rkmessage))) {
-                error!("Failed to forward message");
-            }
-        }
-    }
-}
-
 impl<C: ConsumerContext> BaseConsumer<C> {
     /// Returns the context used to create this consumer.
     pub fn context(&self) -> &C {
         self.client.context()
-    }
-
-    pub(crate) fn poll_with_sender(&self,
-        sender: Sender<Option<MessageBox>>,
-        timeout: Timeout,
-    ) {
-        if let Some(ref q) = self._queue {
-            unsafe { rdsys::rd_kafka_poll(self.client.native_ptr(), 0) };
-            let sender = Box::new(sender);
-            unsafe {
-                let sender = Box::into_raw(sender) as *const Sender<MessageBox> as *mut std::os::raw::c_void;
-                rdsys::rd_kafka_consume_callback_queue(
-                    q.ptr(),
-                    timeout.as_millis(),
-                    Some(queue_callback),
-                    sender,
-                );
-            }
-        }
     }
 
     /// Polls the consumer for messages and returns a pointer to the native rdkafka-sys struct.


### PR DESCRIPTION
@benesch This gets rid of the extra thread and futures executor block_on, without introducing a tokio dependency.