### PR TITLE
Allow offset 0 in `Offset::to_raw`

### DIFF
--- a/src/topic_partition_list.rs
+++ b/src/topic_partition_list.rs
@@ -69,7 +69,7 @@ impl Offset {
             Offset::End => Some(OFFSET_END),
             Offset::Stored => Some(OFFSET_STORED),
             Offset::Invalid => Some(OFFSET_INVALID),
-            Offset::Offset(n) if n > 0 => Some(n),
+            Offset::Offset(n) if n >= 0 => Some(n),
             Offset::OffsetTail(n) if n > 0 => Some(OFFSET_TAIL_BASE - n),
             Offset::Offset(_) | Offset::OffsetTail(_) => None,
         }


### PR DESCRIPTION
Offsets usually start from 0 in Kafka topic partitions.