### PR TITLE
Enable Atomic swap for statistics coming from librdkafka by enabling `Clone` on `Statistics`

### DIFF
--- a/src/statistics.rs
+++ b/src/statistics.rs
@@ -15,7 +15,7 @@ use std::collections::HashMap;
 use serde::Deserialize;
 
 /// Overall statistics.
-#[derive(Deserialize, Debug, Default)]
+#[derive(Deserialize, Debug, Default, Clone)]
 pub struct Statistics {
     /// The name of the librdkafka handle.
     pub name: String,
@@ -73,7 +73,7 @@ pub struct Statistics {
 }
 
 /// Per-broker statistics.
-#[derive(Deserialize, Debug, Default)]
+#[derive(Deserialize, Debug, Default, Clone)]
 pub struct Broker {
     /// The broker hostname, port, and ID, in the form `HOSTNAME:PORT/ID`.
     pub name: String,
@@ -168,7 +168,7 @@ pub struct Broker {
 ///
 /// These values are not exact; they are sampled estimates maintained by an
 /// HDR histogram in librdkafka.
-#[derive(Deserialize, Debug, Default)]
+#[derive(Deserialize, Debug, Default, Clone)]
 pub struct Window {
     /// The smallest value.
     pub min: i64,
@@ -202,7 +202,7 @@ pub struct Window {
 }
 
 /// A topic and partition specifier.
-#[derive(Deserialize, Debug, Default)]
+#[derive(Deserialize, Debug, Default, Clone)]
 pub struct TopicPartition {
     /// The name of the topic.
     pub topic: String,
@@ -211,7 +211,7 @@ pub struct TopicPartition {
 }
 
 /// Per-topic statistics.
-#[derive(Deserialize, Debug, Default)]
+#[derive(Deserialize, Debug, Default, Clone)]
 pub struct Topic {
     /// The name of the topic.
     pub topic: String,
@@ -226,7 +226,7 @@ pub struct Topic {
 }
 
 /// Per-partition statistics.
-#[derive(Deserialize, Debug, Default)]
+#[derive(Deserialize, Debug, Default, Clone)]
 pub struct Partition {
     /// The partition ID.
     pub partition: i32,
@@ -299,7 +299,7 @@ pub struct Partition {
 }
 
 /// Consumer group manager statistics.
-#[derive(Deserialize, Debug, Default)]
+#[derive(Deserialize, Debug, Default, Clone)]
 pub struct ConsumerGroup {
     /// The local consumer group handler's state.
     pub state: String,
@@ -321,7 +321,7 @@ pub struct ConsumerGroup {
 }
 
 /// Exactly-once semantics statistics.
-#[derive(Deserialize, Debug, Default)]
+#[derive(Deserialize, Debug, Default, Clone)]
 pub struct ExactlyOnceSemantics {
     /// The current idempotent producer state.
     pub idemp_state: String,


### PR DESCRIPTION
Adding `Clone` will enable sharing through atomic replacement with a callback.

How?
https://github.com/vertexclique/callysto/blob/master/src/kafka/contexts.rs#L31-L49