### PR TITLE
add support for OAuth

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -33,6 +33,43 @@ use crate::metadata::Metadata;
 use crate::statistics::Statistics;
 use crate::util::{ErrBuf, KafkaDrop, NativePtr, Timeout};
 
+/// OAuthToken Data
+///
+/// When using token refresh, this data structure provides the fields used in
+/// the OAuth token refresh callback function.
+///
+/// NOTE: SASL extensions are not currently supported
+pub struct OAuthTokenData {
+    token: String,
+    lifetime_ms: i64,
+    principal_name: String,
+    errstr_size: usize,
+}
+
+impl OAuthTokenData {
+    /// Creates a new token data structure, with given value, lifetime, and
+    /// principal name. Error string size is set to 512 bytes.
+    pub fn new(token: String, lifetime_ms: i64, principal_name: String) -> Self {
+        Self {
+            token,
+            lifetime_ms,
+            principal_name,
+            errstr_size: 512,
+        }
+    }
+
+    /// Modifies the error string size to the specified value.
+    pub fn with_errorstring_size(&mut self, errstr_size: usize) -> &mut OAuthTokenData {
+        self.errstr_size = errstr_size;
+        self
+    }
+}
+/// Reporting mechanism for errors in generating OAuth tokens.
+pub struct OAuthTokenError(String);
+
+/// Result type specifically used for generating OAuth tokens
+pub type OAuthResult = Result<OAuthTokenData, OAuthTokenError>;
+
 /// Client-level context.
 ///
 /// Each client (consumers and producers included) has a context object that can
@@ -105,13 +142,12 @@ pub trait ClientContext: Send + Sync {
         error!("librdkafka: {}: {}", error, reason);
     }
 
-    /// Refreshes the OAuth token.
+    /// Generates the OAuth token.
     ///
-    /// The default implementation just logs an error message at the `error`
-    /// log level. This function is called if/when the token refresh callback
-    /// is called.
-    fn refresh_oauth_token(&self, _client: *mut RDKafka, _oauthbearer_config: *const i8) {
-        error!("Default token refresh only prints an error");
+    /// The default implementation generates an error.
+    fn generate_oauth_token(&self, _oauthbearer_config: &str) -> OAuthResult {
+        let error_string = "Default token generation only produces an error".into();
+        Err(OAuthTokenError(error_string))
     }
 
     // NOTE: when adding a new method, remember to add it to the
@@ -464,13 +500,74 @@ pub(crate) unsafe extern "C" fn native_error_cb<C: ClientContext>(
     context.error(error, reason.trim());
 }
 
+unsafe fn handle_refresh_error_msg(client: *mut RDKafka, error_msg: &str) {
+    error!("{}", error_msg);
+    rdkafka_sys::rd_kafka_oauthbearer_set_token_failure(
+        client,
+        error_msg.as_ptr() as *const c_char,
+    );
+}
+
 pub(crate) unsafe extern "C" fn native_oauth_refresh_cb<C: ClientContext>(
     client: *mut RDKafka,
     oauthbearer_config: *const i8,
     opaque: *mut c_void,
 ) {
+    // generate the token using generate_oauth_token
     let context = &mut *(opaque as *mut C);
-    context.refresh_oauth_token(client, oauthbearer_config);
+    let oauthbearer_config = CStr::from_ptr(oauthbearer_config).to_string_lossy();
+    let token_info = match context.generate_oauth_token(oauthbearer_config.trim()) {
+        Ok(token_info) => token_info,
+        Err(OAuthTokenError(errmsg)) => {
+            handle_refresh_error_msg(client, &errmsg);
+            return;
+        }
+    };
+
+    let token_cstring = match CString::new(token_info.token) {
+        Ok(token_cstring) => token_cstring,
+        Err(_) => {
+            let errmsg = "Could not convert token String to CString";
+            handle_refresh_error_msg(client, errmsg);
+            return;
+        }
+    };
+
+    let principal_name = match CString::new(token_info.principal_name) {
+        Ok(principal_name) => principal_name,
+        Err(_) => {
+            let errmsg = "Could not convert principal_name String to CString";
+            handle_refresh_error_msg(client, errmsg);
+            return;
+        }
+    };
+
+    let errstr = match CString::new(vec![0_u8; token_info.errstr_size]) {
+        Ok(errstr) => errstr,
+        Err(_) => {
+            let errmsg = "Could not create error string";
+            handle_refresh_error_msg(client, errmsg);
+            return;
+        }
+    };
+
+    let rcode = rdkafka_sys::rd_kafka_oauthbearer_set_token(
+        client,
+        token_cstring.as_ptr(),
+        token_info.lifetime_ms,
+        principal_name.as_ptr(),
+        ptr::null_mut(),
+        0,
+        errstr.as_ptr() as *mut c_char,
+        token_info.errstr_size,
+    );
+
+    if rcode == rdkafka_sys::rd_kafka_resp_err_t::RD_KAFKA_RESP_ERR_NO_ERROR {
+        info!("Successfully set token");
+    } else {
+        let errmsg = errstr.to_string_lossy();
+        handle_refresh_error_msg(client, errmsg.trim());
+    }
 }
 
 #[cfg(test)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -161,6 +161,7 @@ impl NativeClientConfig {
 #[derive(Clone, Debug)]
 pub struct ClientConfig {
     conf_map: HashMap<String, String>,
+    pub(crate) use_token_refresh_cb: bool,
     /// The librdkafka logging level. Refer to [`RDKafkaLogLevel`] for the list
     /// of available levels.
     pub log_level: RDKafkaLogLevel,
@@ -177,6 +178,7 @@ impl ClientConfig {
     pub fn new() -> ClientConfig {
         ClientConfig {
             conf_map: HashMap::new(),
+            use_token_refresh_cb: false,
             log_level: log_level_from_global_config(),
         }
     }
@@ -217,6 +219,13 @@ impl ClientConfig {
     /// on the global log level of the log crate.
     pub fn set_log_level(&mut self, log_level: RDKafkaLogLevel) -> &mut ClientConfig {
         self.log_level = log_level;
+        self
+    }
+
+    /// Tells the client to use the `generate_oauth_token` function defined by the context to
+    /// refresh the OAuth token.
+    pub fn use_oauth_token_refresh_cb(&mut self) -> &mut ClientConfig {
+        self.use_token_refresh_cb = true;
         self
     }
 

--- a/src/producer/future_producer.rs
+++ b/src/producer/future_producer.rs
@@ -12,6 +12,7 @@ use std::time::{Duration, Instant};
 
 use futures_channel::oneshot;
 use futures_util::FutureExt;
+use rdkafka_sys::types::RDKafka;
 
 use crate::client::{Client, ClientContext, DefaultClientContext};
 use crate::config::{ClientConfig, FromClientConfig, FromClientConfigAndContext, RDKafkaLogLevel};
@@ -151,6 +152,11 @@ impl<C: ClientContext + 'static> ClientContext for FutureProducerContext<C> {
 
     fn error(&self, error: KafkaError, reason: &str) {
         self.wrapped_context.error(error, reason);
+    }
+
+    fn refresh_oauth_token(&self, client: *mut RDKafka, oauthbearer_config: *const i8) {
+        self.wrapped_context
+            .refresh_oauth_token(client, oauthbearer_config);
     }
 }
 

--- a/src/producer/future_producer.rs
+++ b/src/producer/future_producer.rs
@@ -12,9 +12,8 @@ use std::time::{Duration, Instant};
 
 use futures_channel::oneshot;
 use futures_util::FutureExt;
-use rdkafka_sys::types::RDKafka;
 
-use crate::client::{Client, ClientContext, DefaultClientContext};
+use crate::client::{Client, ClientContext, DefaultClientContext, OAuthResult};
 use crate::config::{ClientConfig, FromClientConfig, FromClientConfigAndContext, RDKafkaLogLevel};
 use crate::consumer::ConsumerGroupMetadata;
 use crate::error::{KafkaError, KafkaResult, RDKafkaErrorCode};
@@ -154,9 +153,9 @@ impl<C: ClientContext + 'static> ClientContext for FutureProducerContext<C> {
         self.wrapped_context.error(error, reason);
     }
 
-    fn refresh_oauth_token(&self, client: *mut RDKafka, oauthbearer_config: *const i8) {
+    fn generate_oauth_token(&self, oauthbearer_config: &str) -> OAuthResult {
         self.wrapped_context
-            .refresh_oauth_token(client, oauthbearer_config);
+            .generate_oauth_token(oauthbearer_config)
     }
 }
 


### PR DESCRIPTION
This PR is meant to provide the user a way to build a Client that uses the `oauthbearer_refresh_token_cb` functionality in rdkafka-sys. It also provides the plumbing  to define their own callback through the `ClientContext` trait.

- `ClientConfig` has a `pub(crate)` flag that tells the `Client` to set the callback function to that of the given `<impl>ClientContext` type.
- Default implementation of the callback just logs a message at the error level, the user needs to create their own callback function.

Example
```rust
// Define a type that overrides the default refresh_oauth_token method
struct RefreshContext {
    // relevant fields
}

impl RefreshContext {
    // other impl details
}

impl ClientContext for RefreshContext {
    fn refresh_oauth_token(&self, client: &mut RDKafka, oauthbearer_config: *const i8) {
         // set the token with rdkafka_sys::rd_kafka_oauthbearer_set_token
    }
}

let config = ClientConfig::new();
config.use_oauth_token_refresh_cb();
// other settings

let context = RefreshContext::new();
let producer = FutureProducer<RefreshContext> = config
    .create_with_context(context)
    .expect("Producer creation failed");

// etc.
```

Let me know what you think. The prototyping I've done for this has been on an older version of this crate, so testing is needed for these changes, particularly for `Consumer` types.