### PR TITLE
Restore latency of StreamConsumer after consuming all messages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ env_logger = "0.7.1"
 hdrhistogram = "7.0.0"
 rand = "0.3.15"
 regex = "1.1.6"
-tokio = { version = "0.2", features = ["blocking", "macros", "rt-core", "time"] }
+tokio = { version = "0.2", features = ["blocking", "macros", "rt-threaded", "time"] }
 
 [[example]]
 name = "asynchronous_processing"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ backoff = "0.1.5"
 chrono = "0.4.0"
 clap = "2.18.0"
 env_logger = "0.7.1"
+hdrhistogram = "7.0.0"
 rand = "0.3.15"
 regex = "1.1.6"
 tokio = { version = "0.2", features = ["blocking", "macros", "rt-core", "time"] }

--- a/examples/roundtrip.rs
+++ b/examples/roundtrip.rs
@@ -1,5 +1,5 @@
 use std::convert::TryInto;
-use std::time::{SystemTime, UNIX_EPOCH, Instant, Duration};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use clap::{App, Arg};
 use futures::stream::StreamExt;

--- a/examples/roundtrip.rs
+++ b/examples/roundtrip.rs
@@ -1,0 +1,116 @@
+use std::convert::TryInto;
+use std::time::{SystemTime, UNIX_EPOCH, Instant, Duration};
+
+use clap::{App, Arg};
+use futures::stream::StreamExt;
+use hdrhistogram::Histogram;
+
+use rdkafka::config::ClientConfig;
+use rdkafka::consumer::{Consumer, StreamConsumer};
+use rdkafka::message::Message;
+use rdkafka::producer::{FutureProducer, FutureRecord};
+
+use crate::example_utils::setup_logger;
+
+mod example_utils;
+
+#[tokio::main]
+async fn main() {
+    let matches = App::new("Roundtrip example")
+        .version(option_env!("CARGO_PKG_VERSION").unwrap_or(""))
+        .about("Measures latency between producer and consumer")
+        .arg(
+            Arg::with_name("brokers")
+                .short("b")
+                .long("brokers")
+                .help("Broker list in kafka format")
+                .takes_value(true)
+                .default_value("localhost:9092"),
+        )
+        .arg(
+            Arg::with_name("topic")
+                .long("topic")
+                .help("topic")
+                .takes_value(true)
+                .required(true),
+        )
+        .arg(
+            Arg::with_name("log-conf")
+                .long("log-conf")
+                .help("Configure the logging format (example: 'rdkafka=trace')")
+                .takes_value(true),
+        )
+        .get_matches();
+
+    setup_logger(true, matches.value_of("log-conf"));
+
+    let brokers = matches.value_of("brokers").unwrap();
+    let topic = matches.value_of("topic").unwrap().to_owned();
+
+    let producer: FutureProducer = ClientConfig::new()
+        .set("bootstrap.servers", brokers)
+        .set("message.timeout.ms", "5000")
+        .create()
+        .expect("Producer creation error");
+
+    let consumer: StreamConsumer = ClientConfig::new()
+        .set("bootstrap.servers", brokers)
+        .set("session.timeout.ms", "6000")
+        .set("enable.auto.commit", "false")
+        .set("group.id", "rust-rdkafka-roundtrip-example")
+        .create()
+        .expect("Consumer creation failed");
+    consumer.subscribe(&[&topic]).unwrap();
+
+    tokio::spawn(async move {
+        let mut i = 0_usize;
+        loop {
+            producer
+                .send_result(
+                    FutureRecord::to(&topic)
+                        .key(&i.to_string())
+                        .payload("dummy")
+                        .timestamp(now()),
+                )
+                .unwrap()
+                .await
+                .unwrap()
+                .unwrap();
+            i += 1;
+        }
+    });
+
+    let start = Instant::now();
+    let mut stream = consumer.start();
+    let mut latencies = Histogram::<u64>::new(5).unwrap();
+    println!("Warming up for 10s...");
+    while let Some(message) = stream.next().await {
+        let message = message.unwrap();
+        let then = message.timestamp().to_millis().unwrap();
+        if start.elapsed() < Duration::from_secs(10) {
+            // Warming up.
+        } else if start.elapsed() < Duration::from_secs(20) {
+            if latencies.len() == 0 {
+                println!("Recording for 10s...");
+            }
+            latencies += (now() - then) as u64;
+        } else {
+            break;
+        }
+    }
+
+    println!("measurements: {}", latencies.len());
+    println!("mean latency: {}ms", latencies.mean());
+    println!("p50 latency:  {}ms", latencies.value_at_quantile(0.50));
+    println!("p90 latency:  {}ms", latencies.value_at_quantile(0.90));
+    println!("p99 latency:  {}ms", latencies.value_at_quantile(0.99));
+}
+
+fn now() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_millis()
+        .try_into()
+        .unwrap()
+}

--- a/src/client.rs
+++ b/src/client.rs
@@ -65,7 +65,8 @@ pub trait ClientContext: Send + Sync {
         error!("librdkafka: {}: {}", error, reason);
     }
 
-    // NOTE: when adding a new method, remember to add it to the FutureProducerContext as well.
+    // NOTE: when adding a new method, remember to add it to the
+    // StreamConsumerContext and FutureProducerContext as well.
     // https://github.com/rust-lang/rfcs/pull/1406 will maybe help in the future.
 }
 

--- a/src/consumer/base_consumer.rs
+++ b/src/consumer/base_consumer.rs
@@ -122,6 +122,11 @@ impl<C: ConsumerContext> FromClientConfigAndContext<C> for BaseConsumer<C> {
 }
 
 impl<C: ConsumerContext> BaseConsumer<C> {
+    /// Returns the client underlying this consumer.
+    pub fn client(&self) -> &Client<C> {
+        &self.client
+    }
+
     /// Returns the context used to create this consumer.
     pub fn context(&self) -> &C {
         self.client.context()

--- a/src/consumer/mod.rs
+++ b/src/consumer/mod.rs
@@ -117,6 +117,9 @@ pub trait ConsumerContext: ClientContext {
     /// Message queue nonempty callback. This method will run when the
     /// consumer's message queue switches from empty to nonempty.
     fn message_queue_nonempty_callback(&self) {}
+
+    // NOTE: when adding a new method, remember to add it to the
+    // StreamConsumerContext as well.
 }
 
 /// An empty consumer context that can be user when no context is needed.


### PR DESCRIPTION
PR #251 introduced a performance regression in that the new
StreamConsumer implementation could take up to 100ms to notice new
messages after reaching the end of the librdkafka consumer queue.

Rewrite the StreamConsumer to avoid this behavior. By using the
message_queue_nonempty callback, we can poll librdkafka from the same
task that is calling MessageStream.poll, and schedule a wakeup when new
data becomes available.

The latency numbers are now indistinguishable from the implementation
before #251, as measured by the new "roundtrip" example. (Both before
and after report a p99 latency of 2ms, while the implementation in #251
reports a p99 latency of 100ms.)

/cc @redbaron I believe this resolves one of your concerns.