### PR TITLE
feat: Allow concurrent use of StreamConsumer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ log = "0.4.8"
 serde = { version = "1.0.0", features = ["derive"] }
 serde_derive = "1.0.0"
 serde_json = "1.0.0"
+slab = "0.4"
 tokio = { version = "0.3", features = ["rt", "time"], optional = true }
 
 [dev-dependencies]

--- a/src/consumer/base_consumer.rs
+++ b/src/consumer/base_consumer.rs
@@ -49,7 +49,7 @@ unsafe extern "C" fn native_rebalance_cb<C: ConsumerContext>(
     opaque_ptr: *mut c_void,
 ) {
     let context = &mut *(opaque_ptr as *mut C);
-    let native_client = NativeClient::from_ptr(rk);
+    let native_client = NativeClient::from_ptr(rk).unwrap();
     let mut tpl = TopicPartitionList::from_ptr(native_tpl);
 
     context.rebalance(&native_client, err, &mut tpl);


### PR DESCRIPTION
Before, each concurrent consumer would overwrite the earlier set waker
so only one task at a time would be awoken. By changing this to a Slab
where each `MessageStream` has its own slot, which is recycled on drop,
we can start multiple `MessageStream`s which concurrently polls kafka
and all get woken up when new messages arrive.

Based on #291 since these conflict (unfortunately, the recv method added there now needs to lock the context at least three times per poll, didn't see a good way to correct that without breaking changes however).