### PR TITLE
rdkafka-sys: don't bother removing in-tree config.h

### DIFF
--- a/rdkafka-sys/build.rs
+++ b/rdkafka-sys/build.rs
@@ -234,16 +234,6 @@ fn build_librdkafka() {
         config.define("CMAKE_SYSTEM_NAME", system_name);
     }
 
-    // The CMake build will incorrectly use config.h from the non-CMake build,
-    // if it exists, so remove it if it does.
-    match std::fs::remove_file("librdkafka/config.h") {
-        Ok(()) => (),
-        Err(err) => match err.kind() {
-            std::io::ErrorKind::NotFound => (),
-            _ => panic!("Unable to remove config.h from non-CMake build: {}", err),
-        }
-    }
-
     println!("Configuring and compiling librdkafka");
     let dst = config.build();
 


### PR DESCRIPTION
We no longer build in tree when using the non-CMake build, so the CMake
build no longer needs to try to remove config.h, because it's almost
certain not to exist.