### PR TITLE
Re-export the bundled rdkafka-sys modules.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -272,7 +272,7 @@
 
 mod log;
 
-pub use rdkafka_sys::types;
+pub use rdkafka_sys::{bindings, helpers, types};
 
 pub mod admin;
 pub mod client;


### PR DESCRIPTION
It can be problematic to try to drop down to `rdkafka-sys` from outside the `rdkafka` crate. This re-export allows leveraging the pointers provided in `rdkafka` with the lower level `rdkafka-sys` functions.