### PR TITLE
rdkafka-sys: work around upstream OpenSSL issue

### DIFF
--- a/rdkafka-sys/build.rs
+++ b/rdkafka-sys/build.rs
@@ -211,6 +211,12 @@ fn build_librdkafka() {
     if env::var("CARGO_FEATURE_SSL").is_ok() {
         config.define("WITH_SSL", "1");
         config.register_dep("openssl");
+        // Work around a bug in the CMake build system in which this define is
+        // not set correctly when statically linking OpenSSL.
+        // See: https://github.com/edenhill/librdkafka/pull/3249
+        //
+        // TODO(benesch): remove if upstream PR lands.
+        config.cflag("-DWITH_STATIC_LIB_libcrypto");
     } else {
         config.define("WITH_SSL", "0");
     }

--- a/rdkafka-sys/changelog.md
+++ b/rdkafka-sys/changelog.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+* Ensure librdkafka is configured to probe for the system's trusted certificate
+  authorities (CAs) when using CMake build system with the
+  `ssl-vendored` feature enabled.
+
+  This is a fix for an upstream bug ([edenhill/librdkafka#3249]).
+
 ## v3.0.0+1.6.0 (2021-01-30)
 
 * **Breaking change.** Rename `RDKafkaError` to `RDKafkaErrorCode`. This makes
@@ -33,3 +41,4 @@
 * Correct several references to `usize` in the generated bindings to `size_t`.
 
 [edenhill/librdkafka#2672]: https://github.com/edenhill/librdkafka/issues/2672
+[edenhill/librdkafka#3249]: https://github.com/edenhill/librdkafka/issues/3249


### PR DESCRIPTION
The upstream CMake build system does not properly set the
WITH_STATIC_LIB_libcrypto define when linking against a static copy of
OpenSSL, which means the SSL initialization code will not probe for the
system's CA certificate bundle. Work around the issue for now by just
setting the define ourselves.

See: https://github.com/edenhill/librdkafka/pull/3249