### PR TITLE
Note yanking in rdkafka-sys changelog

### DIFF
--- a/rdkafka-sys/changelog.md
+++ b/rdkafka-sys/changelog.md
@@ -1,11 +1,24 @@
 # Changelog
 
-## v2.1.1+1.5.3 (2021-01-05)
+## v3.0.0+1.6.0 (Unreleased)
 
-* Upgrade to librdkafka v1.5.3.
+* **Breaking change.** Rename `RDKafkaError` to `RDKafkaErrorCode`. This makes
+  space for the new `RDKafkaError` type, which mirrors the `rd_kafka_error_t`
+  type added to librdkafka in v1.4.0.
+
+  This change was made to reduce long-term confusion by ensuring the types in
+  rust-rdkafka map to types in librdkafka as directly as possible. The
+  maintainers apologize for the difficulty in upgrading through this change.
+
+* Upgrade to librdkafka v1.6.0. (TODO: pending librdkafka release.)
+
 * Enforce a minimum zstd-sys version of 1.4.19. This bumps the vendored version
   of libzstd to at least v1.4.8, which avoids a bug in libzstd v1.4.5 that could
   cause decompression failures ([edenhill/librdkafka#2672]).
+
+## v2.1.1+1.5.3 (2021-01-05)
+
+* Yanked due to an inadvertent breaking change.
 
 ## v2.1.0+1.5.0 (2020-08-02)
 


### PR DESCRIPTION
v2.1.1+1.5.3 had to be yanked to do its unintentional inclusion of the
RDKafkaErrorCode -> RDKafkaError rename. Note this in the changelog, and
prepare for the v3.0.0+1.6.0 that will be released shortly.

Fix #329.