### PR TITLE
Replace mem::forget with ManuallyDrop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1123,7 +1123,7 @@ dependencies = [
 
 [[package]]
 name = "rdkafka"
-version = "0.27.0-alpha.0"
+version = "0.27.0"
 dependencies = [
  "async-std",
  "backoff",

--- a/src/client.rs
+++ b/src/client.rs
@@ -13,6 +13,7 @@
 
 use std::convert::TryFrom;
 use std::ffi::{CStr, CString};
+use std::mem::ManuallyDrop;
 use std::os::raw::c_char;
 use std::os::raw::c_void;
 use std::ptr;
@@ -204,9 +205,10 @@ impl<C: ClientContext> Client<C> {
         };
 
         let client_ptr = unsafe {
+            let native_config = ManuallyDrop::new(native_config);
             rdsys::rd_kafka_new(
                 rd_kafka_type,
-                native_config.ptr_move(),
+                native_config.ptr(),
                 err_buf.as_mut_ptr(),
                 err_buf.capacity(),
             )

--- a/src/config.rs
+++ b/src/config.rs
@@ -25,7 +25,6 @@
 use std::collections::HashMap;
 use std::ffi::{CStr, CString};
 use std::iter::FromIterator;
-use std::mem;
 use std::os::raw::c_char;
 use std::ptr;
 
@@ -103,15 +102,6 @@ impl NativeClientConfig {
     /// Returns the pointer to the librdkafka RDKafkaConf structure.
     pub fn ptr(&self) -> *mut RDKafkaConf {
         self.ptr.ptr()
-    }
-
-    /// Returns the pointer to the librdkafka RDKafkaConf structure. This method should be used when
-    /// the native pointer is intended to be moved. The destructor won't be executed automatically;
-    /// the caller should take care of deallocating the resource when no longer needed.
-    pub fn ptr_move(self) -> *mut RDKafkaConf {
-        let ptr = self.ptr();
-        mem::forget(self);
-        ptr
     }
 
     /// Gets the value of a parameter in the configuration.


### PR DESCRIPTION
Several of the prior uses of mem::forget could result in double drops in
the face of panics. Replace all possible uses of mem::forget with
ManuallyDrop instead.