### PR TITLE
update CI workflow to avoid deprecation warnings and build errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [master]
 
 env:
-  rust_version: 1.53.0
+  rust_version: 1.54.0
 
 jobs:
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,81 +13,78 @@ jobs:
   lint:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: ${{ env.rust_version }}
-        default: true
-        components: rustfmt, clippy
-    - run: cargo fmt -- --check
-    - run: cargo clippy -- -Dwarnings
-    - run: cargo test --doc
+      - uses: actions/checkout@v2
+      - uses: dtolnay/rust-toolchain@b44cb146d03e8d870c57ab64b80f04586349ca5d
+        with:
+          toolchain: ${{ env.rust_version }}
+          components: rustfmt, clippy
+      - run: cargo fmt -- --check
+      - run: cargo clippy -- -Dwarnings
+      - run: cargo test --doc
 
   check:
     strategy:
       matrix:
         include:
-        - os: macos-11.0
-        - os: windows-2019
-          features: cmake-build,libz-static,curl-static
-          rdkafka-sys-features: cmake-build,libz-static,curl-static
-        - os: ubuntu-20.04
-          features: tracing
-        - os: ubuntu-20.04
-          features: cmake-build,ssl-vendored,gssapi-vendored,libz-static,curl-static,zstd
-          rdkafka-sys-features: cmake-build,ssl-vendored,gssapi-vendored,libz-static,curl-static,zstd
+          - os: macos-11.0
+          - os: windows-2019
+            features: cmake-build,libz-static,curl-static
+            rdkafka-sys-features: cmake-build,libz-static,curl-static
+          - os: ubuntu-20.04
+            features: tracing
+          - os: ubuntu-20.04
+            features: cmake-build,ssl-vendored,gssapi-vendored,libz-static,curl-static,zstd
+            rdkafka-sys-features: cmake-build,ssl-vendored,gssapi-vendored,libz-static,curl-static,zstd
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: ${{ env.rust_version }}
-        default: true
-    - run: cargo build --all-targets --verbose --features "${{ matrix.features }}"
-    - run: cd rdkafka-sys && cargo test --features "${{ matrix.rdkafka-sys-features }}"
+      - uses: actions/checkout@v2
+      - uses: dtolnay/rust-toolchain@b44cb146d03e8d870c57ab64b80f04586349ca5d
+        with:
+          toolchain: ${{ env.rust_version }}
+      - run: cargo build --all-targets --verbose --features "${{ matrix.features }}"
+      - run: cd rdkafka-sys && cargo test --features "${{ matrix.rdkafka-sys-features }}"
 
   # Use the `minimal-versions` resolver to ensure we're not claiming to support
   # an older version of a dependency than we actually do.
   check-minimal-versions:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-        # The version of this toolchain doesn't matter much. It's only used to
-        # generate the minimal-versions lockfile, not to actually run `cargo
-        # check`.
-        toolchain: nightly-2021-01-05
-        components: rustfmt, clippy
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: ${{ env.rust_version }}
-        default: true
-    - run: cargo +nightly-2021-01-05 -Z minimal-versions generate-lockfile
-    - run: cargo check
+      - uses: actions/checkout@v2
+      - uses: dtolnay/rust-toolchain@b44cb146d03e8d870c57ab64b80f04586349ca5d
+        with:
+          # The version of this toolchain doesn't matter much. It's only used to
+          # generate the minimal-versions lockfile, not to actually run `cargo
+          # check`.
+          toolchain: nightly-2021-01-05
+          components: rustfmt, clippy
+      - uses: dtolnay/rust-toolchain@b44cb146d03e8d870c57ab64b80f04586349ca5d
+        with:
+          toolchain: ${{ env.rust_version }}
+      - run: rustup default ${{ env.rust_version }}
+      - run: cargo +nightly-2021-01-05 -Z minimal-versions generate-lockfile
+      - run: cargo check
 
   test:
     strategy:
       fail-fast: false
       matrix:
         include:
-        - confluent-version: 5.3.1
-          kafka-version: 2.3
-        - confluent-version: 5.0.3
-          kafka-version: 2.0
-        - confluent-version: 4.1.3
-          kafka-version: 1.1
+          - confluent-version: 5.3.1
+            kafka-version: 2.3
+          - confluent-version: 5.0.3
+            kafka-version: 2.0
+          - confluent-version: 4.1.3
+            kafka-version: 1.1
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: ${{ env.rust_version }}
-        default: true
-    - run: sudo apt-get update
-    - run: sudo apt-get install -qy valgrind
-    - run: ./test_suite.sh
-      env:
-        CONFLUENT_VERSION: ${{ matrix.confluent-version }}
-        KAFKA_VERSION: ${{ matrix.kafka-version }}
-        TERM: xterm-256color
+      - uses: actions/checkout@v2
+      - uses: dtolnay/rust-toolchain@b44cb146d03e8d870c57ab64b80f04586349ca5d
+        with:
+          toolchain: ${{ env.rust_version }}
+      - run: sudo apt-get update
+      - run: sudo apt-get install -qy valgrind
+      - run: ./test_suite.sh
+        env:
+          CONFLUENT_VERSION: ${{ matrix.confluent-version }}
+          KAFKA_VERSION: ${{ matrix.kafka-version }}
+          TERM: xterm-256color

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [master]
 
 env:
-  rust_version: 1.54.0
+  rust_version: 1.61.0
 
 jobs:
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
   lint:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@b44cb146d03e8d870c57ab64b80f04586349ca5d
         with:
           toolchain: ${{ env.rust_version }}
@@ -37,7 +37,7 @@ jobs:
             rdkafka-sys-features: cmake-build,ssl-vendored,gssapi-vendored,libz-static,curl-static,zstd
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@b44cb146d03e8d870c57ab64b80f04586349ca5d
         with:
           toolchain: ${{ env.rust_version }}
@@ -49,7 +49,7 @@ jobs:
   check-minimal-versions:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@b44cb146d03e8d870c57ab64b80f04586349ca5d
         with:
           # The version of this toolchain doesn't matter much. It's only used to
@@ -77,7 +77,7 @@ jobs:
             kafka-version: 1.1
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@b44cb146d03e8d870c57ab64b80f04586349ca5d
         with:
           toolchain: ${{ env.rust_version }}

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ re-exported as rdkafka features.
 
 ### Minimum supported Rust version (MSRV)
 
-The current minimum supported Rust version (MSRV) is 1.45.0. Note that
+The current minimum supported Rust version (MSRV) is 1.61.0. Note that
 bumping the MSRV is not considered a breaking change. Any release of
 rust-rdkafka may bump the MSRV.
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -102,7 +102,7 @@ pub trait ClientContext: Send + Sync {
     /// The default implementation calls [`ClientContext::stats`] with the
     /// decoded statistics, logging an error if the decoding fails.
     fn stats_raw(&self, statistics: &[u8]) {
-        match serde_json::from_slice(&statistics) {
+        match serde_json::from_slice(statistics) {
             Ok(stats) => self.stats(stats),
             Err(e) => error!("Could not parse statistics JSON: {}", e),
         }

--- a/src/util.rs
+++ b/src/util.rs
@@ -274,6 +274,8 @@ where
     }
 }
 
+// This function is an internal implementation detail
+#[allow(clippy::missing_safety_doc)]
 pub(crate) unsafe trait KafkaDrop {
     const TYPE: &'static str;
     const DROP: unsafe extern "C" fn(*mut Self);


### PR DESCRIPTION
I was taking a look at the repo and noticed that there are a lot of warnings regarding deprecated Node and Action commands regarding the CI workflow.

Part of resolving this is addressing `actions-rs/toolchain`, which is no longer maintained from my understanding. [`dtolnay/rust-toolchain`](https://github.com/dtolnay/rust-toolchain) is actively maintained and works well from my experience, so I think switching over should be fine and resolves the issues. The rest is fixed by just updating `checkout` to `v3`.

This also updates the `rust_version` to 1.54.0, since [this change](https://github.com/fede1024/rust-rdkafka/commit/611aeea5012787ad0f1a3ff74af32b64d41142f8#diff-8731dd08efd465ecbfdd192013294eeb858fd4e18dbd44d7528dc7f763fbf108R440) means that 1.53.0 will no longer build. Not sure if this should be reflected in the MSRV.