### PR TITLE
rdkafka-sys: prepare v2.1.1+1.5.3

### DIFF
--- a/rdkafka-sys/Cargo.toml
+++ b/rdkafka-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rdkafka-sys"
-version = "2.1.0+1.5.0"
+version = "2.1.1+1.5.3"
 authors = ["Federico Giraud <giraud.federico@gmail.com>"]
 build = "build.rs"
 links = "rdkafka"
@@ -15,14 +15,14 @@ edition = "2018"
 num_enum = "0.5.0"
 libc = "0.2.65"
 openssl-sys = { version = "0.9.48", optional = true }
-libz-sys = { version = "1.0", optional = true }
-zstd-sys = { version = "1.4.15", optional = true }
+libz-sys = { version = "1.0.0", optional = true }
+zstd-sys = { version = "1.4.19", optional = true }
 lz4-sys = { version = "1.8.3", optional = true }
 sasl2-sys = { version = "0.1.6", optional = true }
 
 [build-dependencies]
 pkg-config = "0.3.9"
-cmake = { version = "^0.1", optional = true }
+cmake = { version = "0.1.0", optional = true }
 
 [lib]
 name = "rdkafka_sys"

--- a/rdkafka-sys/changelog.md
+++ b/rdkafka-sys/changelog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+<a name="2.1.1+1.5.3></a>
+## v2.1.1+1.5.3
+
+* Upgrade to librdkafka v1.5.3.
+* Enforce a minimum zstd-sys version of 1.4.19. This bumps the vendored version
+  of libzstd to at least v1.4.8, which avoids a bug in libzstd v1.4.5 that could
+  cause decompression failures ([edenhill/librdkafka#2672]).
+
 <a name="2.1.0+1.5.0></a>
 ## v2.1.0+1.5.0
 
@@ -13,3 +21,5 @@
 * Upgrade to librdkafka v1.4.2.
 
 * Correct several references to `usize` in the generated bindings to `size_t`.
+
+[edenhill/librdkafka#2672]: https://github.com/edenhill/librdkafka/issues/2672


### PR DESCRIPTION
Prepare the next version of rdkafka-sys. The features include:

  * Upgrading to the latest version of librdkafka, v1.5.3, which is a
    maintenance release that fixes several bugs in v1.5.0.

  * Upgrading to a version of zstd-sys that does not exhibit the
    decompression bug described in #201.

Fix #201.