### PR TITLE
Fix blocking behavior of FutureProducer::send

### DIFF
--- a/examples/asynchronous_processing.rs
+++ b/examples/asynchronous_processing.rs
@@ -102,12 +102,11 @@ async fn run_async_processor(
                     FutureRecord::to(&output_topic)
                         .key("some key")
                         .payload(&computation_result),
-                    0,
+                    Duration::from_secs(0),
                 );
                 match produce_future.await {
-                    Ok(Ok(delivery)) => println!("Sent: {:?}", delivery),
-                    Ok(Err((e, _))) => println!("Error: {:?}", e),
-                    Err(_) => println!("Future cancelled"),
+                    Ok(delivery) => println!("Sent: {:?}", delivery),
+                    Err((e, _)) => println!("Error: {:?}", e),
                 }
             });
             Ok(())

--- a/examples/at_least_once.rs
+++ b/examples/at_least_once.rs
@@ -11,6 +11,8 @@
 //! For a simpler example of consumers and producers, check the `simple_consumer` and
 //! `simple_producer` files in the example folder.
 
+use std::time::Duration;
+
 use clap::{App, Arg};
 use futures::future;
 use futures::stream::StreamExt;
@@ -158,7 +160,7 @@ async fn main() {
                     if let Some(k) = m.key() {
                         record = record.key(k);
                     }
-                    producer.send(record, 1000)
+                    producer.send(record, Duration::from_secs(1))
                 }))
                 .await
                 .expect("Message delivery failed for some topic");

--- a/src/producer/mod.rs
+++ b/src/producer/mod.rs
@@ -114,10 +114,14 @@
 //!
 
 pub mod base_producer;
+#[cfg(feature = "tokio")]
+#[cfg_attr(docsrs, doc(cfg(feature = "tokio")))]
 pub mod future_producer;
 
 pub use self::base_producer::{
     BaseProducer, BaseRecord, DefaultProducerContext, DeliveryResult, ProducerContext,
     ThreadedProducer,
 };
+#[cfg(feature = "tokio")]
+#[cfg_attr(docsrs, doc(cfg(feature = "tokio")))]
 pub use self::future_producer::{DeliveryFuture, FutureProducer, FutureRecord};

--- a/tests/test_high_producers.rs
+++ b/tests/test_high_producers.rs
@@ -1,11 +1,13 @@
 //! Test data production using high level producers.
 
 use std::collections::HashMap;
+use std::time::{Duration, Instant};
 
 use futures::stream::{FuturesUnordered, StreamExt};
 
 use rdkafka::client::DefaultClientContext;
 use rdkafka::config::ClientConfig;
+use rdkafka::error::{KafkaError, RDKafkaError};
 use rdkafka::message::{Headers, Message, OwnedHeaders};
 use rdkafka::producer::future_producer::FutureRecord;
 use rdkafka::producer::FutureProducer;
@@ -34,7 +36,7 @@ async fn test_future_producer_send() {
         .map(|_| {
             producer.send(
                 FutureRecord::to(&topic_name).payload("A").key("B"),
-                0,
+                Duration::from_secs(0),
             )
         })
         .collect();
@@ -42,10 +44,54 @@ async fn test_future_producer_send() {
     let results: Vec<_> = results.collect().await;
     assert!(results.len() == 10);
     for (i, result) in results.into_iter().enumerate() {
-        let (partition, offset) = result.unwrap().unwrap();
+        let (partition, offset) = result.unwrap();
         assert_eq!(partition, 1);
         assert_eq!(offset, i as i64);
     }
+}
+
+#[tokio::test]
+async fn test_future_producer_send_full() {
+    // Connect to a nonexistent Kafka broker with no message timeout and a tiny
+    // producer queue, so we can permanently fill up the queue by sending a
+    // single message.
+    let mut config = HashMap::new();
+    config.insert("bootstrap.servers", "");
+    config.insert("message.timeout.ms", "0");
+    config.insert("queue.buffering.max.messages", "1");
+    let producer = &future_producer(config);
+    let topic_name = &rand_test_topic();
+
+    // Fill up the queue.
+    producer
+        .send_result(FutureRecord::to(&topic_name).payload("A").key("B"))
+        .unwrap();
+
+    let send_message = |timeout| async move {
+        let start = Instant::now();
+        let res = producer
+            .send(
+                FutureRecord::to(&topic_name).payload("A").key("B"),
+                timeout,
+            )
+            .await;
+        match res {
+            Ok(_) => panic!("send unexpectedly succeeded"),
+            Err((KafkaError::MessageProduction(RDKafkaError::QueueFull), _)) => start.elapsed(),
+            Err((e, _)) => panic!("got incorrect error: {}", e),
+        }
+    };
+
+    // Sending a message with no timeout should return a `QueueFull` error
+    // approximately immediately.
+    let elapsed = send_message(Duration::from_secs(0)).await;
+    assert!(elapsed < Duration::from_millis(10));
+
+    // Sending a message with a 1s timeout should return a `QueueFull` error
+    // in about 1s.
+    let elapsed = send_message(Duration::from_secs(1)).await;
+    assert!(elapsed > Duration::from_millis(800));
+    assert!(elapsed < Duration::from_millis(1200));
 }
 
 #[tokio::test]
@@ -63,11 +109,11 @@ async fn test_future_producer_send_fail() {
                     .add("1", "B")
                     .add("2", "C"),
             ),
-        10000,
+        Duration::from_secs(10),
     );
 
     match future.await {
-        Ok(Err((kafka_error, owned_message))) => {
+        Err((kafka_error, owned_message)) => {
             assert_eq!(
                 kafka_error.to_string(),
                 "Message production error: UnknownPartition (Local: Unknown partition)"


### PR DESCRIPTION
@FSMaxB-dooshop I incorporated your fix from #222 here, along with a rewrite to use `tokio::time::delay_for` rather than `std::thread::sleep`. Let me know what you think. I added one test so far for the successful case (which was evidently totally untested before), but I'm going to try to add another test for the `QueueFull` case before merging.

----

The `block_ms` parameter of `FutureProducer::send` was previously buggy,
and did not behave at all as the documentation claimed. Make several
improvements:

  * Rename the parameter to `queue_timeout`, to better reflect its
    purpose in retrying only the queue phase (not the entire send).

  * Adjust the type from an `i64` representing milliseconds to
    `util::Timeout`, for better consistency with other APIs that allow
    configurable timeouts.

  * Use `tokio::time::delay_for` internally rather than blocking the
    thread with `std::time::sleep`, as the latter is not acceptable in
    asynchronous code.

Closes #222.