### PR TITLE
Add config_map method to ClientConfig

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -181,6 +181,11 @@ impl ClientConfig {
         }
     }
 
+    /// Gets a reference to the underlying config map
+    pub fn config_map(&self) -> &HashMap<String, String> {
+        &self.conf_map
+    }
+
     /// Gets the value of a parameter in the configuration.
     ///
     /// Returns the current value set for `key`, or `None` if no value for `key`


### PR DESCRIPTION
This allows to get a reference to the underlying HashMap that could be useful for making a clean up before logging it (for example to replace passwords).

