### PR TITLE
Use string environment declarations in docker-compose.yml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,17 +4,17 @@ services:
   kafka:
     image: confluentinc/cp-kafka:${CONFLUENT_VERSION:-5.3.1}
     environment:
-      KAFKA_BROKER_ID: 0
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
-      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
-      KAFKA_NUM_PARTITIONS: 3
-      CONFLUENT_SUPPORT_METRICS_ENABLE: 0
+      - KAFKA_BROKER_ID=0
+      - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
+      - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://localhost:9092
+      - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
+      - KAFKA_NUM_PARTITIONS=3
+      - CONFLUENT_SUPPORT_METRICS_ENABLE=0
     ports: ["9092:9092"]
     links: [zookeeper]
 
   zookeeper:
     image: confluentinc/cp-zookeeper:${CONFLUENT_VERSION:-5.3.1}
     environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
+      - ZOOKEEPER_CLIENT_PORT=2181
     ports: ["2181:2181"]


### PR DESCRIPTION
For compatibility with podman-compose. Note that we do not intend to
support podman-compose in general, if there are other incompatibilities,
but this change is straightforward enough to be worthwhile.

Fix #242.