### PR TITLE
Store consumer contexts as an Arc, rather than a Box

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [master]
 
 env:
-  rust_version: 1.43.1
+  rust_version: 1.45.0
 
 jobs:
   lint:

--- a/README.md
+++ b/README.md
@@ -165,6 +165,12 @@ For a full listing of features, consult the [rdkafka-sys crate's
 documentation][rdkafka-sys-features]. All of rdkafka-sys features are
 re-exported as rdkafka features.
 
+### Minimum supported Rust version (MSRV)
+
+The current minimum supported Rust version (MSRV) is 1.45.0. Note that
+bumping the MSRV is not considered a breaking change. Any release of
+rust-rdkafka may bump the MSRV.
+
 ### Asynchronous runtimes
 
 Some features of the [`StreamConsumer`] and [`FutureProducer`] depend on

--- a/changelog.md
+++ b/changelog.md
@@ -24,6 +24,12 @@ See also the [rdkafka-sys changelog](rdkafka-sys/changelog.md).
 * **Breaking change.** Remove the `Consumer::get_base_consumer` method, as
   accessing the `BaseConsumer` that underlied a `StreamConsumer` was dangerous.
 
+* **Breaking change.** Return an `&Arc<C>` from `Client::context` rather than an
+  `&C`. This is expected to cause very little breakage in practice.
+
+* **Breaking change.** Move the `BaseConsumer::context` method to the `Consumer`
+  trait, so that it is available when using the `StreamConsumer` as well.
+
 <a name="0.24.0"></a>
 ## 0.24.0 (2020-07-08)
 

--- a/src/consumer/base_consumer.rs
+++ b/src/consumer/base_consumer.rs
@@ -69,11 +69,11 @@ unsafe extern "C" fn native_message_queue_nonempty_cb<C: ConsumerContext>(
     (*context).message_queue_nonempty_callback();
 }
 
-unsafe fn enable_nonempty_callback<C: ConsumerContext>(queue: &NativeQueue, context: &C) {
+unsafe fn enable_nonempty_callback<C: ConsumerContext>(queue: &NativeQueue, context: &Arc<C>) {
     rdsys::rd_kafka_queue_cb_event_enable(
         queue.ptr(),
         Some(native_message_queue_nonempty_cb::<C>),
-        context as *const C as *mut c_void,
+        Arc::as_ptr(context) as *mut c_void,
     )
 }
 
@@ -134,11 +134,6 @@ impl<C> BaseConsumer<C>
 where
     C: ConsumerContext,
 {
-    /// Returns the context used to create this consumer.
-    pub fn context(&self) -> &C {
-        self.client.context()
-    }
-
     /// Polls the consumer for messages and returns a pointer to the native rdkafka-sys struct.
     /// This method is for internal use only. Use poll instead.
     pub(crate) fn poll_raw(&self, mut timeout: Timeout) -> Option<NativePtr<RDKafkaMessage>> {

--- a/src/consumer/mod.rs
+++ b/src/consumer/mod.rs
@@ -1,6 +1,7 @@
 //! Kafka consumers.
 
 use std::ptr;
+use std::sync::Arc;
 use std::time::Duration;
 
 use log::{error, trace};
@@ -157,6 +158,11 @@ where
 {
     /// Returns the [`Client`] underlying this consumer.
     fn client(&self) -> &Client<C>;
+
+    /// Returns a reference to [`Context`] used to create this consumer.
+    fn context(&self) -> &Arc<C> {
+        self.client().context()
+    }
 
     /// Subscribes the consumer to a list of topics.
     fn subscribe(&self, topics: &[&str]) -> KafkaResult<()>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,6 +157,12 @@
 //! documentation][rdkafka-sys-features]. All of rdkafka-sys features are
 //! re-exported as rdkafka features.
 //!
+//! ### Minimum supported Rust version (MSRV)
+//!
+//! The current minimum supported Rust version (MSRV) is 1.45.0. Note that
+//! bumping the MSRV is not considered a breaking change. Any release of
+//! rust-rdkafka may bump the MSRV.
+//!
 //! ### Asynchronous runtimes
 //!
 //! Some features of the [`StreamConsumer`] and [`FutureProducer`] depend on


### PR DESCRIPTION
This facilitates a forthcoming refactor of stream consumers.