### PR TITLE
Better implementation of Debug trait for TopicPartitionList

### DIFF
--- a/src/topic_partition_list.rs
+++ b/src/topic_partition_list.rs
@@ -78,7 +78,6 @@ impl Offset {
     }
 }
 
-// TODO: implement Debug
 /// One element of the topic partition list.
 pub struct TopicPartitionListElem<'a> {
     ptr: &'a mut RDKafkaTopicPartition,
@@ -162,6 +161,18 @@ impl<'a> PartialEq for TopicPartitionListElem<'a> {
             && self.partition() == other.partition()
             && self.offset() == other.offset()
             && self.metadata() == other.metadata()
+    }
+}
+
+impl fmt::Debug for TopicPartitionListElem<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TopicPartitionListElem")
+            .field("topic", &self.topic())
+            .field("partition", &self.partition())
+            .field("offset", &self.offset())
+            .field("metadata", &self.metadata())
+            .field("error", &self.error())
+            .finish()
     }
 }
 
@@ -380,22 +391,7 @@ impl Default for TopicPartitionList {
 
 impl fmt::Debug for TopicPartitionList {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "TPL {{")?;
-        for (i, elem) in self.elements().iter().enumerate() {
-            if i > 0 {
-                write!(f, "; ")?;
-            }
-            write!(
-                f,
-                "{}/{}: offset={:?} metadata={:?}, error={:?}",
-                elem.topic(),
-                elem.partition(),
-                elem.offset(),
-                elem.metadata(),
-                elem.error(),
-            )?;
-        }
-        write!(f, "}}")
+        f.debug_list().entries(self.elements()).finish()
     }
 }
 

--- a/tests/test_topic_partition_list.rs
+++ b/tests/test_topic_partition_list.rs
@@ -1,0 +1,24 @@
+use rdkafka::{Offset, TopicPartitionList};
+
+/// Test topic partition list API and wrappers.
+
+#[test]
+fn test_fmt_debug() {
+    {
+        let tpl = TopicPartitionList::new();
+        assert_eq!(format!("{tpl:?}"), "[]");
+    }
+
+    {
+        let mut tpl = TopicPartitionList::new();
+        tpl.add_topic_unassigned("foo");
+        tpl.add_partition("bar", 8);
+        tpl.add_partition_offset("bar", 7, Offset::Offset(42))
+            .unwrap();
+        assert_eq!(
+            format!("{tpl:?}"),
+            "[TopicPartitionListElem { topic: \"foo\", partition: -1, offset: Invalid, metadata: \"\", error: Ok(()) }, \
+              TopicPartitionListElem { topic: \"bar\", partition: 8, offset: Invalid, metadata: \"\", error: Ok(()) }, \
+              TopicPartitionListElem { topic: \"bar\", partition: 7, offset: Offset(42), metadata: \"\", error: Ok(()) }]");
+    }
+}


### PR DESCRIPTION
Just implement a pending TODO and make `TopicPartitionList` debug print more friendly.