### PR TITLE
Improve ConsumerContext::commit_callback

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -22,10 +22,17 @@
   Functions that return `future::Stream`s have had the analogous transformation
   applied.
 
+* Change the signature of `ConsumerContext::commit_callback` so that the
+  offsets are passed via a safe `TopicPartitionList` struct, and not a
+  raw `*mut rdkafka_sys::RDKafkaPartitionList` pointer. Thanks, [@scrogson]!
+  ([#198]).
+
 [#187]: https://github.com/fede1024/rust-rdkafka/pull/187
+[#198]: https://github.com/fede1024/rust-rdkafka/pull/198
 
 [@sd2k]: https://github.com/sd2k
 [@dbcfd]: https://github.com/dbcfd
+[@scrogson]: https://github.com/scrogson
 
 <a name="0.22.0"></a>
 ## 0.22.0 (2019-12-01)

--- a/examples/at_least_once.rs
+++ b/examples/at_least_once.rs
@@ -22,6 +22,7 @@ use rdkafka::consumer::stream_consumer::StreamConsumer;
 use rdkafka::consumer::{Consumer, ConsumerContext};
 use rdkafka::error::KafkaResult;
 use rdkafka::producer::{FutureProducer, FutureRecord};
+use rdkafka::topic_partition_list::TopicPartitionList;
 use rdkafka::util::get_rdkafka_version;
 use rdkafka::Message;
 
@@ -39,7 +40,7 @@ impl ConsumerContext for LoggingConsumerContext {
     fn commit_callback(
         &self,
         result: KafkaResult<()>,
-        _offsets: *mut rdkafka_sys::RDKafkaTopicPartitionList,
+        _offsets: &TopicPartitionList,
     ) {
         match result {
             Ok(_) => info!("Offsets committed successfully"),

--- a/examples/simple_consumer.rs
+++ b/examples/simple_consumer.rs
@@ -6,6 +6,7 @@ use rdkafka::client::ClientContext;
 use rdkafka::config::{ClientConfig, RDKafkaLogLevel};
 use rdkafka::consumer::stream_consumer::StreamConsumer;
 use rdkafka::consumer::{CommitMode, Consumer, ConsumerContext, Rebalance};
+use rdkafka::topic_partition_list::TopicPartitionList;
 use rdkafka::error::KafkaResult;
 use rdkafka::message::{Headers, Message};
 use rdkafka::util::get_rdkafka_version;
@@ -33,7 +34,7 @@ impl ConsumerContext for CustomContext {
     fn commit_callback(
         &self,
         result: KafkaResult<()>,
-        _offsets: *mut rdkafka_sys::RDKafkaTopicPartitionList,
+        _offsets: &TopicPartitionList,
     ) {
         info!("Committing offsets: {:?}", result);
     }

--- a/src/consumer/mod.rs
+++ b/src/consumer/mod.rs
@@ -90,7 +90,7 @@ pub trait ConsumerContext: ClientContext {
     /// Post commit callback. This method will run after a group of offsets was committed to the
     /// offset store.
     #[allow(unused_variables)]
-    fn commit_callback(&self, result: KafkaResult<()>, offsets: *mut RDKafkaTopicPartitionList) {}
+    fn commit_callback(&self, result: KafkaResult<()>, offsets: &TopicPartitionList) {}
 
     /// Returns the minimum interval at which to poll the main queue, which
     /// services the logging, stats, and error callbacks.

--- a/tests/test_consumers.rs
+++ b/tests/test_consumers.rs
@@ -35,7 +35,7 @@ impl ConsumerContext for TestContext {
     fn commit_callback(
         &self,
         result: KafkaResult<()>,
-        _offsets: *mut rdkafka_sys::RDKafkaTopicPartitionList,
+        _offsets: &TopicPartitionList,
     ) {
         println!("Committing offsets: {:?}", result);
     }


### PR DESCRIPTION
This PR attempts to remove exposing `*mut rdkafka_sys::RDKafkaTopicPartitionList` in `ConsumerContext::commit_callback` and expose `rdkafka::topic_partition_list::TopicPartitionList` instead.

Should resolve #197 