### PR TITLE
add get_fatal_error, closes #279

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -168,7 +168,8 @@ impl fmt::Display for KafkaError {
 
 impl error::Error for KafkaError {
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
-        self.rdkafka_error().map(|e| e as &(dyn error::Error + 'static))
+        self.rdkafka_error()
+            .map(|e| e as &(dyn error::Error + 'static))
     }
 }
 


### PR DESCRIPTION
Add `get_fatal_error` to the `Client` and expose it to consumers and producers for easy access