### PR TITLE
ci: test minimal versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,9 @@
 version: 2
 updates:
-  - package-ecosystem: "cargo"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
+- package-ecosystem: cargo
+  directory: /
+  schedule: { interval: weekly }
+  open-pull-requests-limit: 10
+  ignore:
+  - dependency-name: "*"
+    update-types: [version-update:semver-minor, version-update:semver-patch]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,26 @@ jobs:
     - run: cargo build --all-targets --verbose --features "${{ matrix.features }}"
     - run: cd rdkafka-sys && cargo test --features "${{ matrix.features }}"
 
+  # Use the `minimal-versions` resolver to ensure we're not claiming to support
+  # an older version of a dependency than we actually do.
+  check-minimal-versions:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions-rs/toolchain@v1
+      with:
+        # The version of this toolchain doesn't matter much. It's only used to
+        # generate the minimal-versions lockfile, not to actually run `cargo
+        # check`.
+        toolchain: nightly-2021-01-05
+        components: rustfmt, clippy
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: ${{ env.rust_version }}
+        default: true
+    - run: cargo +nightly-2021-01-05 -Z minimal-versions generate-lockfile
+    - run: cargo check
+
   test:
     strategy:
       matrix:


### PR DESCRIPTION
Add a test that uses Cargo's unstable minimal-versions resolver to
ensure that the dependency specifactions in the Cargo.toml are correct.
It's easy to declare a dependency on v1.0 and then use a feature that's
only available in v1.1.

Also, tweak the dependabot configuration to ignore patch and minor
bumps. As a library, it's important to be as compatible as possible.
That means that for each dependency we want to use the oldest version
that is SemVer compatible with that dependency's latest release.