### PR TITLE
Add detach_headers for OwnedMessage

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -517,6 +517,12 @@ impl OwnedMessage {
             headers,
         }
     }
+
+    /// Detach `OwnedHeaders` from OwnedMessage.
+    /// If you just need a reference, peek the headers() method.
+    pub fn detach_headers(&mut self) -> Option<OwnedHeaders> {
+        self.headers.take()
+    }
 }
 
 impl Message for OwnedMessage {

--- a/src/message.rs
+++ b/src/message.rs
@@ -518,8 +518,7 @@ impl OwnedMessage {
         }
     }
 
-    /// Detach `OwnedHeaders` from OwnedMessage.
-    /// If you just need a reference, peek the headers() method.
+    /// Detaches the [`OwnedHeaders`] from this `OwnedMessage`.
     pub fn detach_headers(&mut self) -> Option<OwnedHeaders> {
         self.headers.take()
     }


### PR DESCRIPTION
Currently an `OwnedMessage` only allows to get a reference to the attached `OwnedHeaders`. This PR allows to detach the `OwnedHeaders` from the `OwnedMessage`.