### PR TITLE
Add Offset::OffsetTail

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -74,6 +74,19 @@ See also the [rdkafka-sys changelog](rdkafka-sys/changelog.md).
     producers to a new `Producer` trait. This trait is analogous to the
     `Consumer` trait.
 
+* **Breaking change.** Several `TopicPartitionList`-related methods now return
+  `Result<T, KafkaError>` rather than `T`:
+
+  * `TopicPartitionListElem::set_offset`
+  * `TopicPartitionList::from_topic_map`
+  * `TopicPartitionList::add_partition_offset`
+  * `TopicPartitionList::set_all_offsets`
+
+  This was necessary to properly throw errors when an `Offset` passed to one
+  of these methods is representable in Rust but not in C.
+
+* Support end-relative offsets via `Offset::OffsetTail`.
+
 * Fix stalls when using multiple `MessageStream`s simultaneously.
 
   Thanks to [@Marwes] for discovering the issue and contributing the initial

--- a/tests/test_high_consumers.rs
+++ b/tests/test_high_consumers.rs
@@ -142,9 +142,12 @@ async fn test_produce_consume_base_assign() {
     populate_topic(&topic_name, 10, &value_fn, &key_fn, Some(2), None).await;
     let consumer = create_stream_consumer(&rand_test_group(), None);
     let mut tpl = TopicPartitionList::new();
-    tpl.add_partition_offset(&topic_name, 0, Offset::Beginning);
-    tpl.add_partition_offset(&topic_name, 1, Offset::Offset(2));
-    tpl.add_partition_offset(&topic_name, 2, Offset::Offset(9));
+    tpl.add_partition_offset(&topic_name, 0, Offset::Beginning)
+        .unwrap();
+    tpl.add_partition_offset(&topic_name, 1, Offset::Offset(2))
+        .unwrap();
+    tpl.add_partition_offset(&topic_name, 2, Offset::Offset(9))
+        .unwrap();
     consumer.assign(&tpl).unwrap();
 
     let mut partition_count = vec![0, 0, 0];
@@ -248,21 +251,39 @@ async fn test_consumer_commit_message() {
     );
 
     let mut assignment = TopicPartitionList::new();
-    assignment.add_partition_offset(&topic_name, 0, Offset::Invalid);
-    assignment.add_partition_offset(&topic_name, 1, Offset::Invalid);
-    assignment.add_partition_offset(&topic_name, 2, Offset::Invalid);
+    assignment
+        .add_partition_offset(&topic_name, 0, Offset::Invalid)
+        .unwrap();
+    assignment
+        .add_partition_offset(&topic_name, 1, Offset::Invalid)
+        .unwrap();
+    assignment
+        .add_partition_offset(&topic_name, 2, Offset::Invalid)
+        .unwrap();
     assert_eq!(assignment, consumer.assignment().unwrap());
 
     let mut committed = TopicPartitionList::new();
-    committed.add_partition_offset(&topic_name, 0, Offset::Invalid);
-    committed.add_partition_offset(&topic_name, 1, Offset::Offset(11));
-    committed.add_partition_offset(&topic_name, 2, Offset::Invalid);
+    committed
+        .add_partition_offset(&topic_name, 0, Offset::Invalid)
+        .unwrap();
+    committed
+        .add_partition_offset(&topic_name, 1, Offset::Offset(11))
+        .unwrap();
+    committed
+        .add_partition_offset(&topic_name, 2, Offset::Invalid)
+        .unwrap();
     assert_eq!(committed, consumer.committed(timeout).unwrap());
 
     let mut position = TopicPartitionList::new();
-    position.add_partition_offset(&topic_name, 0, Offset::Offset(10));
-    position.add_partition_offset(&topic_name, 1, Offset::Offset(11));
-    position.add_partition_offset(&topic_name, 2, Offset::Offset(12));
+    position
+        .add_partition_offset(&topic_name, 0, Offset::Offset(10))
+        .unwrap();
+    position
+        .add_partition_offset(&topic_name, 1, Offset::Offset(11))
+        .unwrap();
+    position
+        .add_partition_offset(&topic_name, 2, Offset::Offset(12))
+        .unwrap();
     assert_eq!(position, consumer.position().unwrap());
 }
 
@@ -315,20 +336,38 @@ async fn test_consumer_store_offset_commit() {
     );
 
     let mut assignment = TopicPartitionList::new();
-    assignment.add_partition_offset(&topic_name, 0, Offset::Invalid);
-    assignment.add_partition_offset(&topic_name, 1, Offset::Invalid);
-    assignment.add_partition_offset(&topic_name, 2, Offset::Invalid);
+    assignment
+        .add_partition_offset(&topic_name, 0, Offset::Invalid)
+        .unwrap();
+    assignment
+        .add_partition_offset(&topic_name, 1, Offset::Invalid)
+        .unwrap();
+    assignment
+        .add_partition_offset(&topic_name, 2, Offset::Invalid)
+        .unwrap();
     assert_eq!(assignment, consumer.assignment().unwrap());
 
     let mut committed = TopicPartitionList::new();
-    committed.add_partition_offset(&topic_name, 0, Offset::Invalid);
-    committed.add_partition_offset(&topic_name, 1, Offset::Offset(11));
-    committed.add_partition_offset(&topic_name, 2, Offset::Invalid);
+    committed
+        .add_partition_offset(&topic_name, 0, Offset::Invalid)
+        .unwrap();
+    committed
+        .add_partition_offset(&topic_name, 1, Offset::Offset(11))
+        .unwrap();
+    committed
+        .add_partition_offset(&topic_name, 2, Offset::Invalid)
+        .unwrap();
     assert_eq!(committed, consumer.committed(timeout).unwrap());
 
     let mut position = TopicPartitionList::new();
-    position.add_partition_offset(&topic_name, 0, Offset::Offset(10));
-    position.add_partition_offset(&topic_name, 1, Offset::Offset(11));
-    position.add_partition_offset(&topic_name, 2, Offset::Offset(12));
+    position
+        .add_partition_offset(&topic_name, 0, Offset::Offset(10))
+        .unwrap();
+    position
+        .add_partition_offset(&topic_name, 1, Offset::Offset(11))
+        .unwrap();
+    position
+        .add_partition_offset(&topic_name, 2, Offset::Offset(12))
+        .unwrap();
     assert_eq!(position, consumer.position().unwrap());
 }

--- a/tests/test_transactions.rs
+++ b/tests/test_transactions.rs
@@ -74,7 +74,7 @@ async fn test_transaction_abort() -> Result<(), Box<dyn Error>> {
 
     // Commit the first 10 messages.
     let mut commit_tpl = TopicPartitionList::new();
-    commit_tpl.add_partition_offset(&consume_topic, 0, Offset::Offset(10));
+    commit_tpl.add_partition_offset(&consume_topic, 0, Offset::Offset(10))?;
     consumer.commit(&commit_tpl, CommitMode::Sync).unwrap();
 
     // Create a producer and start a transaction.
@@ -85,7 +85,7 @@ async fn test_transaction_abort() -> Result<(), Box<dyn Error>> {
     // Tie the commit of offset 20 to the transaction.
     let cgm = consumer.group_metadata().unwrap();
     let mut txn_tpl = TopicPartitionList::new();
-    txn_tpl.add_partition_offset(&consume_topic, 0, Offset::Offset(20));
+    txn_tpl.add_partition_offset(&consume_topic, 0, Offset::Offset(20))?;
     producer.send_offsets_to_transaction(&txn_tpl, &cgm, Timeout::Never)?;
 
     // Produce 10 records in the transaction.
@@ -142,7 +142,7 @@ async fn test_transaction_commit() -> Result<(), Box<dyn Error>> {
 
     // Commit the first 10 messages.
     let mut commit_tpl = TopicPartitionList::new();
-    commit_tpl.add_partition_offset(&consume_topic, 0, Offset::Offset(10));
+    commit_tpl.add_partition_offset(&consume_topic, 0, Offset::Offset(10))?;
     consumer.commit(&commit_tpl, CommitMode::Sync).unwrap();
 
     // Create a producer and start a transaction.
@@ -153,7 +153,7 @@ async fn test_transaction_commit() -> Result<(), Box<dyn Error>> {
     // Tie the commit of offset 20 to the transaction.
     let cgm = consumer.group_metadata().unwrap();
     let mut txn_tpl = TopicPartitionList::new();
-    txn_tpl.add_partition_offset(&consume_topic, 0, Offset::Offset(20));
+    txn_tpl.add_partition_offset(&consume_topic, 0, Offset::Offset(20))?;
     producer.send_offsets_to_transaction(&txn_tpl, &cgm, Timeout::Never)?;
 
     // Produce 10 records in the transaction.


### PR DESCRIPTION
This allows specifying negative offsets reading from the end of a partition. It mirrors what the `RD_KAFKA_OFFSET_TAIL` macro does in the C lib.

Unfortunately I wasn't able to fully run all tests because `test_topics` topic fails for me (also on master without my changes applied) with a timeout error despite me having a Kafka instance listening on `localhost:9092`.

Let me know if you want me to change anything!