### PR TITLE
Expose unassign

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,12 @@ See also the [rdkafka-sys changelog](rdkafka-sys/changelog.md).
 
 ## Unreleased
 
+* Support for unassigning static partitions by passing `null` to `rdsys::rd_kafka_assign` and expose the
+feature as `unassign` in `base_consumer`
+
+* Expose `rdsys::rd_kafka_incremental_assign` and `rdsys::rd_kafka_incremental_unassign` in `base_consumer` for 
+incremental changes to static assignments
+
 * **Breaking change.** `util::get_rdkafka_version` now returns `(i32, String)`.
   Previously, it returned `(u16, String)` which would silently truncate the hex
   representation of the version:

--- a/src/consumer/base_consumer.rs
+++ b/src/consumer/base_consumer.rs
@@ -291,6 +291,16 @@ where
         Ok(())
     }
 
+    fn unassign(&self) -> KafkaResult<()> {
+        // Passing null to assign clears the current static assignments list
+        let ret_code = unsafe { rdsys::rd_kafka_assign(self.client.native_ptr(), ptr::null()) };
+        if ret_code.is_error() {
+            let error = unsafe { cstr_to_owned(rdsys::rd_kafka_err2str(ret_code)) };
+            return Err(KafkaError::Subscription(error));
+        };
+        Ok(())
+    }
+
     fn seek<T: Into<Timeout>>(
         &self,
         topic: &str,

--- a/src/consumer/base_consumer.rs
+++ b/src/consumer/base_consumer.rs
@@ -18,7 +18,7 @@ use crate::consumer::{
     CommitMode, Consumer, ConsumerContext, ConsumerGroupMetadata, DefaultConsumerContext,
     RebalanceProtocol,
 };
-use crate::error::{IsError, KafkaError, KafkaResult};
+use crate::error::{IsError, KafkaError, KafkaResult, RDKafkaError};
 use crate::groups::GroupList;
 use crate::log::trace;
 use crate::message::{BorrowedMessage, Message};
@@ -296,6 +296,34 @@ where
         let ret_code = unsafe { rdsys::rd_kafka_assign(self.client.native_ptr(), ptr::null()) };
         if ret_code.is_error() {
             let error = unsafe { cstr_to_owned(rdsys::rd_kafka_err2str(ret_code)) };
+            return Err(KafkaError::Subscription(error));
+        };
+        Ok(())
+    }
+
+    fn incremental_assign(&self, assignment: &TopicPartitionList) -> KafkaResult<()> {
+        let ret = unsafe {
+            RDKafkaError::from_ptr(rdsys::rd_kafka_incremental_assign(
+                self.client.native_ptr(),
+                assignment.ptr(),
+            ))
+        };
+        if ret.is_error() {
+            let error = ret.name();
+            return Err(KafkaError::Subscription(error));
+        };
+        Ok(())
+    }
+
+    fn incremental_unassign(&self, assignment: &TopicPartitionList) -> KafkaResult<()> {
+        let ret = unsafe {
+            RDKafkaError::from_ptr(rdsys::rd_kafka_incremental_unassign(
+                self.client.native_ptr(),
+                assignment.ptr(),
+            ))
+        };
+        if ret.is_error() {
+            let error = ret.name();
             return Err(KafkaError::Subscription(error));
         };
         Ok(())

--- a/src/consumer/mod.rs
+++ b/src/consumer/mod.rs
@@ -237,6 +237,9 @@ where
     /// automatic consumer rebalance won't be activated.
     fn assign(&self, assignment: &TopicPartitionList) -> KafkaResult<()>;
 
+    /// Clears all topic and partitions currently assigned to the consumer
+    fn unassign(&self) -> KafkaResult<()>;
+
     /// Seeks to `offset` for the specified `topic` and `partition`. After a
     /// successful call to `seek`, the next poll of the consumer will return the
     /// message with `offset`.

--- a/src/consumer/mod.rs
+++ b/src/consumer/mod.rs
@@ -240,6 +240,12 @@ where
     /// Clears all topic and partitions currently assigned to the consumer
     fn unassign(&self) -> KafkaResult<()>;
 
+    /// Incrementally add partitions from the current assignment
+    fn incremental_assign(&self, assignment: &TopicPartitionList) -> KafkaResult<()>;
+
+    /// Incrementally remove partitions from the current assignment
+    fn incremental_unassign(&self, assignment: &TopicPartitionList) -> KafkaResult<()>;
+
     /// Seeks to `offset` for the specified `topic` and `partition`. After a
     /// successful call to `seek`, the next poll of the consumer will return the
     /// message with `offset`.

--- a/src/consumer/stream_consumer.rs
+++ b/src/consumer/stream_consumer.rs
@@ -384,6 +384,10 @@ where
         self.base.assign(assignment)
     }
 
+    fn unassign(&self) -> KafkaResult<()> {
+        self.base.unassign()
+    }
+
     fn seek<T: Into<Timeout>>(
         &self,
         topic: &str,

--- a/src/consumer/stream_consumer.rs
+++ b/src/consumer/stream_consumer.rs
@@ -388,6 +388,14 @@ where
         self.base.unassign()
     }
 
+    fn incremental_assign(&self, assignment: &TopicPartitionList) -> KafkaResult<()> {
+        self.base.incremental_assign(assignment)
+    }
+
+    fn incremental_unassign(&self, assignment: &TopicPartitionList) -> KafkaResult<()> {
+        self.base.incremental_unassign(assignment)
+    }
+
     fn seek<T: Into<Timeout>>(
         &self,
         topic: &str,


### PR DESCRIPTION
The librdkafka `assign` function can be used to clear the list of current assignments by passing null, but this wasn't exposed.

We added an explicit unassign method (similar to what [the cpp](https://github.com/confluentinc/librdkafka/blob/master/src-cpp/KafkaConsumerImpl.cpp#L181) and [confluent kafka go](https://github.com/confluentinc/confluent-kafka-go/blob/master/kafka/consumer.go#L151) clients do) which precisely does that.

Also exposed `incremental_assign` and `incremental_unassign` which were left off.