### PR TITLE
Allow users to override make when using cmake

### DIFF
--- a/rdkafka-sys/build.rs
+++ b/rdkafka-sys/build.rs
@@ -277,6 +277,10 @@ fn build_librdkafka() {
         config.define("CMAKE_SYSTEM_NAME", system_name);
     }
 
+    if let Ok(make_program) = env::var("CMAKE_MAKE_PROGRAM") {
+        config.define("CMAKE_MAKE_PROGRAM", make_program);
+    }
+
     if !cmake_library_paths.is_empty() {
         env::set_var("CMAKE_LIBRARY_PATH", cmake_library_paths.join(";"));
     }


### PR DESCRIPTION
For some reason the wrong make program is used when building using bazel. Making it possible to change the make program allows me to override it which fixes the problem.