### PR TITLE
Expose underlying client in consumer and producer

### DIFF
--- a/src/consumer/mod.rs
+++ b/src/consumer/mod.rs
@@ -8,7 +8,7 @@ use log::{error, trace};
 use rdkafka_sys as rdsys;
 use rdkafka_sys::types::*;
 
-use crate::client::{ClientContext, NativeClient};
+use crate::client::{Client, ClientContext, NativeClient};
 use crate::error::KafkaResult;
 use crate::groups::GroupList;
 use crate::message::BorrowedMessage;
@@ -321,5 +321,10 @@ pub trait Consumer<C: ConsumerContext = DefaultConsumerContext> {
     /// Resume consumption for the provided list of partitions.
     fn resume(&self, partitions: &TopicPartitionList) -> KafkaResult<()> {
         self.get_base_consumer().resume(partitions)
+    }
+
+    /// Returns the [`Client`] underlying this consumer.
+    fn client(&self) -> &Client<C> {
+        self.get_base_consumer().client()
     }
 }

--- a/src/producer/base_producer.rs
+++ b/src/producer/base_producer.rs
@@ -391,6 +391,11 @@ impl<C: ProducerContext> BaseProducer<C> {
     pub fn in_flight_count(&self) -> i32 {
         unsafe { rdsys::rd_kafka_outq_len(self.native_ptr()) }
     }
+
+    /// Returns the [`Client`] underlying this producer.
+    pub fn client(&self) -> &Client<C> {
+        &*self.client_arc
+    }
 }
 
 impl<C: ProducerContext> Clone for BaseProducer<C> {
@@ -510,6 +515,11 @@ impl<C: ProducerContext + 'static> ThreadedProducer<C> {
     /// Returns the number of messages waiting to be sent, or send but not acknowledged yet.
     pub fn in_flight_count(&self) -> i32 {
         self.producer.in_flight_count()
+    }
+
+    /// Returns the [`Client`] underlying this producer.
+    pub fn client(&self) -> &Client<C> {
+        self.producer.client()
     }
 }
 

--- a/src/producer/future_producer.rs
+++ b/src/producer/future_producer.rs
@@ -12,7 +12,7 @@ use std::time::{Duration, Instant};
 use futures::channel::oneshot;
 use futures::FutureExt;
 
-use crate::client::{ClientContext, DefaultClientContext};
+use crate::client::{Client, ClientContext, DefaultClientContext};
 use crate::config::{ClientConfig, FromClientConfig, FromClientConfigAndContext, RDKafkaLogLevel};
 use crate::error::{KafkaError, KafkaResult, RDKafkaError};
 use crate::message::{Message, OwnedHeaders, OwnedMessage, Timestamp, ToBytes};
@@ -114,7 +114,7 @@ impl<'a, K: ToBytes + ?Sized, P: ToBytes + ?Sized> FutureRecord<'a, K, P> {
 /// The `ProducerContext` used by the `FutureProducer`. This context will use a Future as its
 /// `DeliveryOpaque` and will complete the future when the message is delivered (or failed to).
 #[derive(Clone)]
-struct FutureProducerContext<C: ClientContext + 'static> {
+pub struct FutureProducerContext<C: ClientContext + 'static> {
     wrapped_context: C,
 }
 
@@ -295,6 +295,11 @@ impl<C: ClientContext + 'static> FutureProducer<C> {
     /// Returns the number of messages waiting to be sent, or send but not acknowledged yet.
     pub fn in_flight_count(&self) -> i32 {
         self.producer.in_flight_count()
+    }
+
+    /// Returns the [`Client`] underlying this producer.
+    pub fn client(&self) -> &Client<FutureProducerContext<C>> {
+        self.producer.client()
     }
 }
 


### PR DESCRIPTION
Exposing the client is useful for power users who may need to invoke
custom methods via the underlying librdkafka API. For example, it is
often necessary to explicitly call fetch_metadata on a producer's
client.

The client struct was already public, and somewhat accessible via the
consumer context, so this actually increases the consistency of the API.