### PR TITLE
Snappy is not enabled by default in cmake build, enable it

### DIFF
--- a/rdkafka-sys/build.rs
+++ b/rdkafka-sys/build.rs
@@ -273,6 +273,8 @@ fn build_librdkafka() {
         config.define("ENABLE_LZ4_EXT", "0");
     }
 
+    config.define("WITH_SNAPPY", "1");
+
     if let Ok(system_name) = env::var("CMAKE_SYSTEM_NAME") {
         config.define("CMAKE_SYSTEM_NAME", system_name);
     }


### PR DESCRIPTION
For some reason librdkafka's cmake build does not enable snappy compression support.
This enables snappy unconditionally (because anyway it is not an external dependency)