### PR TITLE
rdkafka-sys: upgrade to librdkafka v1.4.0

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,21 @@
 # Changelog
 
+See also the [rdkafka-sys changelog](rdkafka-sys/changelog.md).
+
+<a name="0.24.0"></a>
+## 0.24.0 (Unreleased)
+
+* Decouple versioning of rdkafka-sys from rdkafka. rdkafka-sys now has its
+  own [changelog](rdkafka-sys/changelog.md) and will follow SemVer conventions.
+  ([#211])
+
+[#211]: https://github.com/fede1024/rust-rdkafka/issues/211
+
+<a name="0.23.1"></a>
+## 0.23.1 (2020-01-13)
+
+* Fix build on docs.rs.
+
 <a name="0.23.0"></a>
 ## 0.23.0 (2019-12-31)
 

--- a/rdkafka-sys/Cargo.toml
+++ b/rdkafka-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rdkafka-sys"
-version = "1.3.1"
+version = "1.4.0+1.4.0"
 authors = ["Federico Giraud <giraud.federico@gmail.com>"]
 build = "build.rs"
 links = "rdkafka"

--- a/rdkafka-sys/README.md
+++ b/rdkafka-sys/README.md
@@ -14,9 +14,12 @@ cargo install bindgen
 
 ## Version
 
-The rdkafka-sys version number is in the format `X.Y.Z-P`, where `X.Y.Z`
-corresponds to the librdkafka version, and `P` indicates the version of the
-rust bindings.
+The rdkafka-sys version number is in the format `X.Y.Z+RX.RY.RZ`, where `X.Y.Z`
+is the version of this crate and follows SemVer conventions, while `RX.RY.RZ`
+is the version of the bundled librdkafka.
+
+Note that versions before v1.4.0+1.4.0 did not follow this convention, and
+instead directly corresponded to the bundled librdkafka version.
 
 ## Build
 

--- a/rdkafka-sys/build.rs
+++ b/rdkafka-sys/build.rs
@@ -193,7 +193,9 @@ fn build_librdkafka() {
         // want a stable location that we can add to the linker search path.
         // Since we're not actually installing to /usr or /usr/local, there's no
         // harm to always using "lib" here.
-        .define("CMAKE_INSTALL_LIBDIR", "lib");
+        .define("CMAKE_INSTALL_LIBDIR", "lib")
+        // Workaround for https://github.com/edenhill/librdkafka/pull/2640.
+        .define("ENABLE_DEVEL", "0");
 
     if env::var("CARGO_FEATURE_LIBZ").is_ok() {
         config.define("WITH_ZLIB", "1");

--- a/rdkafka-sys/changelog.md
+++ b/rdkafka-sys/changelog.md
@@ -1,0 +1,8 @@
+# Changelog
+
+<a name="1.4.0+1.4.0"></a>
+## v1.4.0+1.4.0 (Unreleased)
+
+* Upgrade to librdkafka v1.4.0.
+
+* Start separate changelog for rdkafka-sys.

--- a/rdkafka-sys/src/helpers.rs
+++ b/rdkafka-sys/src/helpers.rs
@@ -60,6 +60,9 @@ pub fn rd_kafka_resp_err_t_to_rdkafka_error(err: RDKafkaRespErr) -> RDKafkaError
         RD_KAFKA_RESP_ERR__GAPLESS_GUARANTEE => GaplessGuarantee,
         RD_KAFKA_RESP_ERR__MAX_POLL_EXCEEDED => PollExceeded,
         RD_KAFKA_RESP_ERR__UNKNOWN_BROKER => UnknownBroker,
+        RD_KAFKA_RESP_ERR__NOT_CONFIGURED => NotConfigured,
+        RD_KAFKA_RESP_ERR__FENCED => Fenced,
+        RD_KAFKA_RESP_ERR__APPLICATION => Application,
         RD_KAFKA_RESP_ERR__END => End,
         RD_KAFKA_RESP_ERR_UNKNOWN => Unknown,
         RD_KAFKA_RESP_ERR_NO_ERROR => NoError,
@@ -148,6 +151,7 @@ pub fn rd_kafka_resp_err_t_to_rdkafka_error(err: RDKafkaRespErr) -> RDKafkaError
         RD_KAFKA_RESP_ERR_MEMBER_ID_REQUIRED => MemberIdRequired,
         RD_KAFKA_RESP_ERR_PREFERRED_LEADER_NOT_AVAILABLE => PreferredLeaderNotAvailable,
         RD_KAFKA_RESP_ERR_GROUP_MAX_SIZE_REACHED => GroupMaxSizeReached,
+        RD_KAFKA_RESP_ERR_FENCED_INSTANCE_ID => FencedInstanceId,
         RD_KAFKA_RESP_ERR_END_ALL => EndAll,
     }
 }

--- a/rdkafka-sys/src/types.rs
+++ b/rdkafka-sys/src/types.rs
@@ -216,6 +216,12 @@ pub enum RDKafkaError {
     PollExceeded = -147,
     /// Unknown broker
     UnknownBroker = -146,
+    /// Functionality not configured
+    NotConfigured,
+    /// Instance has been fenced
+    Fenced,
+    /// Application generated error
+    Application,
     #[doc(hidden)]
     End = -100,
     /// Unknown broker error
@@ -387,6 +393,8 @@ pub enum RDKafkaError {
     PreferredLeaderNotAvailable = 80,
     /// Consumer group has reached maximum size
     GroupMaxSizeReached = 81,
+    /// Static consumer fenced by other consumer with same group.instance.id
+    FencedInstanceId = 82,
     #[doc(hidden)]
     EndAll,
 }


### PR DESCRIPTION
Also allow rdkafka and rdkafka-sys to be versioned independently by
making rdkafka-sys follow SemVer. This will fix future scenarios like
the one described in issue #211.