### PR TITLE
Allow access into inner context in StreamConsumerContext

### DIFF
--- a/src/consumer/stream_consumer.rs
+++ b/src/consumer/stream_consumer.rs
@@ -64,6 +64,12 @@ where
             }
         }
     }
+
+    /// Returns a reference to the inner [`ConsumerContext`] used to create
+    /// this context.
+    pub fn inner(&self) -> &C {
+        &self.inner
+    }
 }
 
 impl<C> ClientContext for StreamConsumerContext<C>


### PR DESCRIPTION
I was creating a custom `ConsumerContext` to customize the rebalancing logic when I noticed that `StreamConsumer` wraps up my context without providing access to it.