### PR TITLE
Fix misleading error message on pkg_config failure

### DIFF
--- a/rdkafka-sys/build.rs
+++ b/rdkafka-sys/build.rs
@@ -65,8 +65,7 @@ fn main() {
             Err(err) => {
                 eprintln!(
                     "librdkafka {} cannot be found on the system: {}",
-                    librdkafka_version,
-                    err
+                    librdkafka_version, err
                 );
                 eprintln!("Dynamic linking failed. Exiting.");
                 process::exit(1);

--- a/rdkafka-sys/build.rs
+++ b/rdkafka-sys/build.rs
@@ -62,10 +62,11 @@ fn main() {
                 eprintln!("  Path: {:?}", library.link_paths);
                 eprintln!("  Version: {}", library.version);
             }
-            Err(_) => {
+            Err(err) => {
                 eprintln!(
-                    "librdkafka {} cannot be found on the system",
-                    librdkafka_version
+                    "librdkafka {} cannot be found on the system: {}",
+                    librdkafka_version,
+                    err
                 );
                 eprintln!("Dynamic linking failed. Exiting.");
                 process::exit(1);


### PR DESCRIPTION
pkg_config could fail for various reasons including dependency issues to other libs, not only when librdkafka is not found. Actually, I needed to `brew install openssl` to make it successful. By printing error together, it should be easier to troubleshoot such errors.
