### PR TITLE
add `tracing` feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
         - os: macos-11.0
         - os: windows-2019
           features: cmake-build,libz-static
+          rdkafka-sys-features: cmake-build,libz-static
+        - os: ubuntu-20.04
+          features: tracing
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2
@@ -38,7 +41,7 @@ jobs:
         toolchain: ${{ env.rust_version }}
         default: true
     - run: cargo build --all-targets --verbose --features "${{ matrix.features }}"
-    - run: cd rdkafka-sys && cargo test --features "${{ matrix.features }}"
+    - run: cd rdkafka-sys && cargo test --features "${{ matrix.rdkafka-sys-features }}"
 
   # Use the `minimal-versions` resolver to ensure we're not claiming to support
   # an older version of a dependency than we actually do.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1079,6 +1079,7 @@ dependencies = [
  "slab",
  "smol",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -1340,6 +1341,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffc92d160b1eef40665be3a05630d003936a3bc7da7421277846c2613e92c71a"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d8d93354fe2a8e50d5953f5ae2e47a3fc2ef03292e7ea46e3cc38f549525fb9"
+dependencies = [
+ "cfg-if 1.0.0",
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8276d9a4a3a558d7b7ad5303ad50b53d58264641b82914b7ada36bd762e7a716"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03cfcb51380632a72d3111cb8d3447a8d908e577d31beeac006f836383d29a23"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ serde_derive = "1.0.0"
 serde_json = "1.0.0"
 slab = "0.4"
 tokio = { version = "1.0", features = ["rt", "time"], optional = true }
+tracing = { version = "0.1.30", optional = true }
 
 [dev-dependencies]
 async-std = { version = "1.9.0", features = ["attributes"] }
@@ -65,5 +66,5 @@ external_lz4 = ["rdkafka-sys/external_lz4"]
 [package.metadata.docs.rs]
 # docs.rs doesn't allow writing to ~/.cargo/registry (reasonably), so we have to
 # use the CMake build for a proper out-of-tree build.
-features = ["cmake_build", "naive-runtime", "tokio"]
+features = ["cmake-build", "naive-runtime", "tracing", "tokio"]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -17,7 +17,6 @@ use std::time::Duration;
 use futures_channel::oneshot;
 use futures_util::future::{self, Either, FutureExt};
 use futures_util::ready;
-use log::{trace, warn};
 
 use rdkafka_sys as rdsys;
 use rdkafka_sys::types::*;
@@ -25,6 +24,7 @@ use rdkafka_sys::types::*;
 use crate::client::{Client, ClientContext, DefaultClientContext, NativeQueue};
 use crate::config::{ClientConfig, FromClientConfig, FromClientConfigAndContext};
 use crate::error::{IsError, KafkaError, KafkaResult};
+use crate::log::{trace, warn};
 use crate::util::{cstr_to_owned, AsCArray, ErrBuf, IntoOpaque, KafkaDrop, NativePtr, Timeout};
 
 //

--- a/src/client.rs
+++ b/src/client.rs
@@ -21,8 +21,6 @@ use std::slice;
 use std::string::ToString;
 use std::sync::Arc;
 
-use log::{debug, error, info, trace, warn};
-
 use rdkafka_sys as rdsys;
 use rdkafka_sys::types::*;
 
@@ -30,6 +28,7 @@ use crate::config::{ClientConfig, NativeClientConfig, RDKafkaLogLevel};
 use crate::consumer::RebalanceProtocol;
 use crate::error::{IsError, KafkaError, KafkaResult};
 use crate::groups::GroupList;
+use crate::log::{debug, error, info, trace, warn};
 use crate::metadata::Metadata;
 use crate::statistics::Statistics;
 use crate::util::{ErrBuf, KafkaDrop, NativePtr, Timeout};

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,13 +28,12 @@ use std::iter::FromIterator;
 use std::os::raw::c_char;
 use std::ptr;
 
-use log::{log_enabled, Level};
-
 use rdkafka_sys as rdsys;
 use rdkafka_sys::types::*;
 
 use crate::client::ClientContext;
 use crate::error::{IsError, KafkaError, KafkaResult};
+use crate::log::{log_enabled, DEBUG, INFO, WARN};
 use crate::util::{ErrBuf, KafkaDrop, NativePtr};
 
 /// The log levels supported by librdkafka.
@@ -286,11 +285,11 @@ impl Extend<(String, String)> for ClientConfig {
 
 /// Return the log level
 fn log_level_from_global_config() -> RDKafkaLogLevel {
-    if log_enabled!(target: "librdkafka", Level::Debug) {
+    if log_enabled!(target: "librdkafka", DEBUG) {
         RDKafkaLogLevel::Debug
-    } else if log_enabled!(target: "librdkafka", Level::Info) {
+    } else if log_enabled!(target: "librdkafka", INFO) {
         RDKafkaLogLevel::Info
-    } else if log_enabled!(target: "librdkafka", Level::Warn) {
+    } else if log_enabled!(target: "librdkafka", WARN) {
         RDKafkaLogLevel::Warning
     } else {
         RDKafkaLogLevel::Error

--- a/src/consumer/base_consumer.rs
+++ b/src/consumer/base_consumer.rs
@@ -7,8 +7,6 @@ use std::os::raw::c_void;
 use std::ptr;
 use std::sync::Arc;
 
-use log::trace;
-
 use rdkafka_sys as rdsys;
 use rdkafka_sys::types::*;
 
@@ -22,6 +20,7 @@ use crate::consumer::{
 };
 use crate::error::{IsError, KafkaError, KafkaResult};
 use crate::groups::GroupList;
+use crate::log::trace;
 use crate::message::{BorrowedMessage, Message};
 use crate::metadata::Metadata;
 use crate::topic_partition_list::{Offset, TopicPartitionList};

--- a/src/consumer/mod.rs
+++ b/src/consumer/mod.rs
@@ -4,14 +4,13 @@ use std::ptr;
 use std::sync::Arc;
 use std::time::Duration;
 
-use log::{error, trace};
-
 use rdkafka_sys as rdsys;
 use rdkafka_sys::types::*;
 
 use crate::client::{Client, ClientContext, NativeClient};
 use crate::error::KafkaResult;
 use crate::groups::GroupList;
+use crate::log::{error, trace};
 use crate::message::BorrowedMessage;
 use crate::metadata::Metadata;
 use crate::topic_partition_list::{Offset, TopicPartitionList};

--- a/src/consumer/stream_consumer.rs
+++ b/src/consumer/stream_consumer.rs
@@ -9,11 +9,11 @@ use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll, Waker};
 use std::time::Duration;
 
+use crate::log::trace;
 use futures_channel::oneshot;
 use futures_util::future::{self, Either, FutureExt};
 use futures_util::pin_mut;
 use futures_util::stream::{Stream, StreamExt};
-use log::trace;
 use slab::Slab;
 
 use rdkafka_sys as rdsys;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,9 +207,13 @@
 //!
 //! ## Debugging
 //!
-//! rust-rdkafka uses the [`log`] and [`env_logger`] crates to handle logging.
-//! Logging can be enabled using the `RUST_LOG` environment variable, for
-//! example:
+//! rust-rdkafka uses the [`log`] crate to handle logging.
+//! Optionally, enable the `tracing` feature to emit [`tracing`]
+//! events as opposed to [`log`] records.
+//!
+//! In test and examples, rust-rdkafka uses the  [`env_logger`] crate
+//! to format logs. In those contexts, logging can be enabled
+//! using the `RUST_LOG` environment variable, for example:
 //!
 //! ```bash
 //! RUST_LOG="librdkafka=trace,rdkafka::client=debug" cargo test
@@ -234,6 +238,7 @@
 //! [`StreamConsumer`]: https://docs.rs/rdkafka/*/rdkafka/consumer/stream_consumer/struct.StreamConsumer.html
 //! [`ThreadedProducer`]: https://docs.rs/rdkafka/*/rdkafka/producer/base_producer/struct.ThreadedProducer.html
 //! [`log`]: https://docs.rs/log
+//! [`tracing`]: https://docs.rs/tracing
 //! [`env_logger`]: https://docs.rs/env_logger
 //! [Apache Kafka]: https://kafka.apache.org
 //! [asynchronous processing example]: https://github.com/fede1024/rust-rdkafka/blob/master/examples/asynchronous_processing.rs
@@ -261,6 +266,8 @@
 #![deny(rust_2018_idioms)]
 #![allow(clippy::type_complexity)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
+
+mod log;
 
 pub use rdkafka_sys::types;
 

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,0 +1,19 @@
+//! A wrapper module to export logging functionality from
+//! [`log`] or [`tracing`] depending on the `tracing` feature.
+//!
+//! [`log`]: https://docs.rs/log
+//! [`tracing`]: https://docs.rs/tracing
+
+#[cfg(not(feature = "tracing"))]
+pub use log::Level::{Debug as DEBUG, Info as INFO, Warn as WARN};
+#[cfg(not(feature = "tracing"))]
+pub use log::{debug, error, info, log_enabled, trace, warn};
+
+#[cfg(feature = "tracing")]
+pub use tracing::{debug, enabled as log_enabled, error, info, trace, warn};
+#[cfg(feature = "tracing")]
+pub const DEBUG: tracing::Level = tracing::Level::DEBUG;
+#[cfg(feature = "tracing")]
+pub const INFO: tracing::Level = tracing::Level::INFO;
+#[cfg(feature = "tracing")]
+pub const WARN: tracing::Level = tracing::Level::WARN;

--- a/src/util.rs
+++ b/src/util.rs
@@ -18,7 +18,8 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use futures_channel::oneshot;
 #[cfg(feature = "naive-runtime")]
 use futures_util::future::{FutureExt, Map};
-use log::trace;
+
+use crate::log::trace;
 
 use rdkafka_sys as rdsys;
 


### PR DESCRIPTION
Much of the rust ecosystem uses `tracing` over `log`

This branch adds an optional feature `tracing` to `rdkafka` that uses `tracing` log lines instead of `log` ones. See https://github.com/MaterializeInc/materialize/blob/883710649f95d232ead5872518969a15c1def542/src/kafka-util/src/client.rs#L28-L47 for an example of how people have to work around this, over using the `DefaultClientContext`

Some notes:
- `tracing::enabled!` is slightly different than `log::log_enabled!` in that it doesn't query the tracing subscriber for specifically `Event` type's. In practice, I have found this to be a vanishingly small difference, but with https://github.com/tokio-rs/tracing/pull/1900 this pr (after its landed, backported, and released), it could be possible to slightly improve
- `tracing` log levels are consts, not variants, so I have to do some re-declaration to make them importable to make the `enabled!` callsites as easy as possible to use
- I am not sure how to test this, other than just `cargo test/check`, but I need help setting up ci to exercise this