### PR TITLE
rdkafka-sys: enable gssapi in sasl2 when vendored

### DIFF
--- a/rdkafka-sys/Cargo.toml
+++ b/rdkafka-sys/Cargo.toml
@@ -18,7 +18,7 @@ openssl-sys = { version = "0.9.48", optional = true }
 libz-sys = { version = "1.0", optional = true }
 zstd-sys = { version = "1.4.15", optional = true }
 lz4-sys = { version = "1.8.3", optional = true }
-sasl2-sys = { version = "0.1", optional = true }
+sasl2-sys = { version = "0.1.6", optional = true }
 
 [build-dependencies]
 pkg-config = "0.3.9"
@@ -54,7 +54,7 @@ ssl-vendored = ["ssl", "openssl-sys/vendored"]
 gssapi = ["ssl", "sasl2-sys"]
 
 # Build and link against the libsasl2 bundled with the sasl2-sys crate.
-gssapi-vendored = ["gssapi", "sasl2-sys/vendored"]
+gssapi-vendored = ["gssapi", "sasl2-sys/gssapi-vendored"]
 
 # Deprecated alias for the `gssapi` feature.
 sasl = ["gssapi"]


### PR DESCRIPTION
librdkafka expects sasl2's GSSAPI plugin to be enabled.