### PR TITLE
add Debug trait to DefaultClientContext/DefaultConsumerContext

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1123,7 +1123,7 @@ dependencies = [
 
 [[package]]
 name = "rdkafka"
-version = "0.27.0"
+version = "0.27.0-alpha.0"
 dependencies = [
  "async-std",
  "backoff",

--- a/src/client.rs
+++ b/src/client.rs
@@ -101,7 +101,7 @@ pub trait ClientContext: Send + Sync {
 /// needed.
 ///
 /// Uses the default callback implementations provided by `ClientContext`.
-#[derive(Clone, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct DefaultClientContext;
 
 impl ClientContext for DefaultClientContext {}

--- a/src/consumer/mod.rs
+++ b/src/consumer/mod.rs
@@ -141,7 +141,7 @@ pub trait ConsumerContext: ClientContext {
 
 /// An inert [`ConsumerContext`] that can be used when no customizations are
 /// needed.
-#[derive(Clone, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct DefaultConsumerContext;
 
 impl ClientContext for DefaultConsumerContext {}


### PR DESCRIPTION
This PR adds Debug trait derives to default client and consumer contexts.

My context is following - I've created a custom consumer context that propagates the statistics provided by librdkafka via `tokio::sync::watch` channel. The code that uses consumers either with custom or default context has a data structure with a field parameterised by context. This data structure is logged with debug formatting. This requires Debug trait implemented for both contexts.