### PR TITLE
Simplify stream consumer, restore support for runtimes other than tokio

### DIFF
--- a/src/consumer/base_consumer.rs
+++ b/src/consumer/base_consumer.rs
@@ -222,6 +222,10 @@ impl<C: ConsumerContext> Consumer<C> for BaseConsumer<C> {
         self
     }
 
+    fn client(&self) -> &Client<C> {
+        &self.client
+    }
+
     fn subscribe(&self, topics: &[&str]) -> KafkaResult<()> {
         let mut tpl = TopicPartitionList::new();
         for topic in topics {

--- a/src/consumer/mod.rs
+++ b/src/consumer/mod.rs
@@ -17,15 +17,11 @@ use crate::topic_partition_list::{Offset, TopicPartitionList};
 use crate::util::{cstr_to_owned, Timeout};
 
 pub mod base_consumer;
-#[cfg(feature = "tokio")]
-#[cfg_attr(docsrs, doc(cfg(feature = "tokio")))]
 pub mod stream_consumer;
 
 // Re-exports.
 pub use self::base_consumer::BaseConsumer;
-#[cfg(feature = "tokio")]
-#[cfg_attr(docsrs, doc(cfg(feature = "tokio")))]
-pub use self::stream_consumer::{MessageStream, StreamConsumer};
+pub use self::stream_consumer::StreamConsumer;
 
 /// Rebalance information.
 #[derive(Clone, Debug)]


### PR DESCRIPTION
This simplifies consumer to become a single straightforward Stream with no background tasks.
    
Mandatroy polls on set intervals are implemented using heartbeat_poll combinator, where every time
stream is Pending timer is armed, which when fired polls stream again.
    
Previous StreamConsumer::{start,start_with} are now feature gated. New generic method start_with_heartbeat is  introduced. It workes with any runtime capable of handling timers.