### PR TITLE
Fix packaging for rdkafka-sys. Point rdkafka to the new version.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["api-bindings"]
 edition = "2018"
 
 [dependencies]
-rdkafka-sys = { path = "rdkafka-sys", version = "1.2.1", default-features = false }
+rdkafka-sys = { path = "rdkafka-sys", version = "1.3.0", default-features = false }
 futures = "0.3.0"
 libc = "0.2.0"
 log = "0.4.8"

--- a/examples/asynchronous_processing.rs
+++ b/examples/asynchronous_processing.rs
@@ -23,7 +23,7 @@ async fn record_borrowed_message_receipt(msg: &BorrowedMessage<'_>) {
     info!("Message received: {}", msg.offset());
 }
 
-async fn record_owned_message_receipt(msg: &OwnedMessage) {
+async fn record_owned_message_receipt(_msg: &OwnedMessage) {
     // Like `record_borrowed_message_receipt`, but takes an `OwnedMessage`
     // instead, as in a real-world use case  an `OwnedMessage` might be more
     // convenient than a `BorrowedMessage`.

--- a/rdkafka-sys/build.rs
+++ b/rdkafka-sys/build.rs
@@ -156,7 +156,7 @@ fn build_librdkafka() {
         //
         // https://github.com/edenhill/mklove/issues/17
         println!("Cloning librdkafka");
-        run_command_or_fail("librdkafka", "git", &["clone", ".", &out_dir]);
+        run_command_or_fail(".", "cp", &["-a", "librdkafka/.", &out_dir]);
     }
 
     println!("Configuring librdkafka");


### PR DESCRIPTION
Use `cp` instead of `git clone` to create a copy of the librdkafka
folder, since the `.git` folder is not present during `cargo package`.
Also point rdkafka to the new rdkafka-sys version.