### PR TITLE
Fix truncation of `rdkafka_sys::rd_kafka_version` in `rdkafka::get_rdkafka_version`.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,17 @@ See also the [rdkafka-sys changelog](rdkafka-sys/changelog.md).
 
 ## Unreleased
 
+* **Breaking change.** `util::get_rdkafka_version` now returns `(i32, String)`.
+  Previously, it returned `(u16, String)` which would silently truncate the hex
+  representation of the version:
+  > Interpreted as hex MM.mm.rr.xx:
+  > 
+  > MM = Major
+  > mm = minor
+  > rr = revision
+  > xx = pre-release id (0xff is the final release)
+  > E.g.: 0x010902ff = 1.9.2
+
 * Add the [`AdminClient::delete_groups`] method, which deletes consumer groups
   from a Kafka cluster ([#510]).
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -25,8 +25,8 @@ use rdkafka_sys as rdsys;
 
 /// Returns a tuple representing the version of `librdkafka` in hexadecimal and
 /// string format.
-pub fn get_rdkafka_version() -> (u16, String) {
-    let version_number = unsafe { rdsys::rd_kafka_version() } as u16;
+pub fn get_rdkafka_version() -> (i32, String) {
+    let version_number = unsafe { rdsys::rd_kafka_version() };
     let c_str = unsafe { CStr::from_ptr(rdsys::rd_kafka_version_str()) };
     (version_number, c_str.to_string_lossy().into_owned())
 }
@@ -458,5 +458,17 @@ impl AsyncRuntime for TokioRuntime {
 
     fn delay_for(duration: Duration) -> Self::Delay {
         tokio::time::sleep(duration)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_rdkafka_version() {
+        let rdk_version = unsafe { rdsys::rd_kafka_version() };
+        let (version_int, _) = get_rdkafka_version();
+        assert_eq!(rdk_version, version_int);
     }
 }


### PR DESCRIPTION
I discovered this when I tried to add  runtime library version checking in our application. `rdkafka::get_rdkafka_version` silently truncates the integer representation so that it's impossible to properly handle how upstream represents the version ( https://docs.confluent.io/platform/current/clients/librdkafka/html/rdkafka_8h.html#aa2e242fb8620a32b650a40575bc7f98e ):

```
Interpreted as hex MM.mm.rr.xx:

MM = Major
mm = minor
rr = revision
xx = pre-release id (0xff is the final release)
E.g.: 0x000801ff = 0.8.1
```
