### PR TITLE
FutureProducer::send: Fix blocking behavior

### DIFF
--- a/src/producer/future_producer.rs
+++ b/src/producer/future_producer.rs
@@ -235,14 +235,8 @@ impl<C: ClientContext + 'static> FutureProducer<C> {
                 Ok(_) => break DeliveryFuture { rx },
                 Err((e, record)) => {
                     if e == KafkaError::MessageProduction(RDKafkaError::QueueFull) {
-                        const POLL_TIMEOUT_MILLISECONDS: u64 = 100;
-                        if block_ms == -1 {
-                            self.poll(Duration::from_millis(POLL_TIMEOUT_MILLISECONDS));
-                            base_record = record;
-                            continue;
-                        } else if block_ms > 0
-                            && start_time.elapsed() < Duration::from_millis(block_ms as u64)
-                        {
+                        if (block_ms == -1) || (block_ms > 0 && start_time.elapsed() < Duration::from_millis(block_ms as u64)) {
+                            const POLL_TIMEOUT_MILLISECONDS: u64 = 100;
                             self.poll(Duration::from_millis(POLL_TIMEOUT_MILLISECONDS));
                             base_record = record;
                             continue;

--- a/src/producer/future_producer.rs
+++ b/src/producer/future_producer.rs
@@ -235,13 +235,15 @@ impl<C: ClientContext + 'static> FutureProducer<C> {
                 Ok(_) => break DeliveryFuture { rx },
                 Err((e, record)) => {
                     if e == KafkaError::MessageProduction(RDKafkaError::QueueFull) {
+                        const POLL_TIMEOUT_MILLISECONDS: u64 = 100;
                         if block_ms == -1 {
+                            self.poll(Duration::from_millis(POLL_TIMEOUT_MILLISECONDS));
                             base_record = record;
                             continue;
                         } else if block_ms > 0
                             && start_time.elapsed() < Duration::from_millis(block_ms as u64)
                         {
-                            self.poll(Duration::from_millis(100));
+                            self.poll(Duration::from_millis(POLL_TIMEOUT_MILLISECONDS));
                             base_record = record;
                             continue;
                         }


### PR DESCRIPTION
The documentation says:

>   Sends the provided [FutureRecord]. Returns a [DeliveryFuture] that will eventually contain the
>   result of the send. The `block_ms` parameter will control for how long the producer
>   is allowed to block if the queue is full. Set it to -1 to block forever, or 0 to never block.
>   If `block_ms` is reached and the queue is still full, a [RDKafkaError::QueueFull] will be
>   reported in the [DeliveryFuture].

The way I'm understanding the current code, it doesn't exactly do that.
* Setting `block_ms` to `0` will create an infinite loop of attempts to send messsages.
* If the `QueueFull` error happens, the corresponding match branch doesn't ever send the error back to the DeliveryFuture, regardless of the `block_ms` setting.

Also in the forever blocking case, `poll` should probably be called in the same way as with a `block_ms` that is larger than zero.

This pull request attempts to fix the behavior.

Looking ahead though, a proper fix would probably involve a `tokio::time::Delay` in the `DeliveryFuture`, "blocking" asynchronously inside of the `DeliveryFuture` instead of blocking synchronously. `FutureProducer::send` will most likely be called as part of a `Future`, thereby breaking the contract of `Future::poll` by blocking (potentially indefinitely).