### PR TITLE
Reduce futures dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -466,9 +466,9 @@ checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "futures"
-version = "0.3.5"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e05b85ec287aac0dc34db7d4a569323df697f9c55b99b15d6b4ef8cde49f613"
+checksum = "28560757fe2bb34e79f907794bb6b22ae8b0e5c669b638a1132f2592b19035b4"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -481,9 +481,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.5"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f366ad74c28cca6ba456d95e6422883cfb4b252a83bed929c83abfdbbf2967d5"
+checksum = "ba3dda0b6588335f360afc675d0564c17a77a2bda81ca178a4b6081bd86c7f0b"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -491,15 +491,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.5"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59f5fff90fd5d971f936ad674802482ba441b6f09ba5e15fd8b39145582ca399"
+checksum = "d0c8ff0461b82559810cdccfde3215c3f373807f5e5232b71479bff7bb2583d7"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.5"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10d6bb888be1153d3abeb9006b11b02cf5e9b209fda28693c31ae1e4e012e314"
+checksum = "29d6d2ff5bb10fb95c85b8ce46538a2e5f5e7fdc755623a7d4529ab8a4ed9d2a"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -508,9 +508,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.5"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de27142b013a8e869c14957e6d2edeef89e97c289e69d042ee3a49acd8b51789"
+checksum = "b1f9d34af5a1aac6fb380f735fe510746c38067c5bf16c7fd250280503c971b2"
 
 [[package]]
 name = "futures-lite"
@@ -529,11 +529,10 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.5"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0b5a30a4328ab5473878237c447333c093297bded83a4983d10f4deea240d39"
+checksum = "6dbd947adfffb0efc70599b3ddcf7b5597bb5fa9e245eb99f62b3a5f7bb8bd3c"
 dependencies = [
- "proc-macro-hack",
  "proc-macro2",
  "quote",
  "syn",
@@ -541,24 +540,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.5"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f2032893cb734c7a05d85ce0cc8b8c4075278e93b24b66f9de99d6eb0fa8acc"
+checksum = "e3055baccb68d74ff6480350f8d6eb8fcfa3aa11bdc1a1ae3afdd0514617d508"
 
 [[package]]
 name = "futures-task"
-version = "0.3.5"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb66b5f09e22019b1ab0830f7785bcea8e7a42148683f99214f73f8ec21a626"
-dependencies = [
- "once_cell",
-]
+checksum = "6ee7c6485c30167ce4dfb83ac568a849fe53274c831081476ee13e0dce1aad72"
 
 [[package]]
 name = "futures-util"
-version = "0.3.5"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8764574ff08b701a084482c3c7031349104b07ac897393010494beaa18ce32c6"
+checksum = "d9b5cf40b47a271f77a8b1bec03ca09044d99d2372c0de244e66430761127164"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -567,10 +563,8 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project",
+ "pin-project-lite",
  "pin-utils",
- "proc-macro-hack",
- "proc-macro-nested",
  "slab",
 ]
 
@@ -873,30 +867,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
 
 [[package]]
-name = "pin-project"
-version = "0.4.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81d480cb4e89522ccda96d0eed9af94180b7a5f93fb28f66e1fd7d68431663d1"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "0.4.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82996f11efccb19b685b14b5df818de31c1edcee3daa256ab5775dd98e72feb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "pin-project-lite"
-version = "0.2.0"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b063f57ec186e6140e2b8b6921e5f1bd89c7356dda5b33acc5401203ca6131c"
+checksum = "e280fbe77cc62c91527259e9442153f4688736748d24660126286329742b4c6c"
 
 [[package]]
 name = "pin-utils"
@@ -933,22 +907,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-hack"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d659fe7c6d27f25e9d80a1a094c223f5246f6a6596453e09d7229bf42750b63"
-
-[[package]]
-name = "proc-macro-nested"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e946095f9d3ed29ec38de908c22f95d9ac008e424c7bcae54c75a79c527c694"
-
-[[package]]
 name = "proc-macro2"
-version = "1.0.13"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53f5ffe53a6b28e37c9c1ce74893477864d64f74778a93a4beb43c8fa167f639"
+checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
 dependencies = [
  "unicode-xid",
 ]
@@ -1101,6 +1063,9 @@ dependencies = [
  "clap",
  "env_logger",
  "futures",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
  "hdrhistogram",
  "libc",
  "log",
@@ -1299,9 +1264,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "syn"
-version = "1.0.41"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6690e3e9f692504b941dc6c3b188fd28df054f7fb8469ab40680df52fdcc842b"
+checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,9 @@ members = ["rdkafka-sys"]
 
 [dependencies]
 rdkafka-sys = { path = "rdkafka-sys", version = "4.2.0", default-features = false }
-futures = "0.3.0"
+futures-channel = "0.3.0"
+futures-executor = { version = "0.3.0", optional = true }
+futures-util = { version = "0.3.0", default-features = false }
 libc = "0.2.0"
 log = "0.4.8"
 serde = { version = "1.0.0", features = ["derive"] }
@@ -31,6 +33,7 @@ backoff = "0.1.5"
 chrono = "0.4.0"
 clap = "2.18.0"
 env_logger = "0.9.0"
+futures = "0.3.0"
 hdrhistogram = "7.0.0"
 maplit = "1.0.2"
 rand = "0.3.15"
@@ -42,6 +45,7 @@ tokio = { version = "1.0", features = ["macros", "rt-multi-thread", "time"] }
 # provides. See the rdkafka-sys documentation for details.
 [features]
 default = ["libz", "tokio"]
+naive-runtime = ["futures-executor"]
 cmake-build = ["rdkafka-sys/cmake-build"]
 cmake_build = ["rdkafka-sys/cmake_build"]
 dynamic-linking = ["rdkafka-sys/dynamic-linking"]

--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,9 @@ See also the [rdkafka-sys changelog](rdkafka-sys/changelog.md).
   feature is enabled. This elides a dependency on `futures-executor` when the
   `niave-runtime` feature is disabled.
 
+* **Breaking change.** Remove the deprecated `StreamConsumer::start` method.
+  Use the more clearly-named `StreamConsumer::stream` method instead.
+
 * Add the `PartitionQueue::set_nonempty_callback` method to register a callback
   for a specific partition queue that will run when that queue becomes
   nonempty. This is a more flexible replacement for the

--- a/changelog.md
+++ b/changelog.md
@@ -4,11 +4,30 @@ See also the [rdkafka-sys changelog](rdkafka-sys/changelog.md).
 
 ## Unreleased
 
+* **Breaking change.** Pass through errors from librdkafka in
+  `BaseProducer::flush`, `StreamProducer::flush`, and `FutureProducer::flush`.
+
+  Thanks, [@cjubb39].
+
+* **Breaking change.** Only provide `NaiveRuntime` if the `naive-runtime`
+  feature is enabled. This elides a dependency on `futures-executor` when the
+  `niave-runtime` feature is disabled.
+
 * Add the `PartitionQueue::set_nonempty_callback` method to register a callback
   for a specific partition queue that will run when that queue becomes
   nonempty. This is a more flexible replacement for the
   `ConsumerContext::message_queue_nonempty_callback` method that was removed
   in the last release.
+
+* In `BaseConsumer::rebalance_protocol` and `StreamConsumer::rebalance_protocol`,
+  handle null return values from the underlying librdkakfa API ([#417]). This
+  avoids an occasional segfault in the rebalance callback.
+
+  Thanks, [@bruceg].
+
+[#417]: https://github.com/fede1024/rust-rdkafka/issues/417
+[@bruceg]: https://github.com/bruceg
+[@cjubb39]: https://github.com/cjubb39
 
 ## 0.28.0 (2021-11-27)
 

--- a/examples/runtime_async_std.rs
+++ b/examples/runtime_async_std.rs
@@ -66,7 +66,7 @@ async fn main() {
     let brokers = matches.value_of("brokers").unwrap();
     let topic = matches.value_of("topic").unwrap().to_owned();
 
-    let producer: FutureProducer = ClientConfig::new()
+    let producer: FutureProducer<_, AsyncStdRuntime> = ClientConfig::new()
         .set("bootstrap.servers", brokers)
         .set("message.timeout.ms", "5000")
         .create()

--- a/examples/runtime_smol.rs
+++ b/examples/runtime_smol.rs
@@ -66,7 +66,7 @@ fn main() {
     let topic = matches.value_of("topic").unwrap().to_owned();
 
     smol::block_on(async {
-        let producer: FutureProducer = ClientConfig::new()
+        let producer: FutureProducer<_, SmolRuntime> = ClientConfig::new()
             .set("bootstrap.servers", brokers)
             .set("message.timeout.ms", "5000")
             .create()

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -14,9 +14,9 @@ use std::task::{Context, Poll};
 use std::thread::{self, JoinHandle};
 use std::time::Duration;
 
-use futures::channel::oneshot;
-use futures::future::{self, Either, FutureExt};
-use futures::ready;
+use futures_channel::oneshot;
+use futures_util::future::{self, Either, FutureExt};
+use futures_util::ready;
 use log::{trace, warn};
 
 use rdkafka_sys as rdsys;

--- a/src/consumer/stream_consumer.rs
+++ b/src/consumer/stream_consumer.rs
@@ -268,12 +268,6 @@ where
         MessageStream::new(&self.wakers, &self.queue)
     }
 
-    /// Constructs a stream that yields messages from this consumer.
-    #[deprecated = "use the more clearly named \"StreamConsumer::stream\" method instead"]
-    pub fn start(&self) -> MessageStream<'_> {
-        self.stream()
-    }
-
     /// Receives the next message from the stream.
     ///
     /// This method will block until the next message is available or an error

--- a/src/producer/future_producer.rs
+++ b/src/producer/future_producer.rs
@@ -10,8 +10,8 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::{Duration, Instant};
 
-use futures::channel::oneshot;
-use futures::FutureExt;
+use futures_channel::oneshot;
+use futures_util::FutureExt;
 
 use crate::client::{Client, ClientContext, DefaultClientContext};
 use crate::config::{ClientConfig, FromClientConfig, FromClientConfigAndContext, RDKafkaLogLevel};
@@ -202,8 +202,11 @@ where
     }
 }
 
-impl FromClientConfig for FutureProducer {
-    fn from_config(config: &ClientConfig) -> KafkaResult<FutureProducer> {
+impl<R> FromClientConfig for FutureProducer<DefaultClientContext, R>
+where
+    R: AsyncRuntime,
+{
+    fn from_config(config: &ClientConfig) -> KafkaResult<FutureProducer<DefaultClientContext, R>> {
         FutureProducer::from_config_and_context(config, DefaultClientContext)
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -10,11 +10,14 @@ use std::ptr;
 use std::ptr::NonNull;
 use std::slice;
 use std::sync::Arc;
+#[cfg(feature = "naive-runtime")]
 use std::thread;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
-use futures::channel::oneshot;
-use futures::future::{FutureExt, Map};
+#[cfg(feature = "naive-runtime")]
+use futures_channel::oneshot;
+#[cfg(feature = "naive-runtime")]
+use futures_util::future::{FutureExt, Map};
 use log::trace;
 
 use rdkafka_sys as rdsys;
@@ -364,25 +367,51 @@ pub trait AsyncRuntime: Send + Sync + 'static {
 /// The default [`AsyncRuntime`] used when one is not explicitly specified.
 ///
 /// This is defined to be the [`TokioRuntime`] when the `tokio` feature is
-/// enabled, and the [`NaiveRuntime`] otherwise.
-#[cfg(not(feature = "tokio"))]
+/// enabled, or the [`NaiveRuntime`] if the `naive-runtime` feature is enabled.
+///
+/// If neither the `tokio` nor `naive-runtime` feature is enabled, this is
+/// defined to be `()`, which is not a valid `AsyncRuntime` and will cause
+/// compilation errors if used as one. You will need to explicitly specify a
+/// custom async runtime wherever one is required.
+#[cfg(not(any(feature = "tokio", feature = "naive-runtime")))]
+pub type DefaultRuntime = ();
+
+/// The default [`AsyncRuntime`] used when one is not explicitly specified.
+///
+/// This is defined to be the [`TokioRuntime`] when the `tokio` feature is
+/// enabled, or the [`NaiveRuntime`] if the `naive-runtime` feature is enabled.
+///
+/// If neither the `tokio` nor `naive-runtime` feature is enabled, this is
+/// defined to be `()`, which is not a valid `AsyncRuntime` and will cause
+/// compilation errors if used as one. You will need to explicitly specify a
+/// custom async runtime wherever one is required.
+#[cfg(all(not(feature = "tokio"), feature = "naive-runtime"))]
 pub type DefaultRuntime = NaiveRuntime;
 
 /// The default [`AsyncRuntime`] used when one is not explicitly specified.
 ///
 /// This is defined to be the [`TokioRuntime`] when the `tokio` feature is
-/// enabled, and the [`NaiveRuntime`] otherwise.
+/// enabled, or the [`NaiveRuntime`] if the `naive-runtime` feature is enabled.
+///
+/// If neither the `tokio` nor `naive-runtime` feature is enabled, this is
+/// defined to be `()`, which is not a valid `AsyncRuntime` and will cause
+/// compilation errors if used as one. You will need to explicitly specify a
+/// custom async runtime wherever one is required.
 #[cfg(feature = "tokio")]
 pub type DefaultRuntime = TokioRuntime;
 
 /// An [`AsyncRuntime`] implementation backed by the executor in the
-/// [futures](futures) crate.
+/// [`futures_executor`](futures_executor) crate.
 ///
 /// This runtime should not be used when performance is a concern, as it makes
-/// heavy use of threads to compenstate for the lack of a timer in the futures
+/// heavy use of threads to compensate for the lack of a timer in the futures
 /// executor.
+#[cfg(feature = "naive-runtime")]
+#[cfg_attr(docsrs, doc(cfg(feature = "naive-runtime")))]
 pub struct NaiveRuntime;
 
+#[cfg(feature = "naive-runtime")]
+#[cfg_attr(docsrs, doc(cfg(feature = "naive-runtime")))]
 impl AsyncRuntime for NaiveRuntime {
     type Delay = Map<oneshot::Receiver<()>, fn(Result<(), oneshot::Canceled>)>;
 
@@ -390,7 +419,7 @@ impl AsyncRuntime for NaiveRuntime {
     where
         T: Future<Output = ()> + Send + 'static,
     {
-        thread::spawn(|| futures::executor::block_on(task));
+        thread::spawn(|| futures_executor::block_on(task));
     }
 
     fn delay_for(duration: Duration) -> Self::Delay {


### PR DESCRIPTION
In the main library, swap the dependency on `futures` for individual
dependencies on `futures-channel`, `futures-util`, and
`futures-executor`. This reduces the dependency load on downstream
projects. Additionally disable the `futures-util::select` macro and use
the slightly more cumbersome function to lose a dependency on
proc-macro-hack and proc-macro nested.

This has two changes from #432:

  * The `futures-executor` dependency is optionalized on the new
    `naive-runtime` feature.

  * The tests and examples continue to use the main `futures` crate,
    since there's no need to be so careful with dependencies in
    tests/examples. In examples particularly I think it's much clearer
    to refer to the main `futures` crate rather than its subcrates.

Closes #432.

Co-authored-by: Rob Ede <robjtede@icloud.com>