### PR TITLE
Adjust FutureProducer for new StreamConsumer

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,7 +13,7 @@ See also the [rdkafka-sys changelog](rdkafka-sys/changelog.md).
   rust-rdkafka map to types in librdkafka as directly as possible. The
   maintainers apologize for the difficulty in upgrading through this change.
 
-* **Breaking changes.** Rework the consumer APIs to fix several bugs and design
+* **Breaking change.** Rework the consumer APIs to fix several bugs and design
   warts:
 
   * Rename `StreamConsumer::start` to `StreamConsumer::stream`, though the
@@ -46,6 +46,18 @@ See also the [rdkafka-sys changelog](rdkafka-sys/changelog.md).
 
   * Move the `BaseConsumer::context` method to the `Consumer`
     trait, so that it is available when using the `StreamConsumer` as well.
+
+* **Breaking change.** Rework the producer APIs to fix several design warts:
+
+    * Remove the `FutureProducer::send_with_runtime` method. Use the `send`
+      method instead. The `AsyncRuntime` to use is determined by the new `R`
+      type parameter to `FutureProducer`, which you can specify when you create
+      the producer.
+
+      This change makes the `FutureProducer` mirror the redesigned
+      `StreamConsumer`.
+
+      This change should have no impact on users who use the default runtime.
 
 * Fix stalls when using multiple `MessageStream`s simultaneously.
 

--- a/examples/smol_runtime.rs
+++ b/examples/smol_runtime.rs
@@ -73,7 +73,7 @@ fn main() {
             .expect("Producer creation error");
 
         let delivery_status = producer
-            .send_with_runtime::<SmolRuntime, Vec<u8>, _, _>(
+            .send::<Vec<u8>, _, _>(
                 FutureRecord::to(&topic).payload("hello from smol"),
                 Duration::from_secs(0),
             )

--- a/tests/test_metadata.rs
+++ b/tests/test_metadata.rs
@@ -2,8 +2,6 @@
 
 use std::time::Duration;
 
-use futures::*;
-
 use rdkafka::config::ClientConfig;
 use rdkafka::consumer::{Consumer, StreamConsumer};
 use rdkafka::topic_partition_list::TopicPartitionList;

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -17,7 +17,6 @@ use rdkafka::error::KafkaResult;
 use rdkafka::message::ToBytes;
 use rdkafka::producer::{FutureProducer, FutureRecord};
 use rdkafka::statistics::Statistics;
-use rdkafka::util::DefaultRuntime;
 use rdkafka::TopicPartitionList;
 
 #[macro_export]
@@ -134,7 +133,7 @@ where
         .map(|id| {
             let future = async move {
                 producer
-                    .send_with_runtime::<DefaultRuntime, _, _, _>(
+                    .send(
                         FutureRecord {
                             topic: topic_name,
                             payload: Some(&value_fn(id)),


### PR DESCRIPTION
Make the FutureProducer work more like the new StreamConsumer by making
the AsyncRuntime a type parameter of the FutureProducer, rather than its
methods.