### PR TITLE
ci: explicitly request msvc toolchain on windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ jobs:
     rust: stable
   - os: windows
     arch: amd64
-    rust: stable
+    rust: stable-msvc
     env: FEATURES=cmake_build,libz-static
 
 script:


### PR DESCRIPTION
The Travis CI Windows environment has changed in a way that causes CMake
to fail. Try using the MSVC toolchain instead.