### PR TITLE
Fix references to dynamic_linking feature name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ tokio = { version = "1.0", features = ["macros", "rt-multi-thread", "time"] }
 default = ["libz", "tokio"]
 cmake-build = ["rdkafka-sys/cmake-build"]
 cmake_build = ["rdkafka-sys/cmake_build"]
+dynamic-linking = ["rdkafka-sys/dynamic-linking"]
 dynamic_linking = ["rdkafka-sys/dynamic_linking"]
 ssl = ["rdkafka-sys/ssl"]
 ssl-vendored = ["rdkafka-sys/ssl-vendored"]

--- a/rdkafka-sys/Cargo.toml
+++ b/rdkafka-sys/Cargo.toml
@@ -41,7 +41,10 @@ cmake_build = ["cmake-build"]
 # Dynamically link the system's librdkafka, rather than building and linking the
 # bundled version statically. This feature requires that the system has
 # librdkafka installed somewhere where pkg-config can find it.
-dynamic_linking = []
+dynamic-linking = []
+
+# Deprecated alias for the `dynamic-linking` feature.
+dynamic_linking = ["dynamic-linking"]
 
 # Enable SSL support.
 ssl = ["openssl-sys"]


### PR DESCRIPTION
The correct name of the feature flag is `dynamic_linking`, not `dynamic-linking`. This PR replaces the incorrect names to the correct one.