### PR TITLE
Add `Timestamp` to the `OwnedDeliveryResult` tuple.

### DIFF
--- a/src/producer/future_producer.rs
+++ b/src/producer/future_producer.rs
@@ -134,7 +134,7 @@ pub struct FutureProducerContext<C: ClientContext + 'static> {
 /// partition and offset of the message. If the message failed to be delivered
 /// an error will be returned, together with an owned copy of the original
 /// message.
-pub type OwnedDeliveryResult = Result<(i32, i64), (KafkaError, OwnedMessage)>;
+pub type OwnedDeliveryResult = Result<(i32, i64, Timestamp), (KafkaError, OwnedMessage)>;
 
 // Delegates all the methods calls to the wrapped context.
 impl<C: ClientContext + 'static> ClientContext for FutureProducerContext<C> {
@@ -174,7 +174,7 @@ impl<C: ClientContext + 'static> ProducerContext for FutureProducerContext<C> {
         tx: Box<oneshot::Sender<OwnedDeliveryResult>>,
     ) {
         let owned_delivery_result = match *delivery_result {
-            Ok(ref message) => Ok((message.partition(), message.offset())),
+            Ok(ref message) => Ok((message.partition(), message.offset(), message.timestamp())),
             Err((ref error, ref message)) => Err((error.clone(), message.detach())),
         };
         let _ = tx.send(owned_delivery_result); // TODO: handle error

--- a/tests/test_high_producers.rs
+++ b/tests/test_high_producers.rs
@@ -44,7 +44,7 @@ async fn test_future_producer_send() {
     let results: Vec<_> = results.collect().await;
     assert!(results.len() == 10);
     for (i, result) in results.into_iter().enumerate() {
-        let (partition, offset) = result.unwrap();
+        let (partition, offset, _) = result.unwrap();
         assert_eq!(partition, 1);
         assert_eq!(offset, i as i64);
     }

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -148,7 +148,7 @@ where
     let mut message_map = HashMap::new();
     for (id, future) in futures {
         match future.await {
-            Ok((partition, offset)) => message_map.insert((partition, offset), id),
+            Ok((partition, offset, _)) => message_map.insert((partition, offset), id),
             Err((kafka_error, _message)) => panic!("Delivery failed: {}", kafka_error),
         };
     }


### PR DESCRIPTION
**Note:** This is an API breaking change.

Currently the `Timestamp` value is being dropped as part of the conversion from `BorrowedMessage` to `OwnedDeliveryResult`, however this value is updated once the message has been published and callers should have access to the updated value. As far as I can tell, this is the **only** other value that is updated as part of publishing.

An alternative to expanding the tuple would be to replace it with a struct. This is a bit more disruptive now, but would making adding values in the future a backwards compatible change. So it depends how likely it is that there will be further new values.

This could also be done in a way that isn't a breaking change, but would involve duplicating functions and copying some types, i.e. `DeliveryFuture`. It doesn't seem like that level of complexity is justified given the pre 1.0 status.