### PR TITLE
Add Clone to OwnedMessage

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -457,7 +457,7 @@ impl Drop for OwnedHeaders {
 /// An [OwnedMessage] can be created from a [BorrowedMessage] using the [BorrowedMessage::detach]
 /// method. [OwnedMessage]s don't hold any reference to the consumer and don't use any memory inside the
 /// consumer buffer.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct OwnedMessage {
     payload: Option<Vec<u8>>,
     key: Option<Vec<u8>>,


### PR DESCRIPTION
There doesn't seem to be a reason that `OwnedMessage` should not implement `Clone`. Certain use cases like using a `tokio::sync::broadcast` channel require `Clone` to be implemented.
