### PR TITLE
refactor: Homogenize the unsafe around drop (and more)

### DIFF
--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -7,6 +7,7 @@ use rdkafka_sys as rdsys;
 use rdkafka_sys::types::*;
 
 use crate::error::IsError;
+use crate::util::{KafkaDrop, NativePtr};
 
 /// Broker metadata information.
 pub struct MetadataBroker(RDKafkaMetadataBroker);
@@ -102,23 +103,32 @@ impl MetadataTopic {
 
 /// Metadata container. This structure wraps the metadata pointer returned by rdkafka-sys,
 /// and deallocates all the native resources when dropped.
-pub struct Metadata(*const RDKafkaMetadata);
+pub struct Metadata(NativePtr<RDKafkaMetadata>);
+
+unsafe impl KafkaDrop for RDKafkaMetadata {
+    const TYPE: &'static str = "metadata";
+    const DROP: unsafe extern "C" fn(*mut Self) = drop_metadata;
+}
+
+unsafe extern "C" fn drop_metadata(ptr: *mut RDKafkaMetadata) {
+    rdsys::rd_kafka_metadata_destroy(ptr as *const _)
+}
 
 impl Metadata {
     /// Creates a new Metadata container given a pointer to the native rdkafka-sys metadata.
     pub(crate) unsafe fn from_ptr(ptr: *const RDKafkaMetadata) -> Metadata {
-        Metadata(ptr)
+        Metadata(NativePtr::from_ptr(ptr as *mut _).unwrap())
     }
 
     /// Returns the id of the broker originating this metadata.
     pub fn orig_broker_id(&self) -> i32 {
-        unsafe { (*self.0).orig_broker_id }
+        self.0.orig_broker_id
     }
 
     /// Returns the hostname of the broker originating this metadata.
     pub fn orig_broker_name(&self) -> &str {
         unsafe {
-            CStr::from_ptr((*self.0).orig_broker_name)
+            CStr::from_ptr(self.0.orig_broker_name)
                 .to_str()
                 .expect("Broker name is not a valid UTF-8 string")
         }
@@ -128,8 +138,8 @@ impl Metadata {
     pub fn brokers(&self) -> &[MetadataBroker] {
         unsafe {
             slice::from_raw_parts(
-                (*self.0).brokers as *const MetadataBroker,
-                (*self.0).broker_cnt as usize,
+                self.0.brokers as *const MetadataBroker,
+                self.0.broker_cnt as usize,
             )
         }
     }
@@ -138,16 +148,10 @@ impl Metadata {
     pub fn topics(&self) -> &[MetadataTopic] {
         unsafe {
             slice::from_raw_parts(
-                (*self.0).topics as *const MetadataTopic,
-                (*self.0).topic_cnt as usize,
+                self.0.topics as *const MetadataTopic,
+                self.0.topic_cnt as usize,
             )
         }
-    }
-}
-
-impl Drop for Metadata {
-    fn drop(&mut self) {
-        unsafe { rdsys::rd_kafka_metadata_destroy(self.0) };
     }
 }
 


### PR DESCRIPTION
Did a pass through the crate and cleaned up a lot of the logic around drops. The `NativePtr` were added as a small abstraction around an owned ptr and where I could, I moved the allocated ptr into this structure as early as possible to ensure drops were not forgotten.

Fixed a few other small things on the way as well.