### PR TITLE
Use CMake's install target for proper MSVC handling

### DIFF
--- a/rdkafka-sys/build.rs
+++ b/rdkafka-sys/build.rs
@@ -171,9 +171,7 @@ fn build_librdkafka() {
 fn build_librdkafka() {
     let mut config = cmake::Config::new("librdkafka");
 
-    config
-        .define("RDKAFKA_BUILD_STATIC", "1")
-        .build_target("rdkafka");
+    config.define("RDKAFKA_BUILD_STATIC", "1");
 
     if env::var("CARGO_FEATURE_LIBZ").is_ok() {
         config.define("WITH_ZLIB", "1");
@@ -230,14 +228,6 @@ fn build_librdkafka() {
     println!("Configuring and compiling librdkafka");
     let dst = config.build();
 
-    if cfg!(target_env = "msvc") {
-        let profile = match &env::var("PROFILE").expect("Cannot determine build profile")[..] {
-            "release" | "bench" => "Release",
-            _ => "Debug"
-        };
-        println!("cargo:rustc-link-search=native={}/build/src/{}", dst.display(), profile);
-    } else {
-        println!("cargo:rustc-link-search=native={}/build/src", dst.display());
-    }
+    println!("cargo:rustc-link-search=native={}/lib", dst.display());
     println!("cargo:rustc-link-lib=static=rdkafka");
 }


### PR DESCRIPTION
The approach in #176 to handle MSVC was flawed, as it did not properly
account for CMake's RelWithDebInfo configuration type. The correct
approach is to ask CMake to install the library, rather than just
building it, at which point the library will be at a stable path
(OUT_DIR/lib) regardless of the directory structure that the particular
CMake generator uses.

Fix #191.