### PR TITLE
Rename StreamConsumer::next -> recv

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -79,7 +79,7 @@ See also the [rdkafka-sys changelog](rdkafka-sys/changelog.md).
   Thanks to [@Marwes] for discovering the issue and contributing the initial
   fix.
 
-* Add a convenience method, `StreamConsumer::next`, to yield the next message
+* Add a convenience method, `StreamConsumer::recv`, to yield the next message
   from a stream.
 
   Thanks again to [@Marwes].

--- a/examples/at_least_once.rs
+++ b/examples/at_least_once.rs
@@ -142,7 +142,7 @@ async fn main() {
     let producer = create_producer(brokers);
 
     loop {
-        match consumer.next().await {
+        match consumer.recv().await {
             Err(e) => {
                 warn!("Kafka error: {}", e);
             }

--- a/examples/roundtrip.rs
+++ b/examples/roundtrip.rs
@@ -83,7 +83,7 @@ async fn main() {
     let mut latencies = Histogram::<u64>::new(5).unwrap();
     println!("Warming up for 10s...");
     loop {
-        let message = consumer.next().await.unwrap();
+        let message = consumer.recv().await.unwrap();
         let then = message.timestamp().to_millis().unwrap();
         if start.elapsed() < Duration::from_secs(10) {
             // Warming up.

--- a/examples/simple_consumer.rs
+++ b/examples/simple_consumer.rs
@@ -58,7 +58,7 @@ async fn consume_and_print(brokers: &str, group_id: &str, topics: &[&str]) {
         .expect("Can't subscribe to specified topics");
 
     loop {
-        match consumer.next().await {
+        match consumer.recv().await {
             Err(e) => warn!("Kafka error: {}", e),
             Ok(m) => {
                 let payload = match m.payload_view::<str>() {

--- a/src/consumer/stream_consumer.rs
+++ b/src/consumer/stream_consumer.rs
@@ -316,10 +316,10 @@ where
         self.stream()
     }
 
-    /// Yields the next message from the stream.
+    /// Receives the next message from the stream.
     ///
     /// This method will block until the next message is available or an error
-    /// occurs. It is legal to call `next` from multiple threads simultaneously.
+    /// occurs. It is legal to call `recv` from multiple threads simultaneously.
     ///
     /// Note that this method is exactly as efficient as constructing a
     /// single-use message stream and extracting one message from it:
@@ -331,7 +331,7 @@ where
     /// consumer.stream().next().await.expect("MessageStream never returns None");
     /// # }
     /// ```
-    pub async fn next(&self) -> Result<BorrowedMessage<'_>, KafkaError> {
+    pub async fn recv(&self) -> Result<BorrowedMessage<'_>, KafkaError> {
         self.stream()
             .next()
             .await

--- a/tests/test_metadata.rs
+++ b/tests/test_metadata.rs
@@ -94,7 +94,7 @@ async fn test_subscription() {
     consumer.subscribe(&[topic_name.as_str()]).unwrap();
 
     // Make sure the consumer joins the group.
-    let _consumer_future = consumer.next().await;
+    let _consumer_future = consumer.recv().await;
 
     let mut tpl = TopicPartitionList::new();
     tpl.add_topic_unassigned(&topic_name);
@@ -114,7 +114,7 @@ async fn test_group_membership() {
     consumer.subscribe(&[topic_name.as_str()]).unwrap();
 
     // Make sure the consumer joins the group.
-    let _consumer_future = consumer.next().await;
+    let _consumer_future = consumer.recv().await;
 
     let group_list = consumer
         .fetch_group_list(None, Duration::from_secs(5))


### PR DESCRIPTION
Per @Marwes's request, to make it more clear that this method does not
come from the StreamExt trait.