### PR TITLE
[producer] pass through error when calling flush

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -147,6 +147,8 @@ pub enum KafkaError {
     ClientCreation(String),
     /// Consumer commit failed.
     ConsumerCommit(RDKafkaErrorCode),
+    /// Flushing failed
+    Flush(RDKafkaErrorCode),
     /// Global error.
     Global(RDKafkaErrorCode),
     /// Group list fetch failed.
@@ -198,6 +200,7 @@ impl fmt::Debug for KafkaError {
             KafkaError::ConsumerCommit(err) => {
                 write!(f, "KafkaError (Consumer commit error: {})", err)
             }
+            KafkaError::Flush(err) => write!(f, "KafkaError (Flush error: {})", err),
             KafkaError::Global(err) => write!(f, "KafkaError (Global error: {})", err),
             KafkaError::GroupListFetch(err) => {
                 write!(f, "KafkaError (Group list fetch error: {})", err)
@@ -246,6 +249,7 @@ impl fmt::Display for KafkaError {
             }
             KafkaError::ClientCreation(ref err) => write!(f, "Client creation error: {}", err),
             KafkaError::ConsumerCommit(err) => write!(f, "Consumer commit error: {}", err),
+            KafkaError::Flush(err) => write!(f, "Flush error: {}", err),
             KafkaError::Global(err) => write!(f, "Global error: {}", err),
             KafkaError::GroupListFetch(err) => write!(f, "Group list fetch error: {}", err),
             KafkaError::MessageConsumption(err) => write!(f, "Message consumption error: {}", err),
@@ -276,6 +280,7 @@ impl Error for KafkaError {
             KafkaError::ClientConfig(..) => None,
             KafkaError::ClientCreation(_) => None,
             KafkaError::ConsumerCommit(err) => Some(err),
+            KafkaError::Flush(err) => Some(err),
             KafkaError::Global(err) => Some(err),
             KafkaError::GroupListFetch(err) => Some(err),
             KafkaError::MessageConsumption(err) => Some(err),
@@ -312,6 +317,7 @@ impl KafkaError {
             KafkaError::ClientConfig(..) => None,
             KafkaError::ClientCreation(_) => None,
             KafkaError::ConsumerCommit(err) => Some(*err),
+            KafkaError::Flush(err) => Some(*err),
             KafkaError::Global(err) => Some(*err),
             KafkaError::GroupListFetch(err) => Some(*err),
             KafkaError::MessageConsumption(err) => Some(*err),

--- a/src/producer/base_producer.rs
+++ b/src/producer/base_producer.rs
@@ -385,8 +385,13 @@ where
         &*self.client_arc
     }
 
-    fn flush<T: Into<Timeout>>(&self, timeout: T) {
-        unsafe { rdsys::rd_kafka_flush(self.native_ptr(), timeout.into().as_millis()) };
+    fn flush<T: Into<Timeout>>(&self, timeout: T) -> KafkaResult<()> {
+        let ret = unsafe { rdsys::rd_kafka_flush(self.native_ptr(), timeout.into().as_millis()) };
+        if ret.is_error() {
+            Err(KafkaError::Flush(ret.into()))
+        } else {
+            Ok(())
+        }
     }
 
     fn in_flight_count(&self) -> i32 {
@@ -582,8 +587,8 @@ where
         self.producer.client()
     }
 
-    fn flush<T: Into<Timeout>>(&self, timeout: T) {
-        self.producer.flush(timeout);
+    fn flush<T: Into<Timeout>>(&self, timeout: T) -> KafkaResult<()> {
+        self.producer.flush(timeout)
     }
 
     fn in_flight_count(&self) -> i32 {

--- a/src/producer/future_producer.rs
+++ b/src/producer/future_producer.rs
@@ -356,8 +356,8 @@ where
         self.producer.client()
     }
 
-    fn flush<T: Into<Timeout>>(&self, timeout: T) {
-        self.producer.flush(timeout);
+    fn flush<T: Into<Timeout>>(&self, timeout: T) -> KafkaResult<()> {
+        self.producer.flush(timeout)
     }
 
     fn in_flight_count(&self) -> i32 {

--- a/src/producer/mod.rs
+++ b/src/producer/mod.rs
@@ -235,7 +235,7 @@ where
     ///
     /// This method should be called before termination to ensure delivery of
     /// all enqueued messages. It will call `poll()` internally.
-    fn flush<T: Into<Timeout>>(&self, timeout: T);
+    fn flush<T: Into<Timeout>>(&self, timeout: T) -> KafkaResult<()>;
 
     /// Enable sending transactions with this producer.
     ///

--- a/tests/test_high_producers.rs
+++ b/tests/test_high_producers.rs
@@ -90,7 +90,7 @@ async fn test_future_producer_send_full() {
     assert!(elapsed > Duration::from_millis(800));
     assert!(elapsed < Duration::from_millis(1200));
 
-    producer.flush(Timeout::Never);
+    producer.flush(Timeout::Never).unwrap();
 }
 
 #[tokio::test]

--- a/tests/test_low_producers.rs
+++ b/tests/test_low_producers.rs
@@ -183,7 +183,7 @@ fn test_base_producer_timeout() {
         .filter(|r| r.is_ok())
         .count();
 
-    producer.flush(Duration::from_secs(10));
+    producer.flush(Duration::from_secs(10)).unwrap();
 
     assert_eq!(results_count, 10);
 
@@ -252,7 +252,7 @@ fn test_base_producer_headers() {
         .filter(|r| r.is_ok())
         .count();
 
-    producer.flush(Duration::from_secs(10));
+    producer.flush(Duration::from_secs(10)).unwrap();
 
     assert_eq!(results_count, 10);
     assert_eq!((*ids_set.lock().unwrap()).len(), 10);
@@ -276,7 +276,7 @@ fn test_threaded_producer_send() {
         .count();
 
     assert_eq!(results_count, 10);
-    producer.flush(Duration::from_secs(10));
+    producer.flush(Duration::from_secs(10)).unwrap();
 
     let delivery_results = context.results.lock().unwrap();
     let mut ids = HashSet::new();
@@ -316,7 +316,7 @@ fn test_base_producer_opaque_arc() -> Result<(), Box<dyn Error>> {
         .filter(|r| r.is_ok())
         .count();
 
-    producer.flush(Duration::from_secs(10));
+    producer.flush(Duration::from_secs(10)).unwrap();
 
     let shared_count = Arc::try_unwrap(shared_count).unwrap().into_inner()?;
     assert_eq!(results_count, shared_count);

--- a/tests/test_transactions.rs
+++ b/tests/test_transactions.rs
@@ -103,7 +103,7 @@ async fn test_transaction_abort() -> Result<(), Box<dyn Error>> {
     }
 
     // Abort the transaction, but only after producing all messages.
-    producer.flush(Timeout::Never);
+    producer.flush(Timeout::Never)?;
     producer.abort_transaction(Timeout::Never)?;
 
     // Check that no records were produced in read committed mode, but that


### PR DESCRIPTION
Per the [rdkafka documentation](https://docs.confluent.io/5.5.1/clients/librdkafka/rdkafka_8h.html#aaff06c4372bce917c17f3c1a5d8b205d), `flush` can return `RD_KAFKA_RESP_ERR__TIMED_OUT`.  Pass that through on the `Producer` trait instead of swallowing it.