### PR TITLE
Introduce AsyncRuntime trait to allow pluggable async runtimes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,6 @@ jobs:
   - os: linux
     arch: amd64
     rust: stable
-  - os: linux
-    arch: amd64
-    rust: nightly-2020-05-17
     env: RDKAFKA_RUN_TESTS=1
   - os: linux
     arch: arm64

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ env_logger = "0.7.1"
 hdrhistogram = "7.0.0"
 rand = "0.3.15"
 regex = "1.1.6"
+smol = { version = "0.1.7" }
 tokio = { version = "0.2", features = ["blocking", "macros", "rt-threaded", "time"] }
 
 [[example]]
@@ -39,6 +40,10 @@ required-features = ["tokio"]
 
 [[example]]
 name = "at_least_once"
+required-features = ["tokio"]
+
+[[example]]
+name = "roundtrip"
 required-features = ["tokio"]
 
 [[example]]

--- a/changelog.md
+++ b/changelog.md
@@ -33,6 +33,15 @@ See also the [rdkafka-sys changelog](rdkafka-sys/changelog.md).
   Thanks to [@FSMaxB-dooshop] for discovering the issue and contributing the
   initial fix.
 
+* Introduce the `StreamConsumer::start_with_runtime` and
+  `FutureProducer::send_with_runtime` methods. These methods are identical to
+  their respective non-`_with_runtime` counterparts, except that they take
+  an additional `AsyncRuntime` generic parameter that permits using an
+  asynchronous runtime besides Tokio.
+
+  For an example of using rdkafka with the [smol] runtime, see the
+  new [smol_runtime] example.
+
 * **Breaking change.** Remove the `util::duration_to_millis` function. This
   functionality is now available in the standard library as
   [`std::time::Duration::as_millis`].
@@ -46,6 +55,8 @@ See also the [rdkafka-sys changelog](rdkafka-sys/changelog.md).
 
 [#211]: https://github.com/fede1024/rust-rdkafka/issues/211
 [`std::time::Duration::as_millis`]: https://doc.rust-lang.org/stable/std/time/struct.Duration.html#method.as_millis
+[smol_runtime]: https://github.com/fede1024/rust-rdkafka/tree/master/examples/smol_runtime.rs
+[smol]: docs.rs/smol
 
 [@FSMaxB-dooshop]: https://github.com/FSMaxB-dooshop
 

--- a/examples/smol_runtime.rs
+++ b/examples/smol_runtime.rs
@@ -1,0 +1,118 @@
+use std::future::Future;
+use std::process;
+use std::time::{Duration, Instant};
+
+use clap::{App, Arg};
+use futures::future::{self, FutureExt};
+use futures::stream::StreamExt;
+
+use rdkafka::config::ClientConfig;
+use rdkafka::consumer::{Consumer, StreamConsumer};
+use rdkafka::message::Message;
+use rdkafka::producer::{FutureProducer, FutureRecord};
+use rdkafka::util::AsyncRuntime;
+
+use crate::example_utils::setup_logger;
+
+mod example_utils;
+
+pub struct SmolRuntime;
+
+impl AsyncRuntime for SmolRuntime {
+    type Delay = future::Map<smol::Timer, fn(Instant)>;
+
+    fn spawn<T>(task: T)
+    where
+        T: Future<Output = ()> + Send + 'static,
+    {
+        smol::Task::spawn(task).detach()
+    }
+
+    fn delay_for(duration: Duration) -> Self::Delay {
+        smol::Timer::after(duration).map(|_| ())
+    }
+}
+
+fn main() {
+    let matches = App::new("smol runtime example")
+        .version(option_env!("CARGO_PKG_VERSION").unwrap_or(""))
+        .about("Demonstrates using rust-rdkafka with a custom async runtime")
+        .arg(
+            Arg::with_name("brokers")
+                .short("b")
+                .long("brokers")
+                .help("Broker list in kafka format")
+                .takes_value(true)
+                .default_value("localhost:9092"),
+        )
+        .arg(
+            Arg::with_name("topic")
+                .long("topic")
+                .help("topic")
+                .takes_value(true)
+                .required(true),
+        )
+        .arg(
+            Arg::with_name("log-conf")
+                .long("log-conf")
+                .help("Configure the logging format (example: 'rdkafka=trace')")
+                .takes_value(true),
+        )
+        .get_matches();
+
+    setup_logger(true, matches.value_of("log-conf"));
+
+    let brokers = matches.value_of("brokers").unwrap();
+    let topic = matches.value_of("topic").unwrap().to_owned();
+
+    let producer: FutureProducer = ClientConfig::new()
+        .set("bootstrap.servers", brokers)
+        .set("message.timeout.ms", "5000")
+        .create()
+        .expect("Producer creation error");
+
+    let consumer: StreamConsumer = ClientConfig::new()
+        .set("bootstrap.servers", brokers)
+        .set("session.timeout.ms", "6000")
+        .set("enable.auto.commit", "false")
+        .set("auto.offset.reset", "earliest")
+        .set("group.id", "rust-rdkafka-smol-runtime-example")
+        .create()
+        .expect("Consumer creation failed");
+    consumer.subscribe(&[&topic]).unwrap();
+
+    smol::run(async {
+        let delivery_status = producer
+            .send_with_runtime::<SmolRuntime, Vec<u8>, _, _>(
+                FutureRecord::to(&topic).payload("hello from smol"),
+                Duration::from_secs(0),
+            )
+            .await;
+        if let Err((e, _)) = delivery_status {
+            eprintln!("unable to send message: {}", e);
+            process::exit(1);
+        }
+
+        let mut stream =
+            consumer.start_with_runtime::<SmolRuntime>(Duration::from_millis(100), false);
+        let message = stream.next().await;
+        match message {
+            Some(Ok(message)) => println!(
+                "Received message: {}",
+                match message.payload_view::<str>() {
+                    None => "",
+                    Some(Ok(s)) => s,
+                    Some(Err(_)) => "<invalid utf-8>",
+                }
+            ),
+            Some(Err(e)) => {
+                eprintln!("Error receiving message: {}", e);
+                process::exit(1);
+            }
+            None => {
+                eprintln!("Consumer unexpectedly returned no messages");
+                process::exit(1);
+            }
+        }
+    })
+}

--- a/rdkafka.suppressions
+++ b/rdkafka.suppressions
@@ -9,3 +9,19 @@
    fun:allocate_stack
    fun:pthread_create@@GLIBC_2.2.5
 }
+
+# https://github.com/tokio-rs/tokio/issues/2535
+{
+   tokio_timer
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   fun:_ZN5alloc5alloc5alloc17he087c7e38f51d006E
+   fun:_ZN62_$LT$alloc..alloc..Global$u20$as$u20$core..alloc..AllocRef$GT$5alloc17hccff2ce3ae1a6272E
+   fun:_ZN5alloc5alloc15exchange_malloc17h80754a3a25ff9f9cE
+   fun:_ZN5alloc4sync12Arc$LT$T$GT$3new17hd2c2cfd0c7bd83c0E
+   fun:_ZN5tokio4time6driver15Driver$LT$T$GT$3new17h9c908d59f58cfa85E
+   fun:_ZN5tokio7runtime4time7variant13create_driver17h16ae8147c345bc34E
+   fun:_ZN5tokio7runtime7builder7Builder22build_threaded_runtime17hf039db4dbf147207E
+   fun:_ZN5tokio7runtime7builder7Builder5build17h17906686f002965aE
+}

--- a/src/consumer/mod.rs
+++ b/src/consumer/mod.rs
@@ -17,14 +17,10 @@ use crate::topic_partition_list::{Offset, TopicPartitionList};
 use crate::util::{cstr_to_owned, Timeout};
 
 pub mod base_consumer;
-#[cfg(feature = "tokio")]
-#[cfg_attr(docsrs, doc(cfg(feature = "tokio")))]
 pub mod stream_consumer;
 
 // Re-exports.
 pub use self::base_consumer::BaseConsumer;
-#[cfg(feature = "tokio")]
-#[cfg_attr(docsrs, doc(cfg(feature = "tokio")))]
 pub use self::stream_consumer::{MessageStream, StreamConsumer};
 
 /// Rebalance information.

--- a/src/producer/mod.rs
+++ b/src/producer/mod.rs
@@ -114,14 +114,10 @@
 //!
 
 pub mod base_producer;
-#[cfg(feature = "tokio")]
-#[cfg_attr(docsrs, doc(cfg(feature = "tokio")))]
 pub mod future_producer;
 
 pub use self::base_producer::{
     BaseProducer, BaseRecord, DefaultProducerContext, DeliveryResult, ProducerContext,
     ThreadedProducer,
 };
-#[cfg(feature = "tokio")]
-#[cfg_attr(docsrs, doc(cfg(feature = "tokio")))]
 pub use self::future_producer::{DeliveryFuture, FutureProducer, FutureRecord};

--- a/test_suite.sh
+++ b/test_suite.sh
@@ -11,7 +11,7 @@ git submodule update --init
 cargo test --no-run
 
 run_with_valgrind() {
-    if ! valgrind --error-exitcode=100 --suppressions=rdkafka.suppressions --leak-check=full "$1" --nocapture
+    if ! valgrind --error-exitcode=100 --suppressions=rdkafka.suppressions --leak-check=full "$1" --nocapture --test-threads=1
     then
         echo -e "${RED}*** Failure in $1 ***${NC}"
         exit 1
@@ -51,6 +51,12 @@ run_tests() {
         fi
     done
     echo -e "${GREEN}*** Integration tests succeeded ***${NC}"
+
+    # SMOL RUNTIME EXAMPLE
+
+    echo -e "${GREEN}*** Run smol_runtime example ***${NC}"
+    cargo run --example smol_runtime --no-default-features --features cmake-build -- --topic smol
+    echo -e "${GREEN}*** smol_runtime example succeeded ***${NC}"
 }
 
 run_tests 5.3.1 2.3

--- a/tests/test_high_producers.rs
+++ b/tests/test_high_producers.rs
@@ -70,10 +70,7 @@ async fn test_future_producer_send_full() {
     let send_message = |timeout| async move {
         let start = Instant::now();
         let res = producer
-            .send(
-                FutureRecord::to(&topic_name).payload("A").key("B"),
-                timeout,
-            )
+            .send(FutureRecord::to(&topic_name).payload("A").key("B"), timeout)
             .await;
         match res {
             Ok(_) => panic!("send unexpectedly succeeded"),


### PR DESCRIPTION
This is an alternative to #256 I had in the works that does not require rewriting the `StreamConsumer`.

----

rdkafka only depends on Tokio for tokio::time::delay_for and
tokio::task::spawn. It is easy enough to package those up into a trait
so that users can swap in an asynchronous runtime of their choosing.

By default we only supply an implementation of AsyncRuntime for Tokio,
and only if the `tokio` feature is enabled, but this patch introduces an
example that uses the smol runtime. If some of these other runtimes
prove to be popular we can look into shipping "official" AsyncRuntime
implementations for those runtimes behind feature flags.