### PR TITLE
Derives `serde::Serialize` on `Statistics`

### DIFF
--- a/src/statistics.rs
+++ b/src/statistics.rs
@@ -12,7 +12,7 @@
 
 use std::collections::HashMap;
 
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 /// Overall statistics.
 #[derive(Serialize, Deserialize, Debug, Default, Clone)]

--- a/src/statistics.rs
+++ b/src/statistics.rs
@@ -12,10 +12,10 @@
 
 use std::collections::HashMap;
 
-use serde::Deserialize;
+use serde::{Serialize, Deserialize};
 
 /// Overall statistics.
-#[derive(Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct Statistics {
     /// The name of the librdkafka handle.
     pub name: String,
@@ -73,7 +73,7 @@ pub struct Statistics {
 }
 
 /// Per-broker statistics.
-#[derive(Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct Broker {
     /// The broker hostname, port, and ID, in the form `HOSTNAME:PORT/ID`.
     pub name: String,
@@ -168,7 +168,7 @@ pub struct Broker {
 ///
 /// These values are not exact; they are sampled estimates maintained by an
 /// HDR histogram in librdkafka.
-#[derive(Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct Window {
     /// The smallest value.
     pub min: i64,
@@ -202,7 +202,7 @@ pub struct Window {
 }
 
 /// A topic and partition specifier.
-#[derive(Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct TopicPartition {
     /// The name of the topic.
     pub topic: String,
@@ -211,7 +211,7 @@ pub struct TopicPartition {
 }
 
 /// Per-topic statistics.
-#[derive(Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct Topic {
     /// The name of the topic.
     pub topic: String,
@@ -226,7 +226,7 @@ pub struct Topic {
 }
 
 /// Per-partition statistics.
-#[derive(Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct Partition {
     /// The partition ID.
     pub partition: i32,
@@ -299,7 +299,7 @@ pub struct Partition {
 }
 
 /// Consumer group manager statistics.
-#[derive(Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct ConsumerGroup {
     /// The local consumer group handler's state.
     pub state: String,
@@ -321,7 +321,7 @@ pub struct ConsumerGroup {
 }
 
 /// Exactly-once semantics statistics.
-#[derive(Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone)]
 pub struct ExactlyOnceSemantics {
     /// The current idempotent producer state.
     pub idemp_state: String,


### PR DESCRIPTION
I realize that there is a `stats_raw` trait method, but it would be better to not have to re-type out the statistics fields myself. This came about because I would like to act on many of the individual fields locally via some aggregations, but then output them back out (along with other fields in a larger status struct) as a JSON-encoded string, e.g.:

```rs
#[derive(Serialize)]
pub struct Status {
  pub sample_field: u64,
  pub sample_field_2: boolean,
  pub statistics: Statistics,
}
```
