### PR TITLE
perf: Only register wakeups in the consumer when no messages are ready

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ serde = { version = "1.0.0", features = ["derive"] }
 serde_derive = "1.0.0"
 serde_json = "1.0.0"
 slab = "0.4"
-tokio = { version = "1.0", features = ["rt", "time"], optional = true }
+tokio-dep = { version = "1.0", features = ["sync"], package = "tokio", default-features = false }
 
 [dev-dependencies]
 backoff = "0.1.5"
@@ -33,7 +33,7 @@ hdrhistogram = "7.0.0"
 rand = "0.3.15"
 regex = "1.1.6"
 smol = "1.2.4"
-tokio = { version = "1.0", features = ["macros", "rt-multi-thread", "time"] }
+tokio-dep = { version = "1.0", features = ["macros", "rt-multi-thread", "time"], package = "tokio" }
 
 # These features are re-exports of the features that the rdkafka-sys crate
 # provides. See the rdkafka-sys documentation for details.
@@ -44,6 +44,7 @@ cmake_build = ["rdkafka-sys/cmake_build"]
 dynamic_linking = ["rdkafka-sys/dynamic_linking"]
 ssl = ["rdkafka-sys/ssl"]
 ssl-vendored = ["rdkafka-sys/ssl-vendored"]
+tokio = ["tokio-dep/rt", "tokio-dep/time"]
 gssapi = ["rdkafka-sys/gssapi"]
 gssapi-vendored = ["rdkafka-sys/gssapi-vendored"]
 sasl = ["rdkafka-sys/sasl"]

--- a/examples/asynchronous_processing.rs
+++ b/examples/asynchronous_processing.rs
@@ -189,3 +189,6 @@ async fn main() {
         .for_each(|_| async { () })
         .await
 }
+
+// The tokio dependency is renamed for rdkafka to allow for a `tokio` feature
+use tokio_dep as tokio;

--- a/examples/at_least_once.rs
+++ b/examples/at_least_once.rs
@@ -170,3 +170,6 @@ async fn main() {
         }
     }
 }
+
+// The tokio dependency is renamed for rdkafka to allow for a `tokio` feature
+use tokio_dep as tokio;

--- a/examples/roundtrip.rs
+++ b/examples/roundtrip.rs
@@ -112,3 +112,6 @@ fn now() -> i64 {
         .try_into()
         .unwrap()
 }
+
+// The tokio dependency is renamed for rdkafka to allow for a `tokio` feature
+use tokio_dep as tokio;

--- a/examples/simple_consumer.rs
+++ b/examples/simple_consumer.rs
@@ -132,3 +132,6 @@ async fn main() {
 
     consume_and_print(brokers, group_id, &topics).await
 }
+
+// The tokio dependency is renamed for rdkafka to allow for a `tokio` feature
+use tokio_dep as tokio;

--- a/examples/simple_producer.rs
+++ b/examples/simple_producer.rs
@@ -86,3 +86,6 @@ async fn main() {
 
     produce(brokers, topic).await;
 }
+
+// The tokio dependency is renamed for rdkafka to allow for a `tokio` feature
+use tokio_dep as tokio;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,6 @@
 //!
 //! `rust-rdkafka` provides a safe Rust interface to librdkafka. The master
 //! branch is currently based on librdkafka 1.4.2.
-//!
 //! ### Documentation
 //!
 //! - [Current master branch](https://fede1024.github.io/rust-rdkafka/)

--- a/src/util.rs
+++ b/src/util.rs
@@ -17,6 +17,9 @@ use futures::channel::oneshot;
 use futures::future::{FutureExt, Map};
 use log::trace;
 
+#[cfg(feature = "tokio")]
+use tokio_dep as tokio;
+
 use rdkafka_sys as rdsys;
 
 /// Returns a tuple representing the version of `librdkafka` in hexadecimal and

--- a/tests/test_low_consumers.rs
+++ b/tests/test_low_consumers.rs
@@ -285,7 +285,10 @@ async fn test_produce_consume_message_queue_nonempty_callback() {
     assert_eq!(wakeups.load(Ordering::SeqCst), 1);
 
     // Verify there are no messages waiting.
-    assert!(consumer.poll(Duration::from_secs(0)).is_none());
+    assert_eq!(
+        consumer.poll(Duration::from_secs(0)).map(|r| r.map(|_| ())),
+        None
+    );
 
     // Populate the topic, and expect a wakeup notifying us of the new messages.
     populate_topic(&topic_name, 2, &value_fn, &key_fn, None, None).await;

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -19,6 +19,8 @@ use rdkafka::producer::{FutureProducer, FutureRecord};
 use rdkafka::statistics::Statistics;
 use rdkafka::TopicPartitionList;
 
+pub use tokio_dep as tokio;
+
 #[macro_export]
 macro_rules! map(
     { $($key:expr => $value:expr),+ } => {


### PR DESCRIPTION
By using tokio's `Notify` type and it's capability to get notified even
if no one was available to be notified when the notification fires we
avoid the need for locking and we keep synchronization out of the
common path (a message being available).

This does force tokio to be pulled in for non-tokio users, however they
will only get the now required `sync` feature which excludes most of
tokio.

https://docs.rs/tokio/1.0.1/tokio/sync/struct.Notify.html