### PR TITLE
Fix possible unsoundness in IntoOpaque to do with pointer provenance

### DIFF
--- a/src/producer/base_producer.rs
+++ b/src/producer/base_producer.rs
@@ -323,7 +323,7 @@ where
     // unstable.
     pub fn send<'a, K, P>(
         &self,
-        record: BaseRecord<'a, K, P, C::DeliveryOpaque>,
+        mut record: BaseRecord<'a, K, P, C::DeliveryOpaque>,
     ) -> Result<(), (KafkaError, BaseRecord<'a, K, P, C::DeliveryOpaque>)>
     where
         K: ToBytes + ?Sized,
@@ -338,6 +338,7 @@ where
         let (payload_ptr, payload_len) = as_bytes(record.payload);
         let (key_ptr, key_len) = as_bytes(record.key);
         let topic_cstring = CString::new(record.topic.to_owned()).unwrap();
+        let ptr = record.delivery_opaque.into_ptr();
         let produce_error = unsafe {
             rdsys::rd_kafka_producev(
                 self.native_ptr(),
@@ -354,7 +355,7 @@ where
                 key_ptr,
                 key_len,
                 RD_KAFKA_VTYPE_OPAQUE,
-                record.delivery_opaque.as_ptr(),
+                ptr,
                 RD_KAFKA_VTYPE_TIMESTAMP,
                 record.timestamp.unwrap_or(0),
                 RD_KAFKA_VTYPE_HEADERS,
@@ -366,10 +367,10 @@ where
             )
         };
         if produce_error.is_error() {
+            record.delivery_opaque = unsafe { C::DeliveryOpaque::from_ptr(ptr) };
             Err((KafkaError::MessageProduction(produce_error.into()), record))
         } else {
-            // The kafka producer now owns the delivery opaque and the headers
-            mem::forget(record.delivery_opaque);
+            // The kafka producer now owns the headers
             mem::forget(record.headers);
             Ok(())
         }

--- a/src/producer/base_producer.rs
+++ b/src/producer/base_producer.rs
@@ -338,7 +338,7 @@ where
         let (payload_ptr, payload_len) = as_bytes(record.payload);
         let (key_ptr, key_len) = as_bytes(record.key);
         let topic_cstring = CString::new(record.topic.to_owned()).unwrap();
-        let ptr = record.delivery_opaque.into_ptr();
+        let opaque_ptr = record.delivery_opaque.into_ptr();
         let produce_error = unsafe {
             rdsys::rd_kafka_producev(
                 self.native_ptr(),
@@ -355,7 +355,7 @@ where
                 key_ptr,
                 key_len,
                 RD_KAFKA_VTYPE_OPAQUE,
-                ptr,
+                opaque_ptr,
                 RD_KAFKA_VTYPE_TIMESTAMP,
                 record.timestamp.unwrap_or(0),
                 RD_KAFKA_VTYPE_HEADERS,
@@ -367,7 +367,7 @@ where
             )
         };
         if produce_error.is_error() {
-            record.delivery_opaque = unsafe { C::DeliveryOpaque::from_ptr(ptr) };
+            record.delivery_opaque = unsafe { C::DeliveryOpaque::from_ptr(opaque_ptr) };
             Err((KafkaError::MessageProduction(produce_error.into()), record))
         } else {
             // The kafka producer now owns the headers


### PR DESCRIPTION
See #471

For `Arc`, an alternative that doesn't break the existing code would be to leave `as_ptr` as is and use `Arc::as_ptr(self)`, but the relevant `Box` methods take by `self`, so a more thorough analysis is required.