### PR TITLE
Fix compilation on aarch64, which uses unsigned chars

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 See also the [rdkafka-sys changelog](rdkafka-sys/changelog.md).
 
+## Unreleased
+
+* Fix compilation for the aarch64 target.
+
 <a name="0.25.0"></a>
 ## 0.25.0 (2021-01-30)
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -25,6 +25,7 @@
 use std::collections::HashMap;
 use std::ffi::{CStr, CString};
 use std::mem;
+use std::os::raw::c_char;
 use std::ptr;
 
 use log::{log_enabled, Level};
@@ -150,7 +151,7 @@ impl NativeClientConfig {
             rdsys::rd_kafka_conf_get(
                 self.ptr(),
                 key_c.as_ptr(),
-                buf.as_mut_ptr() as *mut i8,
+                buf.as_mut_ptr() as *mut c_char,
                 &mut size,
             )
         };


### PR DESCRIPTION
On aarch64, the char type in C is unsigned. Use the os::raw::c_char
type in a cast, rather than `i8`, to avoid hardcoding assumptions
about the signedness of char.

Since the switch to GitHub Actions we haven't had automatic testing of
aarch64 in CI. (Travis CI latency had become unbearable since its new
owners decided to squeeze every last drop of profit out of the company.)
For now I've just tested this locally, but we may want to consider an
aarch64 runner if issues like this one come up frequently.