### PR TITLE
fix: dropping a consumer can block indefinitely

### DIFF
--- a/src/consumer/stream_consumer.rs
+++ b/src/consumer/stream_consumer.rs
@@ -165,9 +165,9 @@ pub struct StreamConsumer<C = DefaultConsumerContext, R = DefaultRuntime>
 where
     C: ConsumerContext,
 {
+    queue: NativeQueue, // queue must be dropped before the base to avoid deadlock
     base: BaseConsumer<C>,
     wakers: Arc<WakerSlab>,
-    queue: NativeQueue,
     _shutdown_trigger: oneshot::Sender<()>,
     _runtime: PhantomData<R>,
 }


### PR DESCRIPTION
The call to `rd_kafka_consumer_close()` in the `Drop` trait of `BaseConsumer` can block in the rebalance callback indefinitely. It's stuck in the call `rd_kafka_rebalance_protocol()` waiting for a queue operation to be completed. We often see this happen when an external process deletes a topic that was currently being consumed in our application, leaving thread trying to drop the `BaseConsumer` in a hung state.

Rust drops fields in a struct in the order they are declared in the source. When the `StreamConsumer` is dropped, it will first call `base.drop()`, which eventually executes `rd_kafka_consumer_close()`, and then calls `queue.drop()`, which eventually executes `rd_kafka_queue_destroy()`. This ordering is incorrect according to the documentation for [rd_kafka_queue_get_consumer()](https://docs.confluent.io/3.2.1/clients/librdkafka/rdkafka_8h.html#acacdb55ae7cb6abfbde89621e512b078). Moving the queue `field` above `base` causes rust to then call the underlying librdkafka functions in the correct order when the `StreamConsumer` is dropped.

Shout out to @penick for the collaboration on troubleshooting and testing the fix.