### PR TITLE
Make deatch public on BorrowedHeaders

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -140,7 +140,9 @@ impl BorrowedHeaders {
         self as *const BorrowedHeaders as *const RDKafkaHeaders
     }
 
-    fn detach(&self) -> OwnedHeaders {
+    /// Clones the content of `BorrowedHeaders` and returns an `OwnedMessage`,
+    /// that can outlive the consumer. This operation requires memory allocation and can be expensive.
+    pub fn detach(&self) -> OwnedHeaders {
         OwnedHeaders {
             ptr: unsafe { rdsys::rd_kafka_headers_copy(self.as_native_ptr()) },
         }


### PR DESCRIPTION
This PR exposes the detach function on BorrowedHeaders. This is already exposed through `detach` on `BorrowedMessage`, but this allows us to incrementally copy the message. 