### PR TITLE
Implement Send + Sync on TopicPartitionList

### DIFF
--- a/src/topic_partition_list.rs
+++ b/src/topic_partition_list.rs
@@ -350,6 +350,9 @@ impl fmt::Debug for TopicPartitionList {
     }
 }
 
+unsafe impl Send for TopicPartitionList {}
+unsafe impl Sync for TopicPartitionList {}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
librdkafka is thread safe. This allows to assign a `TopicPartitionList` to a consumer before calling `start()` in an async/await context under Rust.

For example (inside a `tokio::spawn` thread):

```Rust
let mut tpl = TopicPartitionList::new();
tpl.add_partition_offset("topic", 0, Offset::Beginning);
consumer.assign(&tpl)?;

while let Some(message) = consumer.start().try_next().await? {
    // ...
}
```

This fails without the patch:
```
tokio::spawn(async {
^^^^^^^^^^^^ future is not `Send`
```