### PR TITLE
Change signature for seek_partitions

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@ See also the [rdkafka-sys changelog](rdkafka-sys/changelog.md).
 
 ## Unreleased
 
+* **Breaking change.** Change signature for `seek_partitions`. Following
+  librdkafka, individual partition errors should be reported in the per-partition
+  `error` field of `TopicPartitionList` elements.
+
 ## 0.33.0 (2023-06-30)
 
 * Add interface to specify custom partitioners by extending `ProducerContext`

--- a/src/consumer/base_consumer.rs
+++ b/src/consumer/base_consumer.rs
@@ -352,9 +352,9 @@ where
 
     fn seek_partitions<T: Into<Timeout>>(
         &self,
-        topic_partition_list: &TopicPartitionList,
+        topic_partition_list: TopicPartitionList,
         timeout: T,
-    ) -> KafkaResult<()> {
+    ) -> KafkaResult<TopicPartitionList> {
         let ret = unsafe {
             RDKafkaError::from_ptr(rdsys::rd_kafka_seek_partitions(
                 self.client.native_ptr(),
@@ -366,7 +366,7 @@ where
             let error = ret.name();
             return Err(KafkaError::Seek(error));
         }
-        Ok(())
+        Ok(topic_partition_list)
     }
 
     fn commit(

--- a/src/consumer/mod.rs
+++ b/src/consumer/mod.rs
@@ -261,11 +261,13 @@ where
     /// in the `offset` field of `TopicPartitionListElem`.
     /// The offset can be either absolute (>= 0) or a logical offset.
     /// Seek should only be performed on already assigned/consumed partitions.
+    /// Individual partition errors are reported in the per-partition `error` field of
+    /// `TopicPartitionListElem`.
     fn seek_partitions<T: Into<Timeout>>(
         &self,
-        topic_partition_list: &TopicPartitionList,
+        topic_partition_list: TopicPartitionList,
         timeout: T,
-    ) -> KafkaResult<()>;
+    ) -> KafkaResult<TopicPartitionList>;
 
     /// Commits the offset of the specified message. The commit can be sync
     /// (blocking), or async. Notice that when a specific offset is committed,

--- a/src/consumer/stream_consumer.rs
+++ b/src/consumer/stream_consumer.rs
@@ -412,9 +412,9 @@ where
 
     fn seek_partitions<T: Into<Timeout>>(
         &self,
-        topic_partition_list: &TopicPartitionList,
+        topic_partition_list: TopicPartitionList,
         timeout: T,
-    ) -> KafkaResult<()> {
+    ) -> KafkaResult<TopicPartitionList> {
         self.base.seek_partitions(topic_partition_list, timeout)
     }
 

--- a/src/topic_partition_list.rs
+++ b/src/topic_partition_list.rs
@@ -387,11 +387,12 @@ impl fmt::Debug for TopicPartitionList {
             }
             write!(
                 f,
-                "{}/{}: offset={:?} metadata={:?}",
+                "{}/{}: offset={:?} metadata={:?}, error={:?}",
                 elem.topic(),
                 elem.partition(),
                 elem.offset(),
                 elem.metadata(),
+                elem.error(),
             )?;
         }
         write!(f, "}}")


### PR DESCRIPTION
Following librdkafka, individual partition errors should be reported in the per-partition`error` field of `TopicPartitionList` elements.

Example where errors are returned for each partition rather than the method call (which succeded)
`TopicPartitionList {test-seek/0: offset=Offset(3) metadata="", error=Err(KafkaError (Offset fetch error: InProgress (Local: Operation in progress))); test-seek/1: offset=Offset(0) metadata="", error=Err(KafkaError (Offset fetch error: InProgress (Local: Operation in progress))); test-seek/2: offset=Offset(10) metadata="", error=Err(KafkaError (Offset fetch error: InProgress (Local: Operation in progress)))}`