### PR TITLE
derive Debug for ClientConfig

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -105,7 +105,7 @@ impl Drop for NativeClientConfig {
 }
 
 /// Client configuration.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct ClientConfig {
     conf_map: HashMap<String, String>,
     /// The librdkafka logging level. Refer to `RDKafkaLogLevel` for the list of available levels.


### PR DESCRIPTION
Debug is needed when ClientConfig is put into Context struct of some web frameworks