### PR TITLE
Vastly simplify StreamConsumer API

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,23 @@ See also the [rdkafka-sys changelog](rdkafka-sys/changelog.md).
   rust-rdkafka map to types in librdkafka as directly as possible. The
   maintainers apologize for the difficulty in upgrading through this change.
 
+* **Breaking change.** Simplify the `StreamConsumer` API. The `StreamConsumer`
+  type now implements [`Stream`] directly, so you no longer need to "start" the
+  stream consumer via, e.g., `StreamConsumer::start` to obtain a
+  `MessageStream`.
+
+  Specifically, this release removes the following items:
+
+    * `StreamConsumer::start`
+    * `StreamConsumer::start_with`
+    * `StreamConsumer::start_with_runtime`
+    * `MessageStream`
+    * `KafkaError::NoMessageReceived`
+
+  There is no replacement for the `no_message_parameter` of
+  `StreamConsumer::start_with` and `StreamConsumer::start_with_runtime`. If you
+  need this behavior, use a downstream stream combinator like [`tokio_stream::StreamExt::timeout`].
+
 <a name="0.24.0"></a>
 ## 0.24.0 (2020-07-08)
 
@@ -68,13 +85,6 @@ See also the [rdkafka-sys changelog](rdkafka-sys/changelog.md).
 * Decouple versioning of rdkafka-sys from rdkafka. rdkafka-sys now has its
   own [changelog](rdkafka-sys/changelog.md) and will follow SemVer conventions.
   ([#211])
-
-[#211]: https://github.com/fede1024/rust-rdkafka/issues/211
-[`std::time::Duration::as_millis`]: https://doc.rust-lang.org/stable/std/time/struct.Duration.html#method.as_millis
-[smol runtime]: https://github.com/fede1024/rust-rdkafka/tree/master/examples/smol_runtime.rs
-[smol]: docs.rs/smol
-
-[@FSMaxB-dooshop]: https://github.com/FSMaxB-dooshop
 
 <a name="0.23.1"></a>
 ## 0.23.1 (2020-01-13)
@@ -378,3 +388,12 @@ See also the [rdkafka-sys changelog](rdkafka-sys/changelog.md).
 * More metadata for consumers
 * Watermark API
 * First iteration of integration test suite
+
+[#211]: https://github.com/fede1024/rust-rdkafka/issues/211
+[`Stream`]: https://docs.rs/futures/0.3.8/futures/stream/trait.Stream.html
+[`std::time::Duration::as_millis`]: https://doc.rust-lang.org/stable/std/time/struct.Duration.html#method.as_millis
+[smol runtime]: https://github.com/fede1024/rust-rdkafka/tree/master/examples/smol_runtime.rs
+[smol]: docs.rs/smol
+[`tokio_stream::StreamExt::timeout`]: https://docs.rs/tokio-stream/0.1.0/tokio_stream/trait.StreamExt.html#method.timeout
+
+[@FSMaxB-dooshop]: https://github.com/FSMaxB-dooshop

--- a/src/consumer/mod.rs
+++ b/src/consumer/mod.rs
@@ -21,7 +21,7 @@ pub mod stream_consumer;
 
 // Re-exports.
 pub use self::base_consumer::BaseConsumer;
-pub use self::stream_consumer::{MessageStream, StreamConsumer};
+pub use self::stream_consumer::StreamConsumer;
 
 /// Rebalance information.
 #[derive(Clone, Debug)]

--- a/src/consumer/stream_consumer.rs
+++ b/src/consumer/stream_consumer.rs
@@ -1,12 +1,10 @@
 //! Stream-based consumer implementation.
 
-use std::future::Future;
 use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll, Waker};
-use std::time::Duration;
 
-use futures::{ready, Stream};
+use futures::Stream;
 
 use rdkafka_sys as rdsys;
 use rdkafka_sys::types::*;
@@ -19,9 +17,7 @@ use crate::error::{KafkaError, KafkaResult};
 use crate::message::BorrowedMessage;
 use crate::statistics::Statistics;
 use crate::topic_partition_list::TopicPartitionList;
-#[cfg(feature = "tokio")]
-use crate::util::TokioRuntime;
-use crate::util::{AsyncRuntime, NativePtr, Timeout};
+use crate::util::{NativePtr, Timeout};
 
 /// The [`ConsumerContext`] used by the [`StreamConsumer`]. This context will
 /// automatically wake up the message stream when new data is available.
@@ -90,113 +86,6 @@ impl<C: ConsumerContext + 'static> ConsumerContext for StreamConsumerContext<C> 
     }
 }
 
-/// A Kafka consumer implementing [`futures::Stream`].
-pub struct MessageStream<
-    'a,
-    C,
-    // Ugly, but this provides backwards compatibility when the `tokio` feature
-    // is enabled, as it is by default.
-    #[cfg(feature = "tokio")] R = TokioRuntime,
-    #[cfg(not(feature = "tokio"))] R,
-> where
-    C: ConsumerContext + 'static,
-    R: AsyncRuntime,
-{
-    consumer: &'a StreamConsumer<C>,
-    interval: Duration,
-    delay: Pin<Box<Option<R::Delay>>>,
-    no_message_error: bool,
-}
-
-impl<'a, C, R> MessageStream<'a, C, R>
-where
-    C: ConsumerContext + 'static,
-    R: AsyncRuntime,
-{
-    fn new(
-        consumer: &'a StreamConsumer<C>,
-        interval: Duration,
-        no_message_error: bool,
-    ) -> MessageStream<'a, C, R> {
-        MessageStream {
-            consumer,
-            interval,
-            delay: Box::pin(None),
-            no_message_error,
-        }
-    }
-
-    fn context(&self) -> &StreamConsumerContext<C> {
-        self.consumer.get_base_consumer().context()
-    }
-
-    fn client_ptr(&self) -> *mut RDKafka {
-        self.consumer.client().native_ptr()
-    }
-
-    fn set_waker(&self, waker: Waker) {
-        self.context()
-            .waker
-            .lock()
-            .expect("lock poisoned")
-            .replace(waker);
-    }
-
-    fn poll(&self) -> Option<KafkaResult<BorrowedMessage<'a>>> {
-        unsafe {
-            NativePtr::from_ptr(rdsys::rd_kafka_consumer_poll(self.client_ptr(), 0))
-                .map(|p| BorrowedMessage::from_consumer(p, self.consumer))
-        }
-    }
-
-    // SAFETY: All access to `self.delay` occurs via the following two
-    // functions. These functions are careful to never move out of `self.delay`.
-    // (They can *drop* the future stored in `self.delay`, but that is
-    // permitted.) They never return a non-pinned pointer to the contents of
-    // `self.delay`.
-
-    fn ensure_delay(&mut self, delay: R::Delay) -> Pin<&mut R::Delay> {
-        unsafe { Pin::new_unchecked(self.delay.as_mut().get_unchecked_mut().get_or_insert(delay)) }
-    }
-
-    fn clear_delay(&mut self) {
-        unsafe { *self.delay.as_mut().get_unchecked_mut() = None }
-    }
-}
-
-impl<'a, C, R> Stream for MessageStream<'a, C, R>
-where
-    C: ConsumerContext + 'a,
-    R: AsyncRuntime,
-{
-    type Item = KafkaResult<BorrowedMessage<'a>>;
-
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Option<Self::Item>> {
-        // Unconditionally store the waker so that we are woken up if the queue
-        // flips from non-empty to empty. We have to store the waker on every
-        // call to poll in case this future migrates between tasks. We also need
-        // to store the waker *before* calling poll to avoid a race where `poll`
-        // returns None to indicate that the queue is empty, but the queue
-        // becomes non-empty before we've installed the waker.
-        self.set_waker(cx.waker().clone());
-
-        match self.poll() {
-            None => loop {
-                let delay = R::delay_for(self.interval);
-                ready!(self.ensure_delay(delay).poll(cx));
-                self.clear_delay();
-                if self.no_message_error {
-                    break Poll::Ready(Some(Err(KafkaError::NoMessageReceived)));
-                }
-            },
-            Some(message) => {
-                self.clear_delay();
-                Poll::Ready(Some(message))
-            }
-        }
-    }
-}
-
 /// A Kafka consumer providing a [`futures::Stream`] interface.
 ///
 /// This consumer doesn't need to be polled explicitly since `await`ing the
@@ -237,46 +126,45 @@ impl<C: ConsumerContext> FromClientConfigAndContext<C> for StreamConsumer<C> {
 }
 
 impl<C: ConsumerContext> StreamConsumer<C> {
-    /// Starts the stream consumer with default configuration (100ms polling
-    /// interval and no `NoMessageReceived` notifications).
-    ///
-    /// **Note:** this method must be called from within the context of a Tokio
-    /// runtime.
-    #[cfg(feature = "tokio")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "tokio")))]
-    pub fn start(&self) -> MessageStream<C, TokioRuntime> {
-        self.start_with(Duration::from_millis(100), false)
+    fn context(&self) -> &StreamConsumerContext<C> {
+        self.consumer.get_base_consumer().context()
     }
 
-    /// Starts the stream consumer with the specified poll interval.
-    ///
-    /// If `no_message_error` is set to true, the returned `MessageStream` will
-    /// yield an error of type `KafkaError::NoMessageReceived` every time the
-    /// poll interval is reached and no message has been received.
-    #[cfg(feature = "tokio")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "tokio")))]
-    pub fn start_with(
-        &self,
-        poll_interval: Duration,
-        no_message_error: bool,
-    ) -> MessageStream<C, TokioRuntime> {
-        // TODO: verify called once
-        self.start_with_runtime(poll_interval, no_message_error)
+    fn client_ptr(&self) -> *mut RDKafka {
+        self.consumer.client().native_ptr()
     }
 
-    /// Like [`StreamConsumer::start_with`], but with a customizable
-    /// asynchronous runtime.
-    ///
-    /// See the [`AsyncRuntime`] trait for the details on the interface the
-    /// runtime must satisfy.
-    pub fn start_with_runtime<R>(
-        &self,
-        poll_interval: Duration,
-        no_message_error: bool,
-    ) -> MessageStream<C, R>
-    where
-        R: AsyncRuntime,
-    {
-        MessageStream::new(self, poll_interval, no_message_error)
+    fn poll<'a>(&'a self) -> Option<KafkaResult<BorrowedMessage<'a>>> {
+        unsafe {
+            NativePtr::from_ptr(rdsys::rd_kafka_consumer_poll(self.client_ptr(), 0))
+                .map(|p| BorrowedMessage::from_consumer(p, self))
+        }
+    }
+
+    fn set_waker(&self, waker: Waker) {
+        self.context()
+            .waker
+            .lock()
+            .expect("lock poisoned")
+            .replace(waker);
+    }
+}
+
+impl<'a, C: ConsumerContext> Stream for &'a StreamConsumer<C> {
+    type Item = KafkaResult<BorrowedMessage<'a>>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        // Unconditionally store the waker so that we are woken up if the queue
+        // flips from non-empty to empty. We have to store the waker on every
+        // call to poll in case this future migrates between tasks. We also need
+        // to store the waker *before* calling poll to avoid a race where `poll`
+        // returns None to indicate that the queue is empty, but the queue
+        // becomes non-empty before we've installed the waker.
+        self.set_waker(cx.waker().clone());
+
+        match self.poll() {
+            None => Poll::Pending,
+            Some(message) => Poll::Ready(Some(message)),
+        }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -60,8 +60,6 @@ pub enum KafkaError {
     MessageProduction(RDKafkaErrorCode),
     /// Metadata fetch error.
     MetadataFetch(RDKafkaErrorCode),
-    /// No message was received.
-    NoMessageReceived,
     /// Unexpected null pointer
     Nul(ffi::NulError),
     /// Offset fetch failed.
@@ -112,9 +110,6 @@ impl fmt::Debug for KafkaError {
             KafkaError::MetadataFetch(err) => {
                 write!(f, "KafkaError (Metadata fetch error: {})", err)
             }
-            KafkaError::NoMessageReceived => {
-                write!(f, "No message received within the given poll interval")
-            }
             KafkaError::Nul(_) => write!(f, "FFI null error"),
             KafkaError::OffsetFetch(err) => write!(f, "KafkaError (Offset fetch error: {})", err),
             KafkaError::PartitionEOF(part_n) => write!(f, "KafkaError (Partition EOF: {})", part_n),
@@ -151,9 +146,6 @@ impl fmt::Display for KafkaError {
             KafkaError::MessageConsumption(err) => write!(f, "Message consumption error: {}", err),
             KafkaError::MessageProduction(err) => write!(f, "Message production error: {}", err),
             KafkaError::MetadataFetch(err) => write!(f, "Meta data fetch error: {}", err),
-            KafkaError::NoMessageReceived => {
-                write!(f, "No message received within the given poll interval")
-            }
             KafkaError::Nul(_) => write!(f, "FFI nul error"),
             KafkaError::OffsetFetch(err) => write!(f, "Offset fetch error: {}", err),
             KafkaError::PartitionEOF(part_n) => write!(f, "Partition EOF: {}", part_n),
@@ -204,7 +196,6 @@ impl KafkaError {
             KafkaError::MessageConsumption(err) => Some(err),
             KafkaError::MessageProduction(err) => Some(err),
             KafkaError::MetadataFetch(err) => Some(err),
-            KafkaError::NoMessageReceived => None,
             KafkaError::Nul(_) => None,
             KafkaError::OffsetFetch(err) => Some(err),
             KafkaError::PartitionEOF(_) => None,

--- a/tests/test_high_consumers.rs
+++ b/tests/test_high_consumers.rs
@@ -3,7 +3,7 @@
 use std::collections::HashMap;
 use std::sync::atomic::AtomicUsize;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use futures::future;
 use futures::stream::StreamExt;
@@ -52,7 +52,6 @@ async fn test_produce_consume_base() {
     consumer.subscribe(&[topic_name.as_str()]).unwrap();
 
     let _consumer_future = consumer
-        .start()
         .take(100)
         .for_each(|message| {
             match message {
@@ -92,7 +91,6 @@ async fn test_produce_consume_base_assign() {
     let mut partition_count = vec![0, 0, 0];
 
     let _consumer_future = consumer
-        .start()
         .take(19)
         .for_each(|message| {
             match message {
@@ -118,7 +116,6 @@ async fn test_produce_consume_with_timestamp() {
     consumer.subscribe(&[topic_name.as_str()]).unwrap();
 
     let _consumer_future = consumer
-        .start()
         .take(100)
         .for_each(|message| {
             match message {
@@ -147,67 +144,6 @@ async fn test_produce_consume_with_timestamp() {
     assert_eq!(tp.error(), Ok(()));
 }
 
-#[tokio::test(flavor = "multi_thread")]
-async fn test_consume_with_no_message_error() {
-    let _r = env_logger::try_init();
-
-    let consumer = create_stream_consumer(&rand_test_group(), None);
-
-    let mut message_stream = consumer.start_with(Duration::from_millis(200), true);
-
-    let mut first_poll_time = None;
-    let mut timeouts_count = 0;
-    while let Some(message) = message_stream.next().await {
-        match message {
-            Err(KafkaError::NoMessageReceived) => {
-                // TODO: use entry interface for Options once available
-                if first_poll_time.is_none() {
-                    first_poll_time = Some(Instant::now());
-                }
-                timeouts_count += 1;
-                if timeouts_count == 26 {
-                    break;
-                }
-            }
-            Ok(m) => panic!("A message was actually received: {:?}", m),
-            Err(e) => panic!("Unexpected error while receiving message: {:?}", e),
-        };
-    }
-
-    assert_eq!(timeouts_count, 26);
-    // It should take 5000ms
-    println!("Duration: {:?}", first_poll_time.unwrap().elapsed());
-    assert!(first_poll_time.unwrap().elapsed() < Duration::from_millis(7000));
-    assert!(first_poll_time.unwrap().elapsed() > Duration::from_millis(4500));
-
-    // Subscribe to a topic with one record.
-    let topic_name = rand_test_topic();
-    populate_topic(&topic_name, 1, &value_fn, &key_fn, None, None).await;
-    consumer.subscribe(&[&topic_name]).unwrap();
-
-    // Assert that we see that record eventually.
-    while let Some(message) = message_stream.next().await {
-        if let Ok(_) = message {
-            break;
-        }
-    }
-
-    // Assert that we receive a few NoMessageReceived errors after we see the
-    // one record.
-    assert!(matches!(
-        message_stream.next().await,
-        Some(Err(KafkaError::NoMessageReceived))
-    ));
-    assert!(matches!(
-        message_stream.next().await,
-        Some(Err(KafkaError::NoMessageReceived))
-    ));
-    assert!(matches!(
-        message_stream.next().await,
-        Some(Err(KafkaError::NoMessageReceived))
-    ));
-}
-
 // TODO: add check that commit cb gets called correctly
 #[tokio::test(flavor = "multi_thread")]
 async fn test_consumer_commit_message() {
@@ -221,7 +157,6 @@ async fn test_consumer_commit_message() {
     consumer.subscribe(&[topic_name.as_str()]).unwrap();
 
     let _consumer_future = consumer
-        .start()
         .take(33)
         .for_each(|message| {
             match message {
@@ -284,7 +219,6 @@ async fn test_consumer_store_offset_commit() {
     consumer.subscribe(&[topic_name.as_str()]).unwrap();
 
     let _consumer_future = consumer
-        .start()
         .take(36)
         .for_each(|message| {
             match message {


### PR DESCRIPTION
As described in the changelog entry. This is an alternative to #291 that
involves breaking changes.