### PR TITLE
Support bazel builds

### DIFF
--- a/rdkafka-sys/build.rs
+++ b/rdkafka-sys/build.rs
@@ -72,6 +72,11 @@ fn main() {
             }
         }
     } else {
+        // Ensure that we are in the right directory
+        let rdkafkasys_root = Path::new("rdkafka-sys");
+        if rdkafkasys_root.exists() {
+            assert!(env::set_current_dir(&rdkafkasys_root).is_ok());
+        }
         if !Path::new("librdkafka/LICENSE").exists() {
             eprintln!("Setting up submodules");
             run_command_or_fail("../", "git", &["submodule", "update", "--init"]);


### PR DESCRIPTION
Currently, bzl executes the build script in the wrong directory and fails. This checks for this case and sets the right directory if necessary.