### PR TITLE
Fix handling of NULL pointer in `NativeClient::rebalance_protocol`

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -155,12 +155,17 @@ impl NativeClient {
     }
 
     pub(crate) fn rebalance_protocol(&self) -> RebalanceProtocol {
-        let protocol = unsafe { CStr::from_ptr(rdsys::rd_kafka_rebalance_protocol(self.ptr())) };
-        match protocol.to_bytes() {
-            b"NONE" => RebalanceProtocol::None,
-            b"EAGER" => RebalanceProtocol::Eager,
-            b"COOPERATIVE" => RebalanceProtocol::Cooperative,
-            _ => unreachable!(),
+        let protocol = unsafe { rdsys::rd_kafka_rebalance_protocol(self.ptr()) };
+        if protocol.is_null() {
+            RebalanceProtocol::None
+        } else {
+            let protocol = unsafe { CStr::from_ptr(protocol) };
+            match protocol.to_bytes() {
+                b"NONE" => RebalanceProtocol::None,
+                b"EAGER" => RebalanceProtocol::Eager,
+                b"COOPERATIVE" => RebalanceProtocol::Cooperative,
+                _ => unreachable!(),
+            }
         }
     }
 }


### PR DESCRIPTION
The underlying function call `rdsys::rd_kafka_rebalance_protocol` can
return a NULL pointer in the case of an error. The callers within
librdkafka treat this similarly to it returning "NONE", so we will
return `RebalanceProtocol::None` to emulate this behavior.

Closes #416