### PR TITLE
Allow distinguishing between null and empty header values

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,7 @@ jobs:
 
   test:
     strategy:
+      fail-fast: false
       matrix:
         include:
         - confluent-version: 5.3.1
@@ -80,6 +81,7 @@ jobs:
       with:
         toolchain: ${{ env.rust_version }}
         default: true
+    - run: sudo apt-get update
     - run: sudo apt-get install -qy valgrind
     - run: ./test_suite.sh
       env:

--- a/changelog.md
+++ b/changelog.md
@@ -16,6 +16,33 @@ See also the [rdkafka-sys changelog](rdkafka-sys/changelog.md).
 * **Breaking change.** Remove the deprecated `StreamConsumer::start` method.
   Use the more clearly-named `StreamConsumer::stream` method instead.
 
+* **Breaking change.** Rework the `Headers` trait to distinguish between
+  headers with null values and headers with empty values. The `Headers::get`
+  and `Headers::get_as` methods now return a `Header` struct with the following
+  definition:
+
+  ```rust
+  pub struct Header<'a, V> {
+      pub key: &'a str,
+      pub value: Option<V>,
+  }
+  ```
+
+  Previously, these methods operated in terms of key–value pair `(&str, &[u8])`.
+
+  These methods now panic if presented with an out-of-bounds index. This
+  simplifies their usage in the common case where the index is known to be
+  valid. Use the new `Headers::try_get` and `Headers::try_get_as` methods if you
+  need the old behavior of returning `None` if the index is invalid.
+
+* Rename the `OwnedHeader::add` method to `OwnedHeader::insert`, for parity with
+  the equivalent method for the map types in `std::collection` and to avoid
+  confusion with the `add` method of the `std::ops::Add` trait. The method now
+  takes the `Header` type mentioned above as an argument, rather than the key
+  and value as separate arguments.
+
+* Add the `Headers::iter` method to iterate over all message headers in order.
+
 * Add the `PartitionQueue::set_nonempty_callback` method to register a callback
   for a specific partition queue that will run when that queue becomes
   nonempty. This is a more flexible replacement for the

--- a/examples/simple_consumer.rs
+++ b/examples/simple_consumer.rs
@@ -72,9 +72,8 @@ async fn consume_and_print(brokers: &str, group_id: &str, topics: &[&str]) {
                 info!("key: '{:?}', payload: '{}', topic: {}, partition: {}, offset: {}, timestamp: {:?}",
                       m.key(), payload, m.topic(), m.partition(), m.offset(), m.timestamp());
                 if let Some(headers) = m.headers() {
-                    for i in 0..headers.count() {
-                        let header = headers.get(i).unwrap();
-                        info!("  Header {:#?}: {:?}", header.0, header.1);
+                    for header in headers.iter() {
+                        info!("  Header {:#?}: {:?}", header.key, header.value);
                     }
                 }
                 consumer.commit_message(&m, CommitMode::Async).unwrap();

--- a/rdkafka-sys/simple_producer.rs
+++ b/rdkafka-sys/simple_producer.rs
@@ -4,7 +4,7 @@ use clap::{App, Arg};
 use log::info;
 
 use rdkafka::config::ClientConfig;
-use rdkafka::message::{Header, OwnedHeaders};
+use rdkafka::message::OwnedHeaders;
 use rdkafka::producer::{FutureProducer, FutureRecord};
 use rdkafka::util::get_rdkafka_version;
 
@@ -30,10 +30,7 @@ async fn produce(brokers: &str, topic_name: &str) {
                     FutureRecord::to(topic_name)
                         .payload(&format!("Message {}", i))
                         .key(&format!("Key {}", i))
-                        .headers(OwnedHeaders::new().insert(Header {
-                            key: "header_key",
-                            value: Some("header_value"),
-                        })),
+                        .headers(OwnedHeaders::new().add("header_key", "header_value")),
                     Duration::from_secs(0),
                 )
                 .await;


### PR DESCRIPTION
Kafka distinguishes between null header values and empty header values,
but rust-rdkafka was presenting null header values as empty header
values. Rework the API to preserve the distinction.