### PR TITLE
Require Tokio for stream consumer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ log = "0.4.8"
 serde = { version = "1.0.0", features = ["derive"] }
 serde_derive = "1.0.0"
 serde_json = "1.0.0"
+tokio = { version = "0.2", features = ["rt-core", "time"], optional = true }
 
 [dev-dependencies]
 backoff = "0.1.5"
@@ -31,10 +32,30 @@ rand = "0.3.15"
 regex = "1.1.6"
 tokio = { version = "0.2", features = ["blocking", "macros", "rt-core", "time"] }
 
+[[example]]
+name = "asynchronous_processing"
+required-features = ["tokio"]
+
+[[example]]
+name = "at_least_once"
+required-features = ["tokio"]
+
+[[example]]
+name = "simple_consumer"
+required-features = ["tokio"]
+
+[[test]]
+name = "test_high_consumers"
+required-features = ["tokio"]
+
+[[test]]
+name = "test_metadata"
+required-features = ["tokio"]
+
 # These features are re-exports of the features that the rdkafka-sys crate
 # provides. See the rdkafka-sys documentation for details.
 [features]
-default = ["libz"]
+default = ["libz", "tokio"]
 cmake-build = ["rdkafka-sys/cmake-build"]
 cmake_build = ["rdkafka-sys/cmake_build"]
 dynamic_linking = ["rdkafka-sys/dynamic_linking"]
@@ -53,4 +74,5 @@ external_lz4 = ["rdkafka-sys/external_lz4"]
 [package.metadata.docs.rs]
 # docs.rs doesn't allow writing to ~/.cargo/registry (reasonably), so we have to
 # use the CMake build for a proper out-of-tree build.
-features = ["cmake_build"]
+features = ["cmake_build", "tokio"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/README.md
+++ b/README.md
@@ -62,24 +62,14 @@ High level:
 
 For more information about consumers and producers, refer to their module-level documentation.
 
-[`BaseConsumer`]: https://docs.rs/rdkafka/*/rdkafka/consumer/base_consumer/struct.BaseConsumer.html
-[`BaseProducer`]: https://docs.rs/rdkafka/*/rdkafka/producer/base_producer/struct.BaseProducer.html
-[`ThreadedProducer`]: https://docs.rs/rdkafka/*/rdkafka/producer/base_producer/struct.ThreadedProducer.html
-[`StreamConsumer`]: https://docs.rs/rdkafka/*/rdkafka/consumer/stream_consumer/struct.StreamConsumer.html
-[`FutureProducer`]: https://docs.rs/rdkafka/*/rdkafka/producer/future_producer/struct.FutureProducer.html
-[librdkafka]: https://github.com/edenhill/librdkafka
-[futures]: https://github.com/alexcrichton/futures-rs
-[`future`]: https://docs.rs/futures/0.1.3/futures/trait.Future.html
-[`stream`]: https://docs.rs/futures/0.1.3/futures/stream/trait.Stream.html
-
 *Warning*: the library is under active development and the APIs are likely to change.
 
-### Asynchronous data processing with tokio-rs
-[tokio-rs] is a platform for fast processing of asynchronous events in Rust. The interfaces exposed by the [`StreamConsumer`] and the [`FutureProducer`] allow rust-rdkafka users to easily integrate Kafka consumers and producers within the tokio-rs platform, and write asynchronous message processing code. Note that rust-rdkafka can be used without tokio-rs.
+### Asynchronous data processing with Tokio
+[Tokio] is a platform for fast processing of asynchronous events in Rust. The interfaces exposed by the [`StreamConsumer`] and the [`FutureProducer`] allow rust-rdkafka users to easily integrate Kafka consumers and producers within the Tokio platform, and write asynchronous message processing code. Note that rust-rdkafka can be used without Tokio.
 
-To see rust-rdkafka in action with tokio-rs, check out the [asynchronous processing example] in the examples folder.
+To see rust-rdkafka in action with Tokio, check out the [asynchronous processing example] in the examples folder.
 
-[tokio-rs]: https://tokio.rs/
+[Tokio]: https://tokio.rs/
 [asynchronous processing example]: https://github.com/fede1024/rust-rdkafka/blob/master/examples/asynchronous_processing.rs
 
 ### At-least-once delivery
@@ -146,6 +136,20 @@ rdkafka = { version = "0.23", features = ["dynamic-linking"] }
 For a full listing of features, consult the [rdkafka-sys crate's
 documentation](rdkafka-sys/README.md#features). All of rdkafka-sys features are
 re-exported as rdkafka features.
+
+### Tokio dependency
+
+The [`StreamConsumer`] and [`FutureProducer`] depend on Tokio, which can be a
+heavyweight dependency for users who only intend to use the non-async/await
+consumers or producers.
+
+The `tokio` feature is enabled by default. To disable it, turn off default
+features like so:
+
+```toml
+[dependencies]
+rdkafka = { version = "0.23", default-features = false }
+```
 
 ## Compiling from sources
 
@@ -217,6 +221,16 @@ set the `debug` option in the producer or consumer configuration (see librdkafka
 
 To enable debugging in your project, make sure you initialize the logger with
 `env_logger::init()` or equivalent.
+
+[`BaseConsumer`]: https://docs.rs/rdkafka/*/rdkafka/consumer/base_consumer/struct.BaseConsumer.html
+[`BaseProducer`]: https://docs.rs/rdkafka/*/rdkafka/producer/base_producer/struct.BaseProducer.html
+[`ThreadedProducer`]: https://docs.rs/rdkafka/*/rdkafka/producer/base_producer/struct.ThreadedProducer.html
+[`StreamConsumer`]: https://docs.rs/rdkafka/*/rdkafka/consumer/stream_consumer/struct.StreamConsumer.html
+[`FutureProducer`]: https://docs.rs/rdkafka/*/rdkafka/producer/future_producer/struct.FutureProducer.html
+[librdkafka]: https://github.com/edenhill/librdkafka
+[futures]: https://github.com/alexcrichton/futures-rs
+[`future`]: https://docs.rs/futures/0.1.3/futures/trait.Future.html
+[`stream`]: https://docs.rs/futures/0.1.3/futures/stream/trait.Stream.html
 
 ## rdkafka-sys
 

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,11 @@ See also the [rdkafka-sys changelog](rdkafka-sys/changelog.md).
 <a name="0.24.0"></a>
 ## 0.24.0 (Unreleased)
 
+* **Breaking change.** Introduce a dependency on Tokio for the `StreamConsumer`.
+  The new implementation is more efficient and is backed by a single Tokio task.
+  The old implementation required a separate thread and a separate futures
+  executor.
+
 * Decouple versioning of rdkafka-sys from rdkafka. rdkafka-sys now has its
   own [changelog](rdkafka-sys/changelog.md) and will follow SemVer conventions.
   ([#211])

--- a/src/consumer/mod.rs
+++ b/src/consumer/mod.rs
@@ -17,10 +17,14 @@ use crate::topic_partition_list::{Offset, TopicPartitionList};
 use crate::util::{cstr_to_owned, Timeout};
 
 pub mod base_consumer;
+#[cfg(feature = "tokio")]
+#[cfg_attr(docsrs, doc(cfg(feature = "tokio")))]
 pub mod stream_consumer;
 
 // Re-exports.
 pub use self::base_consumer::BaseConsumer;
+#[cfg(feature = "tokio")]
+#[cfg_attr(docsrs, doc(cfg(feature = "tokio")))]
 pub use self::stream_consumer::{MessageStream, StreamConsumer};
 
 /// Rebalance information.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,9 @@
 //! # rust-rdkafka
+//!
 //! A fully asynchronous, [futures]-based Kafka client library for Rust based on [librdkafka].
 //!
 //! ## The library
-//! `rust-rdkafka` provides a safe Rust interface to librdkafka. The master branch is currently based on librdkafka 0.11.6.
+//! `rust-rdkafka` provides a safe Rust interface to librdkafka. The master branch is currently based on librdkafka 1.3.0.
 //!
 //! ### Documentation
 //!
@@ -55,24 +56,14 @@
 //!
 //! For more information about consumers and producers, refer to their module-level documentation.
 //!
-//! [`BaseConsumer`]: consumer/base_consumer/struct.BaseConsumer.html
-//! [`BaseProducer`]: producer/base_producer/struct.BaseProducer.html
-//! [`ThreadedProducer`]: producer/base_producer/struct.ThreadedProducer.html
-//! [`StreamConsumer`]: consumer/stream_consumer/struct.StreamConsumer.html
-//! [`FutureProducer`]: producer/future_producer/struct.FutureProducer.html
-//! [librdkafka]: https://github.com/edenhill/librdkafka
-//! [futures]: https://github.com/alexcrichton/futures-rs
-//! [`future`]: https://docs.rs/futures/0.1.3/futures/trait.Future.html
-//! [`stream`]: https://docs.rs/futures/0.1.3/futures/stream/trait.Stream.html
-//!
 //! *Warning*: the library is under active development and the APIs are likely to change.
 //!
-//! ### Asynchronous data processing with tokio-rs
-//! [tokio-rs] is a platform for fast processing of asynchronous events in Rust. The interfaces exposed by the [`StreamConsumer`] and the [`FutureProducer`] allow rust-rdkafka users to easily integrate Kafka consumers and producers within the tokio-rs platform, and write asynchronous message processing code. Note that rust-rdkafka can be used without tokio-rs.
+//! ### Asynchronous data processing with Tokio
+//! [Tokio] is a platform for fast processing of asynchronous events in Rust. The interfaces exposed by the [`StreamConsumer`] and the [`FutureProducer`] allow rust-rdkafka users to easily integrate Kafka consumers and producers within the Tokio platform, and write asynchronous message processing code. Note that rust-rdkafka can be used without Tokio.
 //!
-//! To see rust-rdkafka in action with tokio-rs, check out the [asynchronous processing example] in the examples folder.
+//! To see rust-rdkafka in action with Tokio, check out the [asynchronous processing example] in the examples folder.
 //!
-//! [tokio-rs]: https://tokio.rs/
+//! [Tokio]: https://tokio.rs/
 //! [asynchronous processing example]: https://github.com/fede1024/rust-rdkafka/blob/master/examples/asynchronous_processing.rs
 //!
 //! ### At-least-once delivery
@@ -107,33 +98,52 @@
 //!
 //! ```toml
 //! [dependencies]
-//! rdkafka = "~0.21"
+//! rdkafka = { version = "0.23", features = ["cmake-build"] }
 //! ```
 //!
-//! This crate will compile librdkafka from sources and link it statically to your executable. To compile librdkafka you'll need:
+//! This crate will compile librdkafka from sources and link it statically to your
+//! executable. To compile librdkafka you'll need:
 //!
 //! * the GNU toolchain
 //! * GNU `make`
 //! * `pthreads`
-//! * `zlib`
-//! * `libssl-dev`: optional, *not* included by default (feature: `ssl`).
-//! * `libsasl2-dev`: optional, *not* included by default (feature: `sasl`).
+//! * `zlib`: optional, but included by default (feature: `libz`)
+//! * `cmake`: optional, *not* included by default (feature: `cmake-build`)
+//! * `libssl-dev`: optional, *not* included by default (feature: `ssl`)
+//! * `libsasl2-dev`: optional, *not* included by default (feature: `gssapi`)
+//! * `libzstd-dev`: optional, *not* included by default (feature: `zstd-pkg-config`)
 //!
-//! To enable ssl and sasl, use the `features` field in `Cargo.toml`. Example:
+//! Note that using the CMake build system, via the `cmake-build` feature, is
+//! **strongly** encouraged. The default build system has a [known
+//! issue](rdkafka-sys/README.md#known-issues) that can cause corrupted builds.
+//!
+//! By default a submodule with the librdkafka sources pinned to a specific commit
+//! will be used to compile and statically link the library. The `dynamic-linking`
+//! feature can be used to instead dynamically link rdkafka to the system's version
+//! of librdkafka. Example:
 //!
 //! ```toml
-//! [dependencies.rdkafka]
-//! version = "~0.21"
-//! features = ["ssl", "sasl"]
+//! [dependencies]
+//! rdkafka = { version = "0.23", features = ["dynamic-linking"] }
 //! ```
 //!
-//! By default a submodule with the librdkafka sources pinned to a specific commit will
-//! be used to compile and statically link the library.
+//! For a full listing of features, consult the [rdkafka-sys crate's
+//! documentation](rdkafka-sys/README.md#features). All of rdkafka-sys features are
+//! re-exported as rdkafka features.
 //!
-//! The `dynamic_linking` feature can be used to link rdkafka to a locally installed
-//! version of librdkafka: if the feature is enabled, the build script will use `pkg-config`
-//! to check the version of the library installed in the system, and it will configure the
-//! compiler to use dynamic linking.
+//! ### Tokio dependency
+//!
+//! The [`StreamConsumer`] and [`FutureProducer`] depend on Tokio, which can be a
+//! heavyweight dependency for users who only intend to use the non-async/await
+//! consumers or producers.
+//!
+//! The `tokio` feature is enabled by default. To disable it, turn off default
+//! features like so:
+//!
+//! ```toml
+//! [dependencies]
+//! rdkafka = { version = "0.23", default-features = false }
+//! ```
 //!
 //! ## Compiling from sources
 //!
@@ -146,7 +156,7 @@
 //! and then compile using `cargo`, selecting the features that you want. Example:
 //!
 //! ```bash
-//! cargo build --features "ssl sasl"
+//! cargo build --features "ssl gssapi"
 //! ```
 //!
 //! ## Examples
@@ -206,8 +216,18 @@
 //! To enable debugging in your project, make sure you initialize the logger with
 //! `env_logger::init()` or equivalent.
 //!
+//! [`BaseConsumer`]: https://docs.rs/rdkafka/*/rdkafka/consumer/base_consumer/struct.BaseConsumer.html
+//! [`BaseProducer`]: https://docs.rs/rdkafka/*/rdkafka/producer/base_producer/struct.BaseProducer.html
+//! [`ThreadedProducer`]: https://docs.rs/rdkafka/*/rdkafka/producer/base_producer/struct.ThreadedProducer.html
+//! [`StreamConsumer`]: https://docs.rs/rdkafka/*/rdkafka/consumer/stream_consumer/struct.StreamConsumer.html
+//! [`FutureProducer`]: https://docs.rs/rdkafka/*/rdkafka/producer/future_producer/struct.FutureProducer.html
+//! [librdkafka]: https://github.com/edenhill/librdkafka
+//! [futures]: https://github.com/alexcrichton/futures-rs
+//! [`future`]: https://docs.rs/futures/0.1.3/futures/trait.Future.html
+//! [`stream`]: https://docs.rs/futures/0.1.3/futures/stream/trait.Stream.html
 
 #![warn(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub use rdkafka_sys::types;
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -286,6 +286,19 @@ where
     }
 }
 
+pub(crate) struct OnDrop<F>(pub F)
+where
+    F: Fn();
+
+impl<F> Drop for OnDrop<F>
+where
+    F: Fn(),
+{
+    fn drop(&mut self) {
+        (self.0)()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/tests/test_high_consumers.rs
+++ b/tests/test_high_consumers.rs
@@ -1,75 +1,29 @@
-//! Test data consumption using low level and high level consumers.
+//! Test data consumption using high level consumers.
 
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::AtomicUsize;
 use std::sync::Arc;
-use std::thread;
 use std::time::{Duration, Instant};
 
-use futures::{future, StreamExt};
+use futures::future;
+use futures::stream::StreamExt;
 
-use rdkafka::consumer::{BaseConsumer, CommitMode, Consumer, ConsumerContext, StreamConsumer};
-use rdkafka::error::{KafkaError, KafkaResult};
+use rdkafka::consumer::{CommitMode, Consumer, ConsumerContext, StreamConsumer};
+use rdkafka::error::KafkaError;
 use rdkafka::topic_partition_list::{Offset, TopicPartitionList};
 use rdkafka::util::current_time_millis;
-use rdkafka::{ClientConfig, ClientContext, Message, Statistics, Timestamp};
+use rdkafka::{Message, Timestamp};
 
 use crate::utils::*;
 
 mod utils;
 
-struct TestContext {
-    _n: i64, // Add data for memory access validation
-    wakeups: Arc<AtomicUsize>,
-}
-
-impl ClientContext for TestContext {
-    // Access stats
-    fn stats(&self, stats: Statistics) {
-        let stats_str = format!("{:?}", stats);
-        println!("Stats received: {} bytes", stats_str.len());
-    }
-}
-
-impl ConsumerContext for TestContext {
-    fn commit_callback(&self, result: KafkaResult<()>, _offsets: &TopicPartitionList) {
-        println!("Committing offsets: {:?}", result);
-    }
-
-    fn message_queue_nonempty_callback(&self) {
-        self.wakeups.fetch_add(1, Ordering::SeqCst);
-    }
-}
-
-fn consumer_config(group_id: &str, config_overrides: Option<HashMap<&str, &str>>) -> ClientConfig {
-    let mut config = ClientConfig::new();
-
-    config.set("group.id", group_id);
-    config.set("client.id", "rdkafka_integration_test_client");
-    config.set("bootstrap.servers", get_bootstrap_server().as_str());
-    config.set("enable.partition.eof", "false");
-    config.set("session.timeout.ms", "6000");
-    config.set("enable.auto.commit", "false");
-    config.set("statistics.interval.ms", "500");
-    config.set("api.version.request", "true");
-    config.set("debug", "all");
-    config.set("auto.offset.reset", "earliest");
-
-    if let Some(overrides) = config_overrides {
-        for (key, value) in overrides {
-            config.set(key, value);
-        }
-    }
-
-    config
-}
-
 // Create stream consumer for tests
 fn create_stream_consumer(
     group_id: &str,
     config_overrides: Option<HashMap<&str, &str>>,
-) -> StreamConsumer<TestContext> {
-    let cons_context = TestContext {
+) -> StreamConsumer<ConsumerTestContext> {
+    let cons_context = ConsumerTestContext {
         _n: 64,
         wakeups: Arc::new(AtomicUsize::new(0)),
     };
@@ -84,46 +38,6 @@ fn create_stream_consumer_with_context<C: ConsumerContext>(
     consumer_config(group_id, config_overrides)
         .create_with_context(context)
         .expect("Consumer creation failed")
-}
-
-fn create_base_consumer(
-    group_id: &str,
-    config_overrides: Option<HashMap<&str, &str>>,
-) -> BaseConsumer<TestContext> {
-    consumer_config(group_id, config_overrides)
-        .create_with_context(TestContext {
-            _n: 64,
-            wakeups: Arc::new(AtomicUsize::new(0)),
-        })
-        .expect("Consumer creation failed")
-}
-
-// All produced messages should be consumed.
-#[tokio::test]
-async fn test_produce_consume_iter() {
-    let _r = env_logger::try_init();
-
-    let start_time = current_time_millis();
-    let topic_name = rand_test_topic();
-    let message_map = populate_topic(&topic_name, 100, &value_fn, &key_fn, None, None).await;
-    let consumer = create_base_consumer(&rand_test_group(), None);
-    consumer.subscribe(&[topic_name.as_str()]).unwrap();
-
-    for message in consumer.iter().take(100) {
-        match message {
-            Ok(m) => {
-                let id = message_map[&(m.partition(), m.offset())];
-                match m.timestamp() {
-                    Timestamp::CreateTime(timestamp) => assert!(timestamp >= start_time),
-                    _ => panic!("Expected createtime for message timestamp"),
-                };
-                assert_eq!(m.payload_view::<str>().unwrap().unwrap(), value_fn(id));
-                assert_eq!(m.key_view::<str>().unwrap().unwrap(), key_fn(id));
-                assert_eq!(m.topic(), topic_name.as_str());
-            }
-            Err(e) => panic!("Error receiving message: {:?}", e),
-        }
-    }
 }
 
 // All produced messages should be consumed.
@@ -157,39 +71,6 @@ async fn test_produce_consume_base() {
             future::ready(())
         })
         .await;
-}
-
-// Seeking should allow replaying messages and skipping messages.
-#[tokio::test]
-async fn test_produce_consume_seek() {
-    let _r = env_logger::try_init();
-
-    let topic_name = rand_test_topic();
-    populate_topic(&topic_name, 5, &value_fn, &key_fn, Some(0), None).await;
-    let consumer = create_base_consumer(&rand_test_group(), None);
-    consumer.subscribe(&[topic_name.as_str()]).unwrap();
-
-    for (i, message) in consumer.iter().take(3).enumerate() {
-        match message {
-            Ok(message) => assert_eq!(dbg!(message.offset()), i as i64),
-            Err(e) => panic!("Error receiving message: {:?}", e),
-        }
-    }
-
-    consumer
-        .seek(&topic_name, 0, Offset::Offset(1), None)
-        .unwrap();
-
-    for (i, message) in consumer.iter().take(3).enumerate() {
-        match message {
-            Ok(message) => assert_eq!(message.offset(), i as i64 + 1),
-            Err(e) => panic!("Error receiving message: {:?}", e),
-        }
-    }
-
-    consumer.seek(&topic_name, 0, Offset::End, None).unwrap();
-
-    ensure_empty(&consumer, "There should be no messages left");
 }
 
 // All produced messages should be consumed.
@@ -426,128 +307,4 @@ async fn test_consumer_store_offset_commit() {
     position.add_partition_offset(&topic_name, 1, Offset::Offset(11));
     position.add_partition_offset(&topic_name, 2, Offset::Offset(12));
     assert_eq!(position, consumer.position().unwrap());
-}
-
-fn ensure_empty<C: ConsumerContext>(consumer: &BaseConsumer<C>, err_msg: &str) {
-    const MAX_TRY_TIME: Duration = Duration::from_secs(2);
-    let start = Instant::now();
-    while start.elapsed() < MAX_TRY_TIME {
-        assert!(consumer.poll(MAX_TRY_TIME).is_none(), "{}", err_msg);
-    }
-}
-
-#[tokio::test]
-async fn test_pause_resume_consumer_iter() {
-    const PAUSE_COUNT: i32 = 3;
-    const MESSAGE_COUNT: i32 = 300;
-    const MESSAGES_PER_PAUSE: i32 = MESSAGE_COUNT / PAUSE_COUNT;
-
-    let _r = env_logger::try_init();
-
-    let topic_name = rand_test_topic();
-    populate_topic(
-        &topic_name,
-        MESSAGE_COUNT,
-        &value_fn,
-        &key_fn,
-        Some(0),
-        None,
-    )
-    .await;
-    let group_id = rand_test_group();
-    let consumer = create_base_consumer(&group_id, None);
-    consumer.subscribe(&[topic_name.as_str()]).unwrap();
-
-    for _ in 0..PAUSE_COUNT {
-        let mut num_taken = 0;
-        for message in consumer.iter().take(MESSAGES_PER_PAUSE as usize) {
-            message.unwrap();
-            num_taken += 1;
-        }
-        assert_eq!(num_taken, MESSAGES_PER_PAUSE);
-
-        let partitions = consumer.assignment().unwrap();
-        assert!(partitions.count() > 0);
-        consumer.pause(&partitions).unwrap();
-
-        ensure_empty(
-            &consumer,
-            "Partition is paused - we should not receive anything",
-        );
-
-        consumer.resume(&partitions).unwrap();
-    }
-
-    ensure_empty(&consumer, "There should be no messages left");
-}
-
-// All produced messages should be consumed.
-#[tokio::test]
-async fn test_produce_consume_message_queue_nonempty_callback() {
-    let _r = env_logger::try_init();
-
-    let topic_name = rand_test_topic();
-
-    let consumer: BaseConsumer<_> = consumer_config(&rand_test_group(), None)
-        .create_with_context(TestContext {
-            _n: 64,
-            wakeups: Arc::new(AtomicUsize::new(0)),
-        })
-        .expect("Consumer creation failed");
-    consumer.subscribe(&[topic_name.as_str()]).unwrap();
-
-    let wakeups = consumer.context().wakeups.clone();
-    let wait_for_wakeups = |target| {
-        let start = Instant::now();
-        let timeout = Duration::from_secs(15);
-        loop {
-            let w = wakeups.load(Ordering::SeqCst);
-            if w == target {
-                break;
-            } else if w > target {
-                panic!("wakeups {} exceeds target {}", w, target);
-            }
-            thread::sleep(Duration::from_millis(100));
-            if start.elapsed() > timeout {
-                panic!("timeout exceeded while waiting for wakeup");
-            }
-        }
-    };
-
-    // Initiate connection.
-    assert!(consumer.poll(Duration::from_secs(0)).is_none());
-
-    // Expect one initial rebalance callback.
-    wait_for_wakeups(1);
-
-    // Expect no additional wakeups for 1s.
-    std::thread::sleep(Duration::from_secs(1));
-    assert_eq!(wakeups.load(Ordering::SeqCst), 1);
-
-    // Verify there are no messages waiting.
-    assert!(consumer.poll(Duration::from_secs(0)).is_none());
-
-    // Populate the topic, and expect a wakeup notifying us of the new messages.
-    populate_topic(&topic_name, 2, &value_fn, &key_fn, None, None).await;
-    wait_for_wakeups(2);
-
-    // Read one of the messages.
-    assert!(consumer.poll(Duration::from_secs(0)).is_some());
-
-    // Add more messages to the topic. Expect no additional wakeups, as the
-    // queue is not fully drained, for 1s.
-    populate_topic(&topic_name, 2, &value_fn, &key_fn, None, None).await;
-    std::thread::sleep(Duration::from_secs(1));
-    assert_eq!(wakeups.load(Ordering::SeqCst), 2);
-
-    // Drain the consumer.
-    assert_eq!(consumer.iter().take(3).count(), 3);
-
-    // Expect no additional wakeups for 1s.
-    std::thread::sleep(Duration::from_secs(1));
-    assert_eq!(wakeups.load(Ordering::SeqCst), 2);
-
-    // Add another message, and expect a wakeup.
-    populate_topic(&topic_name, 1, &value_fn, &key_fn, None, None).await;
-    wait_for_wakeups(3);
 }

--- a/tests/test_low_consumers.rs
+++ b/tests/test_low_consumers.rs
@@ -1,0 +1,213 @@
+//! Test data consumption using low level consumers.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use rdkafka::consumer::{BaseConsumer, Consumer, ConsumerContext};
+use rdkafka::topic_partition_list::Offset;
+use rdkafka::util::current_time_millis;
+use rdkafka::{Message, Timestamp};
+
+use crate::utils::*;
+
+mod utils;
+
+fn create_base_consumer(
+    group_id: &str,
+    config_overrides: Option<HashMap<&str, &str>>,
+) -> BaseConsumer<ConsumerTestContext> {
+    consumer_config(group_id, config_overrides)
+        .create_with_context(ConsumerTestContext {
+            _n: 64,
+            wakeups: Arc::new(AtomicUsize::new(0)),
+        })
+        .expect("Consumer creation failed")
+}
+
+// Seeking should allow replaying messages and skipping messages.
+#[tokio::test]
+async fn test_produce_consume_seek() {
+    let _r = env_logger::try_init();
+
+    let topic_name = rand_test_topic();
+    populate_topic(&topic_name, 5, &value_fn, &key_fn, Some(0), None).await;
+    let consumer = create_base_consumer(&rand_test_group(), None);
+    consumer.subscribe(&[topic_name.as_str()]).unwrap();
+
+    for (i, message) in consumer.iter().take(3).enumerate() {
+        match message {
+            Ok(message) => assert_eq!(dbg!(message.offset()), i as i64),
+            Err(e) => panic!("Error receiving message: {:?}", e),
+        }
+    }
+
+    consumer
+        .seek(&topic_name, 0, Offset::Offset(1), None)
+        .unwrap();
+
+    for (i, message) in consumer.iter().take(3).enumerate() {
+        match message {
+            Ok(message) => assert_eq!(message.offset(), i as i64 + 1),
+            Err(e) => panic!("Error receiving message: {:?}", e),
+        }
+    }
+
+    consumer.seek(&topic_name, 0, Offset::End, None).unwrap();
+
+    ensure_empty(&consumer, "There should be no messages left");
+}
+
+// All produced messages should be consumed.
+#[tokio::test]
+async fn test_produce_consume_iter() {
+    let _r = env_logger::try_init();
+
+    let start_time = current_time_millis();
+    let topic_name = rand_test_topic();
+    let message_map = populate_topic(&topic_name, 100, &value_fn, &key_fn, None, None).await;
+    let consumer = create_base_consumer(&rand_test_group(), None);
+    consumer.subscribe(&[topic_name.as_str()]).unwrap();
+
+    for message in consumer.iter().take(100) {
+        match message {
+            Ok(m) => {
+                let id = message_map[&(m.partition(), m.offset())];
+                match m.timestamp() {
+                    Timestamp::CreateTime(timestamp) => assert!(timestamp >= start_time),
+                    _ => panic!("Expected createtime for message timestamp"),
+                };
+                assert_eq!(m.payload_view::<str>().unwrap().unwrap(), value_fn(id));
+                assert_eq!(m.key_view::<str>().unwrap().unwrap(), key_fn(id));
+                assert_eq!(m.topic(), topic_name.as_str());
+            }
+            Err(e) => panic!("Error receiving message: {:?}", e),
+        }
+    }
+}
+
+fn ensure_empty<C: ConsumerContext>(consumer: &BaseConsumer<C>, err_msg: &str) {
+    const MAX_TRY_TIME: Duration = Duration::from_secs(2);
+    let start = Instant::now();
+    while start.elapsed() < MAX_TRY_TIME {
+        assert!(consumer.poll(MAX_TRY_TIME).is_none(), "{}", err_msg);
+    }
+}
+
+#[tokio::test]
+async fn test_pause_resume_consumer_iter() {
+    const PAUSE_COUNT: i32 = 3;
+    const MESSAGE_COUNT: i32 = 300;
+    const MESSAGES_PER_PAUSE: i32 = MESSAGE_COUNT / PAUSE_COUNT;
+
+    let _r = env_logger::try_init();
+
+    let topic_name = rand_test_topic();
+    populate_topic(
+        &topic_name,
+        MESSAGE_COUNT,
+        &value_fn,
+        &key_fn,
+        Some(0),
+        None,
+    )
+    .await;
+    let group_id = rand_test_group();
+    let consumer = create_base_consumer(&group_id, None);
+    consumer.subscribe(&[topic_name.as_str()]).unwrap();
+
+    for _ in 0..PAUSE_COUNT {
+        let mut num_taken = 0;
+        for message in consumer.iter().take(MESSAGES_PER_PAUSE as usize) {
+            message.unwrap();
+            num_taken += 1;
+        }
+        assert_eq!(num_taken, MESSAGES_PER_PAUSE);
+
+        let partitions = consumer.assignment().unwrap();
+        assert!(partitions.count() > 0);
+        consumer.pause(&partitions).unwrap();
+
+        ensure_empty(
+            &consumer,
+            "Partition is paused - we should not receive anything",
+        );
+
+        consumer.resume(&partitions).unwrap();
+    }
+
+    ensure_empty(&consumer, "There should be no messages left");
+}
+
+// All produced messages should be consumed.
+#[tokio::test]
+async fn test_produce_consume_message_queue_nonempty_callback() {
+    let _r = env_logger::try_init();
+
+    let topic_name = rand_test_topic();
+
+    let consumer: BaseConsumer<_> = consumer_config(&rand_test_group(), None)
+        .create_with_context(ConsumerTestContext {
+            _n: 64,
+            wakeups: Arc::new(AtomicUsize::new(0)),
+        })
+        .expect("Consumer creation failed");
+    consumer.subscribe(&[topic_name.as_str()]).unwrap();
+
+    let wakeups = consumer.context().wakeups.clone();
+    let wait_for_wakeups = |target| {
+        let start = Instant::now();
+        let timeout = Duration::from_secs(15);
+        loop {
+            let w = wakeups.load(Ordering::SeqCst);
+            if w == target {
+                break;
+            } else if w > target {
+                panic!("wakeups {} exceeds target {}", w, target);
+            }
+            thread::sleep(Duration::from_millis(100));
+            if start.elapsed() > timeout {
+                panic!("timeout exceeded while waiting for wakeup");
+            }
+        }
+    };
+
+    // Initiate connection.
+    assert!(consumer.poll(Duration::from_secs(0)).is_none());
+
+    // Expect one initial rebalance callback.
+    wait_for_wakeups(1);
+
+    // Expect no additional wakeups for 1s.
+    std::thread::sleep(Duration::from_secs(1));
+    assert_eq!(wakeups.load(Ordering::SeqCst), 1);
+
+    // Verify there are no messages waiting.
+    assert!(consumer.poll(Duration::from_secs(0)).is_none());
+
+    // Populate the topic, and expect a wakeup notifying us of the new messages.
+    populate_topic(&topic_name, 2, &value_fn, &key_fn, None, None).await;
+    wait_for_wakeups(2);
+
+    // Read one of the messages.
+    assert!(consumer.poll(Duration::from_secs(0)).is_some());
+
+    // Add more messages to the topic. Expect no additional wakeups, as the
+    // queue is not fully drained, for 1s.
+    populate_topic(&topic_name, 2, &value_fn, &key_fn, None, None).await;
+    std::thread::sleep(Duration::from_secs(1));
+    assert_eq!(wakeups.load(Ordering::SeqCst), 2);
+
+    // Drain the consumer.
+    assert_eq!(consumer.iter().take(3).count(), 3);
+
+    // Expect no additional wakeups for 1s.
+    std::thread::sleep(Duration::from_secs(1));
+    assert_eq!(wakeups.load(Ordering::SeqCst), 2);
+
+    // Add another message, and expect a wakeup.
+    populate_topic(&topic_name, 1, &value_fn, &key_fn, None, None).await;
+    wait_for_wakeups(3);
+}


### PR DESCRIPTION
Requiring Tokio admits a much simpler implementation that does not
require a separate thread or executor. The dependency on Tokio is
optional (on by default) in order to allow folks who are using only the
BaseConsumer to avoid the Tokio dependency.

Fix #192.