### PR TITLE
Introduce partitioner interface

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -222,8 +222,17 @@ impl<C: ClientContext> Client<C> {
         rd_kafka_type: RDKafkaType,
         context: C,
     ) -> KafkaResult<Client<C>> {
+        Self::new_context_arc(config, native_config, rd_kafka_type, Arc::new(context))
+    }
+
+    /// Creates a new `Client` given a configuration, a client type and a context.
+    pub fn new_context_arc(
+        config: &ClientConfig,
+        native_config: NativeClientConfig,
+        rd_kafka_type: RDKafkaType,
+        context: Arc<C>,
+    ) -> KafkaResult<Client<C>> {
         let mut err_buf = ErrBuf::new();
-        let context = Arc::new(context);
         unsafe {
             rdsys::rd_kafka_conf_set_opaque(
                 native_config.ptr(),

--- a/src/client.rs
+++ b/src/client.rs
@@ -226,7 +226,7 @@ impl<C: ClientContext> Client<C> {
     }
 
     /// Creates a new `Client` given a configuration, a client type and a context.
-    pub fn new_context_arc(
+    pub(crate) fn new_context_arc(
         config: &ClientConfig,
         native_config: NativeClientConfig,
         rd_kafka_type: RDKafkaType,

--- a/src/producer/base_producer.rs
+++ b/src/producer/base_producer.rs
@@ -272,7 +272,7 @@ where
             unsafe {
                 rdsys::rd_kafka_topic_conf_set_opaque(
                     default_topic_config,
-                    Arc::as_ptr(&context) as *const Part as *mut c_void,
+                    Arc::as_ptr(&context) as *mut c_void,
                 )
             };
             unsafe {

--- a/src/producer/base_producer.rs
+++ b/src/producer/base_producer.rs
@@ -234,12 +234,10 @@ unsafe extern "C" fn partitioner_cb<Part: Partitioner, C: ProducerContext<Part>>
 
     let producer_context = &mut *(rkt_opaque as *mut C);
 
-    match producer_context.get_custom_partitioner() {
-        None => panic!("custom partitioner is not set"),
-        Some(partitioner) => {
-            partitioner.partition(topic_name, key, partition_cnt, is_partition_available)
-        }
-    }
+    producer_context
+        .get_custom_partitioner()
+        .expect("custom partitioner is not set")
+        .partition(topic_name, key, partition_cnt, is_partition_available)
 }
 
 impl FromClientConfig for BaseProducer<DefaultProducerContext> {
@@ -266,7 +264,7 @@ where
         let native_config = config.create_native_config()?;
         let context = Arc::new(context);
 
-        if let Some(_) = context.get_custom_partitioner() {
+        if context.get_custom_partitioner().is_some() {
             let default_topic_config =
                 unsafe { rdsys::rd_kafka_conf_get_default_topic_conf(native_config.ptr()) };
             unsafe {

--- a/src/producer/base_producer.rs
+++ b/src/producer/base_producer.rs
@@ -224,8 +224,7 @@ unsafe extern "C" fn partitioner_cb<Part: Partitioner, C: ProducerContext<Part>>
     let topic_name = CStr::from_ptr(rdsys::rd_kafka_topic_name(topic));
     let topic_name = str::from_utf8_unchecked(topic_name.to_bytes());
 
-    let is_partition_available =
-        |p: i32| { rdsys::rd_kafka_topic_partition_available(topic, p) == 1 };
+    let is_partition_available = |p: i32| rdsys::rd_kafka_topic_partition_available(topic, p) == 1;
 
     let key = if keydata.is_null() {
         None

--- a/src/producer/base_producer.rs
+++ b/src/producer/base_producer.rs
@@ -258,10 +258,11 @@ where
         context: C,
     ) -> KafkaResult<BaseProducer<C, Part>> {
         let native_config = config.create_native_config()?;
+        let context = Arc::new(context);
 
         let partitioner = match context.get_custom_partitioner() {
             None => null_mut(),
-            Some(partitioner) => partitioner.as_ref() as *const Part as *mut c_void,
+            Some(partitioner) => partitioner as *const Part as *mut c_void,
         };
 
         if !partitioner.is_null() {
@@ -279,7 +280,7 @@ where
         unsafe {
             rdsys::rd_kafka_conf_set_dr_msg_cb(native_config.ptr(), Some(delivery_cb::<Part, C>))
         };
-        let client = Client::new(
+        let client = Client::new_context_arc(
             config,
             native_config,
             RDKafkaType::RD_KAFKA_PRODUCER,

--- a/src/producer/base_producer.rs
+++ b/src/producer/base_producer.rs
@@ -443,7 +443,7 @@ where
     }
 }
 
-impl<C, Part> Producer<Part, C> for BaseProducer<C, Part>
+impl<C, Part> Producer<C, Part> for BaseProducer<C, Part>
 where
     Part: Partitioner,
     C: ProducerContext<Part>,
@@ -659,7 +659,7 @@ where
     }
 }
 
-impl<C, Part> Producer<Part, C> for ThreadedProducer<C, Part>
+impl<C, Part> Producer<C, Part> for ThreadedProducer<C, Part>
 where
     Part: Partitioner,
     C: ProducerContext<Part> + 'static,

--- a/src/producer/base_producer.rs
+++ b/src/producer/base_producer.rs
@@ -221,20 +221,20 @@ unsafe extern "C" fn partitioner_cb<Part: Partitioner, C: ProducerContext<Part>>
     rkt_opaque: *mut c_void,
     _msg_opaque: *mut c_void,
 ) -> i32 {
-    let topic_name = unsafe { CStr::from_ptr(rdsys::rd_kafka_topic_name(topic)) };
+    let topic_name = CStr::from_ptr(rdsys::rd_kafka_topic_name(topic));
     let topic_name = str::from_utf8_unchecked(topic_name.to_bytes());
 
     let is_partition_available =
-        |p: i32| unsafe { rdsys::rd_kafka_topic_partition_available(topic, p) == 1 };
+        |p: i32| { rdsys::rd_kafka_topic_partition_available(topic, p) == 1 };
 
     let key = if keydata.is_null() {
         None
     } else {
-        Some(unsafe { slice::from_raw_parts(keydata as *const u8, keylen) })
+        Some(slice::from_raw_parts(keydata as *const u8, keylen))
     };
 
     let producer_context: &mut Part = &mut *(rkt_opaque as *mut Part);
-    return producer_context.partition(topic_name, key, partition_cnt, is_partition_available);
+    producer_context.partition(topic_name, key, partition_cnt, is_partition_available)
 }
 
 impl FromClientConfig for BaseProducer<DefaultProducerContext> {

--- a/src/producer/future_producer.rs
+++ b/src/producer/future_producer.rs
@@ -170,8 +170,7 @@ impl<C: ClientContext + 'static> ClientContext for FutureProducerContext<C> {
     }
 }
 
-impl<C, Part> ProducerContext<Part>
-    for FutureProducerContext<C>
+impl<C, Part> ProducerContext<Part> for FutureProducerContext<C>
 where
     C: ClientContext + 'static,
     Part: Partitioner,
@@ -372,8 +371,7 @@ where
     }
 }
 
-impl<C, R, Part> Producer<Part, FutureProducerContext<C>>
-    for FutureProducer<C, R, Part>
+impl<C, R, Part> Producer<Part, FutureProducerContext<C>> for FutureProducer<C, R, Part>
 where
     C: ClientContext + 'static,
     R: AsyncRuntime,

--- a/src/producer/future_producer.rs
+++ b/src/producer/future_producer.rs
@@ -371,7 +371,7 @@ where
     }
 }
 
-impl<C, R, Part> Producer<Part, FutureProducerContext<C>> for FutureProducer<C, R, Part>
+impl<C, R, Part> Producer<FutureProducerContext<C>, Part> for FutureProducer<C, R, Part>
 where
     C: ClientContext + 'static,
     R: AsyncRuntime,

--- a/src/producer/mod.rs
+++ b/src/producer/mod.rs
@@ -201,9 +201,7 @@ pub trait ProducerContext<Part: Partitioner = NoCustomPartitioner>: ClientContex
     fn delivery(&self, delivery_result: &DeliveryResult<'_>, delivery_opaque: Self::DeliveryOpaque);
 
     /// This method is called when creating producer in order to register custom partitioner.
-    /// Box is used to make sure data is on the heap as partitioner address will fly across FFI boundary.
-    #[allow(clippy::borrowed-box)]
-    fn get_custom_partitioner(&self) -> Option<&Box<Part>> {
+    fn get_custom_partitioner(&self) -> Option<&Part> {
         None
     }
 }

--- a/src/producer/mod.rs
+++ b/src/producer/mod.rs
@@ -267,7 +267,7 @@ impl ProducerContext<NoCustomPartitioner> for DefaultProducerContext {
 }
 
 /// Common trait for all producers.
-pub trait Producer<Part, C = DefaultProducerContext>
+pub trait Producer<C = DefaultProducerContext, Part = NoCustomPartitioner>
 where
     Part: Partitioner,
     C: ProducerContext<Part>,

--- a/src/producer/mod.rs
+++ b/src/producer/mod.rs
@@ -183,7 +183,8 @@ pub use self::future_producer::{DeliveryFuture, FutureProducer, FutureRecord};
 ///
 /// This user-defined object can be used to provide custom callbacks for
 /// producer events. Refer to the list of methods to check which callbacks can
-/// be specified.
+/// be specified. It can also specify custom partitioner to register and to be
+/// used for deciding to which partition write message into.
 ///
 /// In particular, it can be used to specify the `delivery` callback that will
 /// be called when the acknowledgement for a delivered message is received.
@@ -200,7 +201,9 @@ pub trait ProducerContext<Part: Partitioner = NoCustomPartitioner>: ClientContex
     /// when calling send.
     fn delivery(&self, delivery_result: &DeliveryResult<'_>, delivery_opaque: Self::DeliveryOpaque);
 
-    /// This method is called when creating producer in order to register custom partitioner.
+    /// This method is called when creating producer in order to optionally register custom partitioner.
+    /// If custom partitioner is not used then `partitioner` configuration property is used (or its default).
+    /// Configuration property `sticky.partitioning.linger.ms` must be set to 0 to register custom partitioner.
     fn get_custom_partitioner(&self) -> Option<&Part> {
         None
     }

--- a/src/producer/mod.rs
+++ b/src/producer/mod.rs
@@ -202,6 +202,7 @@ pub trait ProducerContext<Part: Partitioner = NoCustomPartitioner>: ClientContex
 
     /// This method is called when creating producer in order to register custom partitioner.
     /// Box is used to make sure data is on the heap as partitioner address will fly across FFI boundary.
+    #[allow(clippy::borrowed-box)]
     fn get_custom_partitioner(&self) -> Option<&Box<Part>> {
         None
     }

--- a/src/producer/mod.rs
+++ b/src/producer/mod.rs
@@ -250,7 +250,6 @@ impl Partitioner for NoCustomPartitioner {
     }
 }
 
-
 /// An inert producer context that can be used when customizations are not
 /// required.
 #[derive(Clone)]

--- a/src/producer/mod.rs
+++ b/src/producer/mod.rs
@@ -201,7 +201,7 @@ pub trait ProducerContext<Part: Partitioner = NoCustomPartitioner>: ClientContex
     fn delivery(&self, delivery_result: &DeliveryResult<'_>, delivery_opaque: Self::DeliveryOpaque);
 
     /// This method is called when creating producer in order to register custom partitioner.
-    /// Box is used to make sure data is on the heap as partitioner address will flying across FFI boundary.
+    /// Box is used to make sure data is on the heap as partitioner address will fly across FFI boundary.
     fn get_custom_partitioner(&self) -> Option<&Box<Part>> {
         None
     }

--- a/src/producer/mod.rs
+++ b/src/producer/mod.rs
@@ -203,7 +203,9 @@ pub trait ProducerContext<Part: Partitioner = NoCustomPartitioner>: ClientContex
 
     /// This method is called when creating producer in order to optionally register custom partitioner.
     /// If custom partitioner is not used then `partitioner` configuration property is used (or its default).
-    /// Configuration property `sticky.partitioning.linger.ms` must be set to 0 to register custom partitioner.
+    ///
+    /// sticky.partitioning.linger.ms must be 0 to run custom partitioner for messages with null key.
+    /// See https://github.com/confluentinc/librdkafka/blob/081fd972fa97f88a1e6d9a69fc893865ffbb561a/src/rdkafka_msg.c#L1192-L1196
     fn get_custom_partitioner(&self) -> Option<&Part> {
         None
     }

--- a/tests/test_low_producers.rs
+++ b/tests/test_low_producers.rs
@@ -94,7 +94,7 @@ impl<Part: Partitioner + Send + Sync> ProducerContext<Part> for CollectingContex
         }
     }
 
-    fn get_custom_partitioner(&self) -> Option<&Box<Part>> {
+    fn get_custom_partitioner(&self) -> Option<&Part> {
         match &self.partitioner {
             None => None,
             Some(p) => Some(&p),

--- a/tests/test_low_producers.rs
+++ b/tests/test_low_producers.rs
@@ -50,7 +50,7 @@ type TestProducerDeliveryResult = (OwnedMessage, Option<KafkaError>, usize);
 struct CollectingContext<Part: Partitioner = NoCustomPartitioner> {
     stats: Arc<Mutex<Vec<Statistics>>>,
     results: Arc<Mutex<Vec<TestProducerDeliveryResult>>>,
-    partitioner: Option<Box<Part>>,
+    partitioner: Option<Part>,
 }
 
 impl CollectingContext {
@@ -68,7 +68,7 @@ impl<Part: Partitioner> CollectingContext<Part> {
         CollectingContext {
             stats: Arc::new(Mutex::new(Vec::new())),
             results: Arc::new(Mutex::new(Vec::new())),
-            partitioner: Some(Box::new(partitioner)),
+            partitioner: Some(partitioner),
         }
     }
 }


### PR DESCRIPTION
Add interface to specify custom partitioners by extending `ProducerContext` trait with capability to return optional custom partitioner.