### PR TITLE
Add Default trait to Statistics

### DIFF
--- a/src/statistics.rs
+++ b/src/statistics.rs
@@ -15,7 +15,7 @@ use std::collections::HashMap;
 use serde::Deserialize;
 
 /// Overall statistics.
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Default)]
 pub struct Statistics {
     /// The name of the librdkafka handle.
     pub name: String,


### PR DESCRIPTION
rdkafka publishes stats every configurable ms. Some of these properties are ever increasing and requires us to calculate the difference between the current value and the previous value (for example the 'tx' and 'txmsgs' fields). Setting a Default trait allow us to use the default values for fields of the struct which are required on startup (if you're storing a default Stats obj).