### PR TITLE
chore: increase Debug derive coverage

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -155,6 +155,7 @@ impl ClientContext for DefaultClientContext {}
 /// A native rdkafka-sys client. This struct shouldn't be used directly. Use
 /// higher level `Client` or producers and consumers.
 // TODO(benesch): this should be `pub(crate)`.
+#[derive(Debug)]
 pub struct NativeClient {
     ptr: NativePtr<RDKafka>,
 }
@@ -208,6 +209,7 @@ impl NativeClient {
 ///
 /// [`consumer`]: crate::consumer
 /// [`producer`]: crate::producer
+#[derive(Debug)]
 pub struct Client<C: ClientContext = DefaultClientContext> {
     native: NativeClient,
     context: Arc<C>,

--- a/src/consumer/base_consumer.rs
+++ b/src/consumer/base_consumer.rs
@@ -65,6 +65,7 @@ unsafe extern "C" fn native_rebalance_cb<C: ConsumerContext>(
 ///
 /// This consumer must be periodically polled to make progress on rebalancing,
 /// callbacks and to receive messages.
+#[derive(Debug)]
 pub struct BaseConsumer<C = DefaultConsumerContext>
 where
     C: ConsumerContext,

--- a/src/consumer/stream_consumer.rs
+++ b/src/consumer/stream_consumer.rs
@@ -50,6 +50,7 @@ unsafe fn disable_nonempty_callback(queue: &NativeQueue) {
     rdsys::rd_kafka_queue_cb_event_enable(queue.ptr(), None, ptr::null_mut())
 }
 
+#[derive(Debug)]
 struct WakerSlab {
     wakers: Mutex<Slab<Option<Waker>>>,
 }
@@ -161,6 +162,7 @@ impl<'a> Drop for MessageStream<'a> {
 ///
 /// [KIP-62]: https://cwiki.apache.org/confluence/display/KAFKA/KIP-62%3A+Allow+consumer+to+send+heartbeats+from+a+background+thread
 #[must_use = "Consumer polling thread will stop immediately if unused"]
+#[derive(Debug)]
 pub struct StreamConsumer<C = DefaultConsumerContext, R = DefaultRuntime>
 where
     C: ConsumerContext,

--- a/src/producer/base_producer.rs
+++ b/src/producer/base_producer.rs
@@ -271,6 +271,7 @@ where
 /// ```
 ///
 /// [`examples`]: https://github.com/fede1024/rust-rdkafka/blob/master/examples/
+#[derive(Debug)]
 pub struct BaseProducer<C = DefaultProducerContext>
 where
     C: ProducerContext,
@@ -494,6 +495,7 @@ where
 /// queued events, such as delivery notifications. The thread will be
 /// automatically stopped when the producer is dropped.
 #[must_use = "The threaded producer will stop immediately if unused"]
+#[derive(Debug)]
 pub struct ThreadedProducer<C>
 where
     C: ProducerContext + 'static,

--- a/src/producer/future_producer.rs
+++ b/src/producer/future_producer.rs
@@ -122,7 +122,7 @@ impl<'a, K: ToBytes + ?Sized, P: ToBytes + ?Sized> FutureRecord<'a, K, P> {
 ///
 /// This context will use a [`Future`] as its `DeliveryOpaque` and will complete
 /// the future when the message is delivered (or failed to).
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct FutureProducerContext<C: ClientContext + 'static> {
     wrapped_context: C,
 }
@@ -193,6 +193,7 @@ impl<C: ClientContext + 'static> ProducerContext for FutureProducerContext<C> {
 /// underlying producer. The internal polling thread will be terminated when the
 /// `FutureProducer` goes out of scope.
 #[must_use = "Producer polling thread will stop immediately if unused"]
+#[derive(Debug)]
 pub struct FutureProducer<C = DefaultClientContext, R = DefaultRuntime>
 where
     C: ClientContext + 'static,


### PR DESCRIPTION
Was wondering if there was an active reason against deriving Debug here. If there is no worries, I've got a fork im building off and I can also skip debug on my producer fields.