### PR TITLE
Add async split_partition_queue to StreamConsumer

### DIFF
--- a/examples/partition_consumer.rs
+++ b/examples/partition_consumer.rs
@@ -1,0 +1,173 @@
+use std::sync::Arc;
+
+use clap::{App, Arg};
+use futures::stream::StreamExt;
+use log::{info, warn};
+
+use rdkafka::client::ClientContext;
+use rdkafka::config::{ClientConfig, RDKafkaLogLevel};
+use rdkafka::consumer::stream_consumer::StreamConsumer;
+use rdkafka::consumer::{CommitMode, Consumer, ConsumerContext, Rebalance};
+use rdkafka::error::KafkaResult;
+use rdkafka::message::{Headers, Message};
+use rdkafka::topic_partition_list::TopicPartitionList;
+use rdkafka::util::get_rdkafka_version;
+
+use crate::example_utils::setup_logger;
+
+mod example_utils;
+
+// A context can be used to change the behavior of producers and consumers by adding callbacks
+// that will be executed by librdkafka.
+// This particular context sets up custom callbacks to log rebalancing events.
+struct CustomContext;
+
+impl ClientContext for CustomContext {}
+
+impl ConsumerContext for CustomContext {
+    fn pre_rebalance(&self, rebalance: &Rebalance) {
+        info!("Pre rebalance {:?}", rebalance);
+    }
+
+    fn post_rebalance(&self, rebalance: &Rebalance) {
+        info!("Post rebalance {:?}", rebalance);
+    }
+
+    fn commit_callback(&self, result: KafkaResult<()>, _offsets: &TopicPartitionList) {
+        info!("Committing offsets: {:?}", result);
+    }
+}
+
+// A type alias with your custom consumer can be created for convenience.
+type LoggingConsumer = StreamConsumer<CustomContext>;
+
+async fn consume_and_print(brokers: &str, group_id: &str, topic: &str) {
+    let context = CustomContext;
+
+    let consumer: LoggingConsumer = ClientConfig::new()
+        .set("group.id", group_id)
+        .set("bootstrap.servers", brokers)
+        .set("enable.partition.eof", "false")
+        .set("session.timeout.ms", "6000")
+        .set("enable.auto.commit", "true")
+        //.set("statistics.interval.ms", "30000")
+        //.set("auto.offset.reset", "smallest")
+        .set_log_level(RDKafkaLogLevel::Debug)
+        .create_with_context(context)
+        .expect("Consumer creation failed");
+
+    let consumer = Arc::new(consumer);
+    let topic_metadata = {
+        let topic = String::from(topic);
+        let consumer = consumer.clone();
+        tokio::task::spawn_blocking(move || {
+            consumer
+                .client()
+                .fetch_metadata(Some(&topic), std::time::Duration::from_secs(10))
+        })
+        .await
+        .unwrap()
+        .expect("Failed to get metadata about topic")
+    };
+    let topic_metadata = topic_metadata
+        .topics()
+        .get(0)
+        .expect("Requested topic does not exist.");
+    let partitions = topic_metadata
+        .partitions()
+        .iter()
+        .map(|x| x.id())
+        .collect::<Vec<i32>>();
+
+    consumer
+        .subscribe(&vec![topic])
+        .expect("Can't subscribe to specified topics");
+
+
+    let streams = partitions
+        .into_iter()
+        .map(|p| {
+            consumer
+                .split_partition_queue(topic, p)
+                .expect("Failed to get partition")
+                .map(move |msg| (p, msg))
+        })
+        .collect::<Vec<_>>();
+
+    let mut streams = futures::stream::select_all(streams);
+    loop {
+        while let Some((p, msg)) = streams.next().await {
+            match msg {
+                Err(e) => warn!("Kafka error: {}", e),
+                Ok(m) => {
+                    let payload = match m.payload_view::<str>() {
+                        None => "",
+                        Some(Ok(s)) => s,
+                        Some(Err(e)) => {
+                            warn!("Error while deserializing message payload: {:?}", e);
+                            ""
+                        }
+                    };
+                    info!("key: '{:?}', payload: '{}', partition: {} == {}, offset: {}",
+                          m.key(), payload, p, m.partition(), m.offset());
+                    if let Some(headers) = m.headers() {
+                        for i in 0..headers.count() {
+                            let header = headers.get(i).unwrap();
+                            info!("  Header {:#?}: {:?}", header.0, header.1);
+                        }
+                    }
+                    consumer.commit_message(&m, CommitMode::Async).unwrap();
+                }
+            }
+        }
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    let matches = App::new("consumer example")
+        .version(option_env!("CARGO_PKG_VERSION").unwrap_or(""))
+        .about("Simple command line consumer")
+        .arg(
+            Arg::with_name("brokers")
+                .short("b")
+                .long("brokers")
+                .help("Broker list in kafka format")
+                .takes_value(true)
+                .default_value("localhost:9092"),
+        )
+        .arg(
+            Arg::with_name("group-id")
+                .short("g")
+                .long("group-id")
+                .help("Consumer group id")
+                .takes_value(true)
+                .default_value("example_consumer_group_id"),
+        )
+        .arg(
+            Arg::with_name("log-conf")
+                .long("log-conf")
+                .help("Configure the logging format (example: 'rdkafka=trace')")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name("topic")
+                .short("t")
+                .long("topic")
+                .help("Topic")
+                .takes_value(true)
+                .required(true),
+        )
+        .get_matches();
+
+    setup_logger(true, matches.value_of("log-conf"));
+
+    let (version_n, version_s) = get_rdkafka_version();
+    info!("rd_kafka_version: 0x{:08x}, {}", version_n, version_s);
+
+    let topic = matches.value_of("topic").unwrap();
+    let brokers = matches.value_of("brokers").unwrap();
+    let group_id = matches.value_of("group-id").unwrap();
+
+    consume_and_print(brokers, group_id, topic).await
+}

--- a/src/consumer/base_consumer.rs
+++ b/src/consumer/base_consumer.rs
@@ -626,6 +626,10 @@ where
         PartitionQueue { consumer, queue }
     }
 
+    pub(super) fn native_queue(&self) -> &NativeQueue {
+        &self.queue
+    }
+
     /// Polls the partition for new messages.
     ///
     /// The `timeout` parameter controls how long to block if no messages are

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,19 +1,16 @@
 //! Store and manipulate Kafka messages.
 
-use std::borrow::ToOwned;
 use std::ffi::{CStr, CString};
 use std::fmt;
 use std::marker::PhantomData;
 use std::os::raw::c_void;
 use std::ptr;
 use std::str;
-use std::sync::Arc;
 use std::time::SystemTime;
 
 use rdkafka_sys as rdsys;
 use rdkafka_sys::types::*;
 
-use crate::consumer::{BaseConsumer, ConsumerContext};
 use crate::error::{IsError, KafkaError, KafkaResult};
 use crate::util::{self, millis_to_epoch, KafkaDrop, NativePtr};
 
@@ -376,152 +373,6 @@ impl<'a> Message for BorrowedMessage<'a> {
 
 unsafe impl<'a> Send for BorrowedMessage<'a> {}
 unsafe impl<'a> Sync for BorrowedMessage<'a> {}
-
-/// A zero-copy Kafka message.
-///
-/// Provides a read-only access to headers owned by a Kafka consumer or producer
-/// or by an [`OwnedMessage`] struct. `ArcMessage` differs from
-/// [`BorrowedMessage`] in that rather than having it's lifetime tied
-/// to a consumer, it insteads holds an Arc to a consumer instead.
-pub struct ArcMessage<C: ConsumerContext> {
-    ptr: NativePtr<RDKafkaMessage>,
-    _owner: Arc<BaseConsumer<C>>,
-}
-
-impl<C: ConsumerContext> fmt::Debug for ArcMessage<C> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Message {{ ptr: {:?} }}", self.ptr())
-    }
-}
-
-impl<C: ConsumerContext> ArcMessage<C> {
-    /// Creates a new `ArcMessage` that wraps the native Kafka message
-    /// pointer returned by a consumer. The message will hold an Arc to the
-    /// consumer ensuring that it's data does not outlive the consumer.
-    /// If the message contains an error, only the error is returned and
-    /// the message structure is freed.
-    pub(crate) unsafe fn from_consumer(
-        ptr: NativePtr<RDKafkaMessage>,
-        consumer: &Arc<BaseConsumer<C>>,
-    ) -> KafkaResult<ArcMessage<C>> {
-        if ptr.err.is_error() {
-            let err = match ptr.err {
-                rdsys::rd_kafka_resp_err_t::RD_KAFKA_RESP_ERR__PARTITION_EOF => {
-                    KafkaError::PartitionEOF((*ptr).partition)
-                }
-                e => KafkaError::MessageConsumption(e.into()),
-            };
-            Err(err)
-        } else {
-            Ok(ArcMessage {
-                ptr,
-                _owner: consumer.clone(),
-            })
-        }
-    }
-
-    /// Returns a pointer to the [`RDKafkaMessage`].
-    pub fn ptr(&self) -> *mut RDKafkaMessage {
-        self.ptr.ptr()
-    }
-
-    /// Returns a pointer to the message's [`RDKafkaTopic`]
-    pub fn topic_ptr(&self) -> *mut RDKafkaTopic {
-        self.ptr.rkt
-    }
-
-    /// Returns the length of the key field of the message.
-    pub fn key_len(&self) -> usize {
-        self.ptr.key_len
-    }
-
-    /// Returns the length of the payload field of the message.
-    pub fn payload_len(&self) -> usize {
-        self.ptr.len
-    }
-
-    /// Clones the content of the `ArcMessage` and returns an
-    /// [`OwnedMessage`] that can outlive the consumer.
-    ///
-    /// This operation requires memory allocation and can be expensive.
-    pub fn detach(&self) -> OwnedMessage {
-        OwnedMessage {
-            key: self.key().map(|k| k.to_vec()),
-            payload: self.payload().map(|p| p.to_vec()),
-            topic: self.topic().to_owned(),
-            timestamp: self.timestamp(),
-            partition: self.partition(),
-            offset: self.offset(),
-            headers: self.headers().map(BorrowedHeaders::detach),
-        }
-    }
-}
-
-impl<C: ConsumerContext> Message for ArcMessage<C> {
-    type Headers = BorrowedHeaders;
-
-    fn key(&self) -> Option<&[u8]> {
-        unsafe { util::ptr_to_opt_slice((*self.ptr).key, (*self.ptr).key_len) }
-    }
-
-    fn payload(&self) -> Option<&[u8]> {
-        unsafe { util::ptr_to_opt_slice((*self.ptr).payload, (*self.ptr).len) }
-    }
-
-    fn topic(&self) -> &str {
-        unsafe {
-            CStr::from_ptr(rdsys::rd_kafka_topic_name((*self.ptr).rkt))
-                .to_str()
-                .expect("Topic name is not valid UTF-8")
-        }
-    }
-
-    fn partition(&self) -> i32 {
-        self.ptr.partition
-    }
-
-    fn offset(&self) -> i64 {
-        self.ptr.offset
-    }
-
-    fn timestamp(&self) -> Timestamp {
-        let mut timestamp_type = rdsys::rd_kafka_timestamp_type_t::RD_KAFKA_TIMESTAMP_NOT_AVAILABLE;
-        let timestamp =
-            unsafe { rdsys::rd_kafka_message_timestamp(self.ptr.ptr(), &mut timestamp_type) };
-        if timestamp == -1 {
-            Timestamp::NotAvailable
-        } else {
-            match timestamp_type {
-                rdsys::rd_kafka_timestamp_type_t::RD_KAFKA_TIMESTAMP_NOT_AVAILABLE => {
-                    Timestamp::NotAvailable
-                }
-                rdsys::rd_kafka_timestamp_type_t::RD_KAFKA_TIMESTAMP_CREATE_TIME => {
-                    Timestamp::CreateTime(timestamp)
-                }
-                rdsys::rd_kafka_timestamp_type_t::RD_KAFKA_TIMESTAMP_LOG_APPEND_TIME => {
-                    Timestamp::LogAppendTime(timestamp)
-                }
-            }
-        }
-    }
-
-    fn headers(&self) -> Option<&BorrowedHeaders> {
-        let mut native_headers_ptr = ptr::null_mut();
-        unsafe {
-            let err = rdsys::rd_kafka_message_headers(self.ptr.ptr(), &mut native_headers_ptr);
-            match err.into() {
-                RDKafkaErrorCode::NoError => {
-                    Some(BorrowedHeaders::from_native_ptr(self, native_headers_ptr))
-                }
-                RDKafkaErrorCode::NoEnt => None,
-                _ => None,
-            }
-        }
-    }
-}
-
-unsafe impl<C: ConsumerContext> Send for ArcMessage<C> {}
-unsafe impl<C: ConsumerContext> Sync for ArcMessage<C> {}
 
 //
 // ********** OWNED MESSAGE **********


### PR DESCRIPTION
I currently need a way to consume partitions concurrently in an asynchronous context. `BaseConsumer` currently provides `split_partition_queue` for "synchronous" polling, but `StreamConsumer` provides no function. I decided to take a stab at implementing it, as it seemed simple enough; however this PR is more in the design stage.

What I opted to do was "overload" `MessageStream` to simply rollover an enum of values, either a `StreamConsumer` or `Arc<BaseConsumer>` + `Partition`.  To achieve this I also had `StreamConsumer` always hold on to an `Arc` of BaseConsumer, which I think should have a very minimal cost compared to the owned version.

The only problem I see is that each `PartitionQueue` has its lifetime tied to the `StreamConsumer` despite each `PartitionQueue` holding an Arc to base consumer. I'm not sure yet if this is an onerous restriction, however an alternate design would require a new `MessageStream` type (which I think may duplicate more code), or allowing `MessageStream` to hold an Arc to `StreamConsumer` or making the implantation of `MessageStream` generic over the "consumer".