### PR TITLE
Adding MUSL feature for cross compiling to alpine

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rdkafka"
-version = "0.23.1"
+version = "0.23.2"
 authors = ["Federico Giraud <giraud.federico@gmail.com>"]
 repository = "https://github.com/fede1024/rust-rdkafka"
 readme = "README.md"
@@ -11,7 +11,7 @@ categories = ["api-bindings"]
 edition = "2018"
 
 [dependencies]
-rdkafka-sys = { path = "rdkafka-sys", version = "1.3.1", default-features = false }
+rdkafka-sys = { path = "rdkafka-sys", version = "1.3.2", default-features = false }
 futures = "0.3.0"
 libc = "0.2.0"
 log = "0.4.8"
@@ -45,6 +45,7 @@ zstd = ["rdkafka-sys/zstd"]
 zstd-pkg-config = ["rdkafka-sys/zstd-pkg-config"]
 external-lz4 = ["rdkafka-sys/external-lz4"]
 external_lz4 = ["rdkafka-sys/external_lz4"]
+musl = ["rdkafka-sys/musl"]
 
 [package.metadata.docs.rs]
 # docs.rs doesn't allow writing to ~/.cargo/registry (reasonably), so we have to

--- a/rdkafka-sys/Cargo.toml
+++ b/rdkafka-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rdkafka-sys"
-version = "1.3.1"
+version = "1.3.2"
 authors = ["Federico Giraud <giraud.federico@gmail.com>"]
 build = "build.rs"
 links = "rdkafka"
@@ -76,6 +76,8 @@ external-lz4 = ["lz4-sys"]
 
 # Deprecated alias for the `external-lz4` feature.
 external_lz4 = ["external-lz4"]
+
+musl = []
 
 [package.metadata.docs.rs]
 # docs.rs doesn't allow writing to ~/.cargo/registry (reasonably), so we have to

--- a/rdkafka-sys/README.md
+++ b/rdkafka-sys/README.md
@@ -76,6 +76,7 @@ you would pass to `configure` if you were compiling manually).
     against its own bundled version of liblz4. Due to limitations with lz4-sys,
     it is not yet possible to dynamically link against the system's version of
     liblz4.
+  * The **`musl`** feature statically links against the musl libc library
 
 All features are disabled by default unless noted otherwise above. The build
 process is defined in [`build.rs`](build.rs).

--- a/rdkafka-sys/build.rs
+++ b/rdkafka-sys/build.rs
@@ -234,6 +234,11 @@ fn build_librdkafka() {
         config.define("CMAKE_SYSTEM_NAME", system_name);
     }
 
+    if env::var("CARGO_FEATURE_MUSL").is_ok() {
+        config.define("CC", "musl-gcc -static -Os");
+        config.define("CMAKE_CXX_COMPILER", "/usr/bin/g++");
+    }
+
     println!("Configuring and compiling librdkafka");
     let dst = config.build();
 

--- a/rdkafka-sys/src/lib.rs
+++ b/rdkafka-sys/src/lib.rs
@@ -76,6 +76,7 @@
 //!     against its own bundled version of liblz4. Due to limitations with lz4-sys,
 //!     it is not yet possible to dynamically link against the system's version of
 //!     liblz4.
+//!   * The **`musl`** feature statically links against the musl libc library
 //!
 //! All features are disabled by default unless noted otherwise above. The build
 //! process is defined in [`build.rs`].


### PR DESCRIPTION
This allows cross compiling from an Ubuntu dev machine to an alpine docker image on the host dev box. I am quite new to rust and honestly feeling around in the dark on the CMake / C and C++ stuff. This will not work on windows machines, I'm happy to look in to warning about that if the flag is set somehow and improving the documentation of this feature if the approach is even palatable! The reasoning behind attempting this is that cargo is caching a lot of depdendencies on the build machine, there are approaches that use multi stage docker files to do the build, this however leaves a lot more of the CI/CD process in a docker file than I would like. If I can copy a statically linked cross compiled binary in to an alpine container, I can run tests from cargo outside of docker, have more of the build process in whatever pipeline definition I'm using, have a small portable container produced at the end and leverage cached target directories for local development and possibly even CI/CD machines. All comments welcome!