### PR TITLE
rdkafka-sys: don't build C++ libs

### DIFF
--- a/rdkafka-sys/build.rs
+++ b/rdkafka-sys/build.rs
@@ -185,7 +185,7 @@ fn build_librdkafka() {
         } else {
             "make"
         },
-        &["libs"],
+        &["-C", "src"],
     );
 
     println!("cargo:rustc-link-search=native={}/src", out_dir);
@@ -276,9 +276,11 @@ fn build_librdkafka() {
         env::set_var("CMAKE_LIBRARY_PATH", cmake_library_paths.join(";"));
     }
 
+    config.build_target("rdkafka");
+
     println!("Configuring and compiling librdkafka");
     let dst = config.build();
 
-    println!("cargo:rustc-link-search=native={}/lib", dst.display());
+    println!("cargo:rustc-link-search=native={}/build/src", dst.display());
     println!("cargo:rustc-link-lib=static=rdkafka");
 }


### PR DESCRIPTION
* My motivation for this is to make cross-compiling easier. This gets rid of the need of a (working) C++ setup for cross compiling
* A small speedup is a welcome side-effect
* I have added this for both mklove and cmake builds, but I do feel like the CMake variant is a bit hacky, using the lib without installing it. If you think this is too brittle, I'd be happy to get only the mklove part accepted
