### PR TITLE
Don't allow access to StreamConsumer's underlying consumer

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -21,6 +21,9 @@ See also the [rdkafka-sys changelog](rdkafka-sys/changelog.md).
   Use a combinator like `tokio_stream::StreamExt::timeout` if you require the
   old behavior.
 
+* **Breaking change.** Remove the `Consumer::get_base_consumer` method, as
+  accessing the `BaseConsumer` that underlied a `StreamConsumer` was dangerous.
+
 <a name="0.24.0"></a>
 ## 0.24.0 (2020-07-08)
 


### PR DESCRIPTION
It is not valid to e.g. call `poll` on the BaseConsumer that underlies a
StreamConsumer. Rather than trying to document all the edge cases that
are invalid when accessing a StreamConsumer's underlying consumer, just
disallow access entirely.