### PR TITLE
feat: Allow concurrent use of StreamConsumer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ log = "0.4.8"
 serde = { version = "1.0.0", features = ["derive"] }
 serde_derive = "1.0.0"
 serde_json = "1.0.0"
+slab = "0.4"
 tokio = { version = "1.0", features = ["rt", "time"], optional = true }
 
 [dev-dependencies]

--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,9 @@ See also the [rdkafka-sys changelog](rdkafka-sys/changelog.md).
   rust-rdkafka map to types in librdkafka as directly as possible. The
   maintainers apologize for the difficulty in upgrading through this change.
 
+* Support calling `StreamConsumer::start` or its variants multiple times on the
+  same `StreamConsumer`.
+
 <a name="0.24.0"></a>
 ## 0.24.0 (2020-07-08)
 


### PR DESCRIPTION
Before, each concurrent consumer would overwrite the earlier set waker
so only one task at a time would be awoken. By changing this to a Slab
where each `MessageStream` has its own slot, which is recycled on drop,
we can start multiple `MessageStream`s which concurrently polls kafka
and all get woken up when new messages arrive.

Co-authored-by: Nikhil Benesch <nikhil.benesch@gmail.com>