### PR TITLE
Use rdkafka event API instead of the callback API

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -403,7 +403,7 @@ fn start_poll_thread(queue: Arc<NativeQueue>, should_stop: Arc<AtomicBool>) -> J
         .expect("Failed to start polling thread")
 }
 
-type NativeEvent = NativePtr<RDKafkaEvent>;
+pub(crate) type NativeEvent = NativePtr<RDKafkaEvent>;
 
 unsafe impl KafkaDrop for RDKafkaEvent {
     const TYPE: &'static str = "event";

--- a/src/client.rs
+++ b/src/client.rs
@@ -280,7 +280,7 @@ impl<C: ClientContext> Client<C> {
 
     pub(crate) fn poll_event(
         &self,
-        queue: Arc<NativeQueue>,
+        queue: &NativeQueue,
         timeout: Timeout,
     ) -> Option<NativeEvent> {
         let event = unsafe { NativeEvent::from_ptr(queue.poll(timeout)) };

--- a/src/client.rs
+++ b/src/client.rs
@@ -11,19 +11,19 @@
 //! [`consumer`]: crate::consumer
 //! [`producer`]: crate::producer
 
-use std::convert::TryFrom;
 use std::error::Error;
 use std::ffi::{CStr, CString};
 use std::mem::ManuallyDrop;
-use std::os::raw::{c_char, c_void};
+use std::os::raw::c_char;
 use std::ptr;
-use std::slice;
 use std::string::ToString;
 use std::sync::Arc;
 
+use libc::c_void;
 use rdkafka_sys as rdsys;
 use rdkafka_sys::types::*;
 
+use crate::admin::NativeEvent;
 use crate::config::{ClientConfig, NativeClientConfig, RDKafkaLogLevel};
 use crate::consumer::RebalanceProtocol;
 use crate::error::{IsError, KafkaError, KafkaResult};
@@ -239,21 +239,6 @@ impl<C: ClientContext> Client<C> {
                 Arc::as_ptr(&context) as *mut c_void,
             )
         };
-        unsafe { rdsys::rd_kafka_conf_set_log_cb(native_config.ptr(), Some(native_log_cb::<C>)) };
-        unsafe {
-            rdsys::rd_kafka_conf_set_stats_cb(native_config.ptr(), Some(native_stats_cb::<C>))
-        };
-        unsafe {
-            rdsys::rd_kafka_conf_set_error_cb(native_config.ptr(), Some(native_error_cb::<C>))
-        };
-        if C::ENABLE_REFRESH_OAUTH_TOKEN {
-            unsafe {
-                rdsys::rd_kafka_conf_set_oauthbearer_token_refresh_cb(
-                    native_config.ptr(),
-                    Some(native_oauth_refresh_cb::<C>),
-                )
-            };
-        }
 
         let client_ptr = unsafe {
             let native_config = ManuallyDrop::new(native_config);
@@ -291,6 +276,126 @@ impl<C: ClientContext> Client<C> {
     /// Returns a reference to the context.
     pub fn context(&self) -> &Arc<C> {
         &self.context
+    }
+
+    pub(crate) fn poll_event(
+        &self,
+        queue: Arc<NativeQueue>,
+        timeout: Timeout,
+    ) -> Option<NativeEvent> {
+        let event = unsafe { NativeEvent::from_ptr(queue.poll(timeout)) };
+        if let Some(ev) = event {
+            let evtype = unsafe { rdsys::rd_kafka_event_type(ev.ptr()) };
+            match evtype {
+                rdsys::RD_KAFKA_EVENT_LOG => self.handle_log_event(ev.ptr()),
+                rdsys::RD_KAFKA_EVENT_STATS => self.handle_stats_event(ev.ptr()),
+                rdsys::RD_KAFKA_EVENT_ERROR => self.handle_error_event(ev.ptr()),
+                rdsys::RD_KAFKA_EVENT_OAUTHBEARER_TOKEN_REFRESH => {
+                    if C::ENABLE_REFRESH_OAUTH_TOKEN {
+                        self.handle_oauth_refresh_event(ev.ptr());
+                    }
+                }
+                _ => {
+                    return Some(ev);
+                }
+            }
+        }
+        None
+    }
+
+    fn handle_log_event(&self, event: *mut RDKafkaEvent) {
+        let mut fac: *const c_char = std::ptr::null();
+        let mut str_: *const c_char = std::ptr::null();
+        let mut level: i32 = 0;
+        let result = unsafe { rdsys::rd_kafka_event_log(event, &mut fac, &mut str_, &mut level) };
+        if result == 0 {
+            let fac = unsafe { CStr::from_ptr(fac).to_string_lossy() };
+            let log_message = unsafe { CStr::from_ptr(str_).to_string_lossy() };
+            self.context().log(
+                RDKafkaLogLevel::from_int(level),
+                fac.trim(),
+                log_message.trim(),
+            );
+        }
+    }
+
+    fn handle_stats_event(&self, event: *mut RDKafkaEvent) {
+        let json = unsafe { CStr::from_ptr(rdsys::rd_kafka_event_stats(event)) };
+        self.context().stats_raw(json.to_bytes());
+    }
+
+    fn handle_error_event(&self, event: *mut RDKafkaEvent) {
+        let rdkafka_err = unsafe { rdsys::rd_kafka_event_error(event) };
+        let error = KafkaError::Global(rdkafka_err.into());
+        let reason =
+            unsafe { CStr::from_ptr(rdsys::rd_kafka_event_error_string(event)).to_string_lossy() };
+        self.context().error(error, reason.trim());
+    }
+
+    fn handle_oauth_refresh_event(&self, event: *mut RDKafkaEvent) {
+        let oauthbearer_config = unsafe { rdsys::rd_kafka_event_config_string(event) };
+        let res: Result<_, Box<dyn Error>> = (|| {
+            let oauthbearer_config = match oauthbearer_config.is_null() {
+                true => None,
+                false => unsafe { Some(util::cstr_to_owned(oauthbearer_config)) },
+            };
+            let token_info = self
+                .context()
+                .generate_oauth_token(oauthbearer_config.as_deref())?;
+            let token = CString::new(token_info.token)?;
+            let principal_name = CString::new(token_info.principal_name)?;
+            Ok((token, principal_name, token_info.lifetime_ms))
+        })();
+        match res {
+            Ok((token, principal_name, lifetime_ms)) => {
+                let mut err_buf = ErrBuf::new();
+                let code = unsafe {
+                    rdkafka_sys::rd_kafka_oauthbearer_set_token(
+                        self.native_ptr(),
+                        token.as_ptr(),
+                        lifetime_ms,
+                        principal_name.as_ptr(),
+                        ptr::null_mut(),
+                        0,
+                        err_buf.as_mut_ptr(),
+                        err_buf.capacity(),
+                    )
+                };
+                if code == RDKafkaRespErr::RD_KAFKA_RESP_ERR_NO_ERROR {
+                    debug!("successfully set refreshed OAuth token");
+                } else {
+                    debug!(
+                        "failed to set refreshed OAuth token (code {:?}): {}",
+                        code, err_buf
+                    );
+                    unsafe {
+                        rdkafka_sys::rd_kafka_oauthbearer_set_token_failure(
+                            self.native_ptr(),
+                            err_buf.as_mut_ptr(),
+                        )
+                    };
+                }
+            }
+            Err(e) => {
+                debug!("failed to refresh OAuth token: {}", e);
+                let message = match CString::new(e.to_string()) {
+                    Ok(message) => message,
+                    Err(e) => {
+                        error!("error message generated while refreshing OAuth token has embedded null character: {}", e);
+                        CString::new(
+                            "error while refreshing OAuth token has embedded null character",
+                        )
+                        .expect("known to be a valid CString")
+                    }
+                };
+                unsafe {
+                    rdkafka_sys::rd_kafka_oauthbearer_set_token_failure(
+                        self.native_ptr(),
+                        message.as_ptr(),
+                    )
+                };
+            }
+        }
     }
 
     /// Returns the metadata information for the specified topic, or for all topics in the cluster
@@ -442,6 +547,11 @@ impl<C: ClientContext> Client<C> {
     pub(crate) fn consumer_queue(&self) -> Option<NativeQueue> {
         unsafe { NativeQueue::from_ptr(rdsys::rd_kafka_queue_get_consumer(self.native_ptr())) }
     }
+
+    /// Returns a NativeQueue for the main librdkafka event queue from the current client.
+    pub(crate) fn main_queue(&self) -> NativeQueue {
+        unsafe { NativeQueue::from_ptr(rdsys::rd_kafka_queue_get_main(self.native_ptr())).unwrap() }
+    }
 }
 
 pub(crate) type NativeTopic = NativePtr<RDKafkaTopic>;
@@ -471,48 +581,6 @@ impl NativeQueue {
     }
 }
 
-pub(crate) unsafe extern "C" fn native_log_cb<C: ClientContext>(
-    client: *const RDKafka,
-    level: i32,
-    fac: *const c_char,
-    buf: *const c_char,
-) {
-    let fac = CStr::from_ptr(fac).to_string_lossy();
-    let log_message = CStr::from_ptr(buf).to_string_lossy();
-
-    let context = &mut *(rdsys::rd_kafka_opaque(client) as *mut C);
-    context.log(
-        RDKafkaLogLevel::from_int(level),
-        fac.trim(),
-        log_message.trim(),
-    );
-}
-
-pub(crate) unsafe extern "C" fn native_stats_cb<C: ClientContext>(
-    _conf: *mut RDKafka,
-    json: *mut c_char,
-    json_len: usize,
-    opaque: *mut c_void,
-) -> i32 {
-    let context = &mut *(opaque as *mut C);
-    context.stats_raw(slice::from_raw_parts(json as *mut u8, json_len));
-    0 // librdkafka will free the json buffer
-}
-
-pub(crate) unsafe extern "C" fn native_error_cb<C: ClientContext>(
-    _client: *mut RDKafka,
-    err: i32,
-    reason: *const c_char,
-    opaque: *mut c_void,
-) {
-    let err = RDKafkaRespErr::try_from(err).expect("global error not an rd_kafka_resp_err_t");
-    let error = KafkaError::Global(err.into());
-    let reason = CStr::from_ptr(reason).to_string_lossy();
-
-    let context = &mut *(opaque as *mut C);
-    context.error(error, reason.trim());
-}
-
 /// A generated OAuth token and its associated metadata.
 ///
 /// When using the `OAUTHBEARER` SASL authentication method, this type is
@@ -527,60 +595,6 @@ pub struct OAuthToken {
     pub principal_name: String,
     /// When the token expires, in number of milliseconds since the Unix epoch.
     pub lifetime_ms: i64,
-}
-
-pub(crate) unsafe extern "C" fn native_oauth_refresh_cb<C: ClientContext>(
-    client: *mut RDKafka,
-    oauthbearer_config: *const c_char,
-    opaque: *mut c_void,
-) {
-    let res: Result<_, Box<dyn Error>> = (|| {
-        let context = &mut *(opaque as *mut C);
-        let oauthbearer_config = match oauthbearer_config.is_null() {
-            true => None,
-            false => Some(util::cstr_to_owned(oauthbearer_config)),
-        };
-        let token_info = context.generate_oauth_token(oauthbearer_config.as_deref())?;
-        let token = CString::new(token_info.token)?;
-        let principal_name = CString::new(token_info.principal_name)?;
-        Ok((token, principal_name, token_info.lifetime_ms))
-    })();
-    match res {
-        Ok((token, principal_name, lifetime_ms)) => {
-            let mut err_buf = ErrBuf::new();
-            let code = rdkafka_sys::rd_kafka_oauthbearer_set_token(
-                client,
-                token.as_ptr(),
-                lifetime_ms,
-                principal_name.as_ptr(),
-                ptr::null_mut(),
-                0,
-                err_buf.as_mut_ptr(),
-                err_buf.capacity(),
-            );
-            if code == RDKafkaRespErr::RD_KAFKA_RESP_ERR_NO_ERROR {
-                debug!("successfully set refreshed OAuth token");
-            } else {
-                debug!(
-                    "failed to set refreshed OAuth token (code {:?}): {}",
-                    code, err_buf
-                );
-                rdkafka_sys::rd_kafka_oauthbearer_set_token_failure(client, err_buf.as_mut_ptr());
-            }
-        }
-        Err(e) => {
-            debug!("failed to refresh OAuth token: {}", e);
-            let message = match CString::new(e.to_string()) {
-                Ok(message) => message,
-                Err(e) => {
-                    error!("error message generated while refreshing OAuth token has embedded null character: {}", e);
-                    CString::new("error while refreshing OAuth token has embedded null character")
-                        .expect("known to be a valid CString")
-                }
-            };
-            rdkafka_sys::rd_kafka_oauthbearer_set_token_failure(client, message.as_ptr());
-        }
-    }
 }
 
 #[cfg(test)]

--- a/src/client.rs
+++ b/src/client.rs
@@ -278,11 +278,7 @@ impl<C: ClientContext> Client<C> {
         &self.context
     }
 
-    pub(crate) fn poll_event(
-        &self,
-        queue: &NativeQueue,
-        timeout: Timeout,
-    ) -> Option<NativeEvent> {
+    pub(crate) fn poll_event(&self, queue: &NativeQueue, timeout: Timeout) -> Option<NativeEvent> {
         let event = unsafe { NativeEvent::from_ptr(queue.poll(timeout)) };
         if let Some(ev) = event {
             let evtype = unsafe { rdsys::rd_kafka_event_type(ev.ptr()) };

--- a/src/consumer/base_consumer.rs
+++ b/src/consumer/base_consumer.rs
@@ -156,6 +156,8 @@ where
                     let native_tpl = rdsys::rd_kafka_event_topic_partition_list(event.ptr());
                     TopicPartitionList::from_ptr(native_tpl)
                 };
+                // The TPL is owned by the Event and will be destroyed when the event is destroyed.
+                // Dropping it here will lead to double free.
                 let mut tpl = ManuallyDrop::new(tpl);
                 self.context()
                     .rebalance(self.client.native_client(), err, &mut tpl);
@@ -185,6 +187,8 @@ where
             let tpl = TopicPartitionList::new();
             self.context().commit_callback(commit_error, &tpl);
         } else {
+            // The TPL is owned by the Event and will be destroyed when the event is destroyed.
+            // Dropping it here will lead to double free.
             let tpl = ManuallyDrop::new(unsafe { TopicPartitionList::from_ptr(offsets) });
             self.context().commit_callback(commit_error, &tpl);
         }

--- a/src/consumer/base_consumer.rs
+++ b/src/consumer/base_consumer.rs
@@ -89,9 +89,9 @@ where
         // need to listen to the consumer queue to observe events like
         // rebalancings and stats.
         unsafe { rdsys::rd_kafka_poll_set_consumer(client.native_ptr()) };
-        let queue = client.consumer_queue().ok_or(KafkaError::ClientCreation(
-            "rdkafka consumer queue not available".to_string(),
-        ))?;
+        let queue = client.consumer_queue().ok_or_else(|| {
+            KafkaError::ClientCreation("rdkafka consumer queue not available".to_string())
+        })?;
         Ok(BaseConsumer {
             client,
             queue,

--- a/src/consumer/base_consumer.rs
+++ b/src/consumer/base_consumer.rs
@@ -225,16 +225,16 @@ where
     fn handle_error_event(&self, event: NativePtr<RDKafkaEvent>) -> Option<KafkaError> {
         let rdkafka_err = unsafe { rdsys::rd_kafka_event_error(event.ptr()) };
         if rdkafka_err.is_error() {
-            let err = match rdkafka_err {
-                rdsys::rd_kafka_resp_err_t::RD_KAFKA_RESP_ERR__PARTITION_EOF => {
-                    let tp_ptr = unsafe { rdsys::rd_kafka_event_topic_partition(event.ptr()) };
-                    let partition = unsafe { (*tp_ptr).partition };
-                    unsafe { rdsys::rd_kafka_topic_partition_destroy(tp_ptr) };
-                    KafkaError::PartitionEOF(partition)
-                }
-                e => KafkaError::MessageConsumption(e.into()),
-            };
-            Some(err)
+            if rdkafka_err == rdsys::rd_kafka_resp_err_t::RD_KAFKA_RESP_ERR__PARTITION_EOF {
+                let tp_ptr = unsafe { rdsys::rd_kafka_event_topic_partition(event.ptr()) };
+                let partition = unsafe { (*tp_ptr).partition };
+                unsafe { rdsys::rd_kafka_topic_partition_destroy(tp_ptr) };
+                Some(KafkaError::PartitionEOF(partition))
+            } else if unsafe { rdsys::rd_kafka_event_error_is_fatal(event.ptr()) } != 0 {
+                Some(KafkaError::MessageConsumptionFatal(rdkafka_err.into()))
+            } else {
+                Some(KafkaError::MessageConsumption(rdkafka_err.into()))
+            }
         } else {
             None
         }

--- a/src/consumer/base_consumer.rs
+++ b/src/consumer/base_consumer.rs
@@ -331,6 +331,27 @@ where
             PartitionQueue::new(self.clone(), queue)
         })
     }
+
+    /// Close the queue used by a consumer.
+    /// Only exposed for advanced usage of this API and should not be used under normal circumstances.
+    pub fn close_queue(&self) -> KafkaResult<()> {
+        let err = unsafe {
+            RDKafkaError::from_ptr(rdsys::rd_kafka_consumer_close_queue(
+                self.client.native_ptr(),
+                self.queue.ptr(),
+            ))
+        };
+        if err.is_error() {
+            Err(KafkaError::ConsumerQueueClose(err.code()))
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Returns true if the consumer is closed, else false.
+    pub fn closed(&self) -> bool {
+        unsafe { rdsys::rd_kafka_consumer_closed(self.client.native_ptr()) == 1 }
+    }
 }
 
 impl<C> Consumer<C> for BaseConsumer<C>

--- a/src/consumer/base_consumer.rs
+++ b/src/consumer/base_consumer.rs
@@ -237,6 +237,10 @@ where
         Iter(self)
     }
 
+    pub(crate) fn get_queue(&self) -> Arc<NativeQueue> {
+        self.queue.clone()
+    }
+
     /// Splits messages for the specified partition into their own queue.
     ///
     /// If the `topic` or `partition` is invalid, returns `None`.

--- a/src/consumer/mod.rs
+++ b/src/consumer/mod.rs
@@ -113,12 +113,12 @@ pub trait ConsumerContext: ClientContext {
     fn commit_callback(&self, result: KafkaResult<()>, offsets: &TopicPartitionList) {}
 
     /// Returns the minimum interval at which to poll the main queue, which
-    /// services the logging, stats, and error callbacks.
+    /// services the logging, stats, and error events.
     ///
     /// The main queue is polled once whenever [`BaseConsumer::poll`] is called.
     /// If `poll` is called with a timeout that is larger than this interval,
     /// then the main queue will be polled at that interval while the consumer
-    /// queue is blocked.
+    /// queue is blocked. This allows serving events while there are no messages.
     ///
     /// For example, if the main queue's minimum poll interval is 200ms and
     /// `poll` is called with a timeout of 1s, then `poll` may block for up to

--- a/src/consumer/stream_consumer.rs
+++ b/src/consumer/stream_consumer.rs
@@ -1,6 +1,5 @@
 //! High-level consumers with a [`Stream`](futures_util::Stream) interface.
 
-use std::ffi::CStr;
 use std::marker::PhantomData;
 use std::os::raw::c_void;
 use std::pin::Pin;
@@ -14,13 +13,11 @@ use futures_channel::oneshot;
 use futures_util::future::{self, Either, FutureExt};
 use futures_util::pin_mut;
 use futures_util::stream::{Stream, StreamExt};
-use log::warn;
 use slab::Slab;
 
 use rdkafka_sys as rdsys;
 use rdkafka_sys::types::*;
 
-use crate::admin::NativeEvent;
 use crate::client::{Client, NativeQueue};
 use crate::config::{ClientConfig, FromClientConfig, FromClientConfigAndContext};
 use crate::consumer::base_consumer::{BaseConsumer, PartitionQueue};
@@ -33,7 +30,7 @@ use crate::groups::GroupList;
 use crate::message::BorrowedMessage;
 use crate::metadata::Metadata;
 use crate::topic_partition_list::{Offset, TopicPartitionList};
-use crate::util::{AsyncRuntime, DefaultRuntime, NativePtr, Timeout};
+use crate::util::{AsyncRuntime, DefaultRuntime, Timeout};
 
 unsafe extern "C" fn native_message_queue_nonempty_cb(_: *mut RDKafka, opaque_ptr: *mut c_void) {
     let wakers = &*(opaque_ptr as *const WakerSlab);
@@ -91,49 +88,50 @@ impl WakerSlab {
 /// A stream of messages from a [`StreamConsumer`].
 ///
 /// See the documentation of [`StreamConsumer::stream`] for details.
-pub struct MessageStream<'a> {
+pub struct MessageStream<'a, C: ConsumerContext> {
     wakers: &'a WakerSlab,
-    queue: &'a NativeQueue,
+    consumer: &'a BaseConsumer<C>,
+    partition_queue: Option<&'a NativeQueue>,
     slot: usize,
 }
 
-impl<'a> MessageStream<'a> {
-    fn new(wakers: &'a WakerSlab, queue: &'a NativeQueue) -> MessageStream<'a> {
+impl<'a, C: ConsumerContext> MessageStream<'a, C> {
+    fn new(wakers: &'a WakerSlab, consumer: &'a BaseConsumer<C>) -> MessageStream<'a, C> {
+        Self::new_with_optional_partition_queue(wakers, consumer, None)
+    }
+
+    fn new_with_partition_queue(
+        wakers: &'a WakerSlab,
+        consumer: &'a BaseConsumer<C>,
+        partition_queue: &'a NativeQueue,
+    ) -> MessageStream<'a, C> {
+        Self::new_with_optional_partition_queue(wakers, consumer, Some(partition_queue))
+    }
+
+    fn new_with_optional_partition_queue(
+        wakers: &'a WakerSlab,
+        consumer: &'a BaseConsumer<C>,
+        partition_queue: Option<&'a NativeQueue>,
+    ) -> MessageStream<'a, C> {
         let slot = wakers.register();
         MessageStream {
             wakers,
-            queue,
+            consumer,
+            partition_queue,
             slot,
         }
     }
 
     fn poll(&self) -> Option<KafkaResult<BorrowedMessage<'a>>> {
-        let timeout: Timeout = Duration::ZERO.into();
-        let event = unsafe { NativeEvent::from_ptr(self.queue.poll(timeout)) };
-        if let Some(ev) = event {
-            let evtype = unsafe { rdsys::rd_kafka_event_type(ev.ptr()) };
-            match evtype {
-                rdsys::RD_KAFKA_EVENT_FETCH => unsafe {
-                    NativePtr::from_ptr(rdsys::rd_kafka_event_message_next(ev.ptr()) as *mut _)
-                        .map(|ptr| BorrowedMessage::from_client(ptr, Arc::new(ev), self.queue))
-                },
-                _ => {
-                    let buf = unsafe {
-                        let evname = rdsys::rd_kafka_event_name(ev.ptr());
-                        CStr::from_ptr(evname).to_bytes()
-                    };
-                    let evname = String::from_utf8(buf.to_vec()).unwrap();
-                    warn!("Ignored event '{}' on consumer poll", evname);
-                    None
-                }
-            }
+        if let Some(queue) = self.partition_queue {
+            self.consumer.poll_queue(queue, Duration::ZERO)
         } else {
-            None
+            self.consumer.poll(Duration::ZERO)
         }
     }
 }
 
-impl<'a> Stream for MessageStream<'a> {
+impl<'a, C: ConsumerContext> Stream for MessageStream<'a, C> {
     type Item = KafkaResult<BorrowedMessage<'a>>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
@@ -160,7 +158,7 @@ impl<'a> Stream for MessageStream<'a> {
     }
 }
 
-impl<'a> Drop for MessageStream<'a> {
+impl<'a, C: ConsumerContext> Drop for MessageStream<'a, C> {
     fn drop(&mut self) {
         self.wakers.unregister(self.slot);
     }
@@ -186,7 +184,6 @@ where
     C: ConsumerContext,
 {
     base: Arc<BaseConsumer<C>>,
-    queue: NativeQueue,
     wakers: Arc<WakerSlab>,
     _shutdown_trigger: oneshot::Sender<()>,
     _runtime: PhantomData<R>,
@@ -218,9 +215,7 @@ where
         };
 
         let base = Arc::new(BaseConsumer::new(config, native_config, context)?);
-        let client = base.client();
-        let native_ptr = client.native_ptr() as usize;
-        let queue = client.main_queue();
+        let native_ptr = base.client().native_ptr() as usize;
 
         let wakers = Arc::new(WakerSlab::new());
         unsafe { enable_nonempty_callback(base.get_queue(), &wakers) }
@@ -255,7 +250,6 @@ where
         Ok(StreamConsumer {
             base,
             wakers,
-            queue,
             _shutdown_trigger: shutdown_trigger,
             _runtime: PhantomData,
         })
@@ -278,8 +272,8 @@ where
     ///
     /// If you want multiple independent views of a Kafka topic, create multiple
     /// consumers, not multiple message streams.
-    pub fn stream(&self) -> MessageStream<'_> {
-        MessageStream::new(&self.wakers, &self.queue)
+    pub fn stream(&self) -> MessageStream<'_, C> {
+        MessageStream::new(&self.wakers, &self.base)
     }
 
     /// Receives the next message from the stream.
@@ -322,7 +316,7 @@ where
     /// `StreamConsumer::recv`.
     ///
     /// You must periodically await `StreamConsumer::recv`, even if no messages
-    /// are expected, to serve callbacks. Consider using a background task like:
+    /// are expected, to serve events. Consider using a background task like:
     ///
     /// ```
     /// # use rdkafka::consumer::StreamConsumer;
@@ -352,6 +346,7 @@ where
             .split_partition_queue(topic, partition)
             .map(|queue| {
                 let wakers = Arc::new(WakerSlab::new());
+                unsafe { enable_nonempty_callback(&queue.queue, &wakers) };
                 StreamPartitionQueue {
                     queue,
                     wakers,
@@ -573,8 +568,12 @@ where
     ///
     /// If you want multiple independent views of a Kafka partition, create
     /// multiple consumers, not multiple partition streams.
-    pub fn stream(&self) -> MessageStream<'_> {
-        MessageStream::new(&self.wakers, &self.queue.queue)
+    pub fn stream(&self) -> MessageStream<'_, C> {
+        MessageStream::new_with_partition_queue(
+            &self.wakers,
+            &self._consumer.base,
+            &self.queue.queue,
+        )
     }
 
     /// Receives the next message from the stream.

--- a/src/consumer/stream_consumer.rs
+++ b/src/consumer/stream_consumer.rs
@@ -200,11 +200,6 @@ where
         let base = BaseConsumer::new(config, native_config, context)?;
         let native_ptr = base.client().native_ptr() as usize;
 
-        // Redirect rdkafka's main queue to the consumer queue so that we only
-        // need to listen to the consumer queue to observe events like
-        // rebalancings and stats.
-        unsafe { rdsys::rd_kafka_poll_set_consumer(base.client().native_ptr()) };
-
         let queue = base.client().consumer_queue().ok_or_else(|| {
             KafkaError::ClientCreation("librdkafka failed to create consumer queue".into())
         })?;

--- a/src/error.rs
+++ b/src/error.rs
@@ -147,6 +147,8 @@ pub enum KafkaError {
     ClientCreation(String),
     /// Consumer commit failed.
     ConsumerCommit(RDKafkaErrorCode),
+    /// Consumer queue close failed.
+    ConsumerQueueClose(RDKafkaErrorCode),
     /// Flushing failed
     Flush(RDKafkaErrorCode),
     /// Global error.
@@ -204,6 +206,9 @@ impl fmt::Debug for KafkaError {
             KafkaError::ConsumerCommit(err) => {
                 write!(f, "KafkaError (Consumer commit error: {})", err)
             }
+            KafkaError::ConsumerQueueClose(err) => {
+                write!(f, "KafkaError (Consumer queue close error: {})", err)
+            }
             KafkaError::Flush(err) => write!(f, "KafkaError (Flush error: {})", err),
             KafkaError::Global(err) => write!(f, "KafkaError (Global error: {})", err),
             KafkaError::GroupListFetch(err) => {
@@ -255,6 +260,7 @@ impl fmt::Display for KafkaError {
             }
             KafkaError::ClientCreation(ref err) => write!(f, "Client creation error: {}", err),
             KafkaError::ConsumerCommit(err) => write!(f, "Consumer commit error: {}", err),
+            KafkaError::ConsumerQueueClose(err) => write!(f, "Consumer queue close error: {}", err),
             KafkaError::Flush(err) => write!(f, "Flush error: {}", err),
             KafkaError::Global(err) => write!(f, "Global error: {}", err),
             KafkaError::GroupListFetch(err) => write!(f, "Group list fetch error: {}", err),
@@ -288,6 +294,7 @@ impl Error for KafkaError {
             KafkaError::ClientConfig(..) => None,
             KafkaError::ClientCreation(_) => None,
             KafkaError::ConsumerCommit(err) => Some(err),
+            KafkaError::ConsumerQueueClose(err) => Some(err),
             KafkaError::Flush(err) => Some(err),
             KafkaError::Global(err) => Some(err),
             KafkaError::GroupListFetch(err) => Some(err),
@@ -327,6 +334,7 @@ impl KafkaError {
             KafkaError::ClientConfig(..) => None,
             KafkaError::ClientCreation(_) => None,
             KafkaError::ConsumerCommit(err) => Some(*err),
+            KafkaError::ConsumerQueueClose(err) => Some(*err),
             KafkaError::Flush(err) => Some(*err),
             KafkaError::Global(err) => Some(*err),
             KafkaError::GroupListFetch(err) => Some(*err),

--- a/src/error.rs
+++ b/src/error.rs
@@ -157,6 +157,8 @@ pub enum KafkaError {
     GroupListFetch(RDKafkaErrorCode),
     /// Message consumption failed.
     MessageConsumption(RDKafkaErrorCode),
+    /// Message consumption failed with fatal error.
+    MessageConsumptionFatal(RDKafkaErrorCode),
     /// Message production error.
     MessageProduction(RDKafkaErrorCode),
     /// Metadata fetch error.
@@ -217,6 +219,9 @@ impl fmt::Debug for KafkaError {
             KafkaError::MessageConsumption(err) => {
                 write!(f, "KafkaError (Message consumption error: {})", err)
             }
+            KafkaError::MessageConsumptionFatal(err) => {
+                write!(f, "(Fatal) KafkaError (Message consumption error: {})", err)
+            }
             KafkaError::MessageProduction(err) => {
                 write!(f, "KafkaError (Message production error: {})", err)
             }
@@ -265,6 +270,9 @@ impl fmt::Display for KafkaError {
             KafkaError::Global(err) => write!(f, "Global error: {}", err),
             KafkaError::GroupListFetch(err) => write!(f, "Group list fetch error: {}", err),
             KafkaError::MessageConsumption(err) => write!(f, "Message consumption error: {}", err),
+            KafkaError::MessageConsumptionFatal(err) => {
+                write!(f, "(Fatal) Message consumption error: {}", err)
+            }
             KafkaError::MessageProduction(err) => write!(f, "Message production error: {}", err),
             KafkaError::MetadataFetch(err) => write!(f, "Meta data fetch error: {}", err),
             KafkaError::NoMessageReceived => {
@@ -299,6 +307,7 @@ impl Error for KafkaError {
             KafkaError::Global(err) => Some(err),
             KafkaError::GroupListFetch(err) => Some(err),
             KafkaError::MessageConsumption(err) => Some(err),
+            KafkaError::MessageConsumptionFatal(err) => Some(err),
             KafkaError::MessageProduction(err) => Some(err),
             KafkaError::MetadataFetch(err) => Some(err),
             KafkaError::NoMessageReceived => None,
@@ -339,6 +348,7 @@ impl KafkaError {
             KafkaError::Global(err) => Some(*err),
             KafkaError::GroupListFetch(err) => Some(*err),
             KafkaError::MessageConsumption(err) => Some(*err),
+            KafkaError::MessageConsumptionFatal(err) => Some(*err),
             KafkaError::MessageProduction(err) => Some(*err),
             KafkaError::MetadataFetch(err) => Some(*err),
             KafkaError::NoMessageReceived => None,

--- a/src/message.rs
+++ b/src/message.rs
@@ -346,7 +346,7 @@ impl<'a> BorrowedMessage<'a> {
         if ptr.err.is_error() {
             let err = match ptr.err {
                 rdsys::rd_kafka_resp_err_t::RD_KAFKA_RESP_ERR__PARTITION_EOF => {
-                    KafkaError::PartitionEOF((*ptr).partition)
+                    KafkaError::PartitionEOF(ptr.partition)
                 }
                 e => KafkaError::MessageConsumption(e.into()),
             };

--- a/src/message.rs
+++ b/src/message.rs
@@ -362,8 +362,8 @@ impl<'a> BorrowedMessage<'a> {
 
     /// Creates a new `BorrowedMessage` that wraps the native Kafka message
     /// pointer returned via the delivery report event. The lifetime of
-    /// the message will be bound to the lifetime of the event passed as
-    /// parameter. The message will not be freed in any circumstance.
+    /// the message will be bound to the lifetime of the client passed as
+    /// parameter.
     pub(crate) unsafe fn from_dr_event<C>(
         ptr: *mut RDKafkaMessage,
         event: Arc<NativeEvent>,

--- a/src/message.rs
+++ b/src/message.rs
@@ -312,6 +312,7 @@ pub struct BorrowedMessage<'a> {
     _owner: PhantomData<&'a u8>,
 }
 
+// When using the Event API, messages must not be freed with rd_kafka_message_destroy
 unsafe extern "C" fn no_op(_: *mut RDKafkaMessage) {}
 
 unsafe impl KafkaDrop for RDKafkaMessage {

--- a/src/producer/base_producer.rs
+++ b/src/producer/base_producer.rs
@@ -611,8 +611,13 @@ where
 {
     fn drop(&mut self) {
         self.purge(PurgeConfig::default().queue().inflight());
-        // Still have to poll after purging to get the results that have been made ready by the purge
-        self.poll(Timeout::After(Duration::ZERO));
+        // Still have to flush after purging to get the results that have been made ready by the purge
+        if let Err(err) = self.flush(Timeout::After(Duration::from_millis(500))) {
+            warn!(
+                "Failed to flush outstanding messages while dropping the producer: {:?}",
+                err
+            );
+        }
     }
 }
 

--- a/src/producer/base_producer.rs
+++ b/src/producer/base_producer.rs
@@ -391,10 +391,10 @@ where
             Vec::from_raw_parts(messages.as_mut_ptr(), msgs_cnt, max_messages)
         };
 
+        let ev = Arc::new(event);
         for msg in messages {
-            let delivery_result = unsafe {
-                BorrowedMessage::from_dr_event(msg as *mut _, event.ptr(), self.client())
-            };
+            let delivery_result =
+                unsafe { BorrowedMessage::from_dr_event(msg as *mut _, ev.clone(), self.client()) };
             let delivery_opaque = unsafe { C::DeliveryOpaque::from_ptr((*msg)._private) };
             self.context().delivery(&delivery_result, delivery_opaque);
         }

--- a/src/util.rs
+++ b/src/util.rs
@@ -48,6 +48,22 @@ impl Timeout {
             Timeout::Never => -1,
         }
     }
+
+    /// Saturating `Duration` subtraction to Timeout.
+    pub(crate) fn saturating_sub(&self, rhs: Duration) -> Timeout {
+        match (self, rhs) {
+            (Timeout::After(lhs), rhs) => Timeout::After(lhs.saturating_sub(rhs)),
+            (Timeout::Never, _) => Timeout::Never,
+        }
+    }
+
+    /// Returns `true` if the timeout is zero.
+    pub(crate) fn is_zero(&self) -> bool {
+        match self {
+            Timeout::After(d) => d.is_zero(),
+            Timeout::Never => false,
+        }
+    }
 }
 
 impl std::ops::SubAssign for Timeout {

--- a/tests/test_metadata.rs
+++ b/tests/test_metadata.rs
@@ -22,6 +22,7 @@ fn create_consumer(group_id: &str) -> StreamConsumer {
         .set("session.timeout.ms", "6000")
         .set("api.version.request", "true")
         .set("debug", "all")
+        .set("auto.offset.reset", "earliest")
         .create()
         .expect("Failed to create StreamConsumer")
 }


### PR DESCRIPTION
This PR changes how rust-rdkafka interacts with librdkafka. Instead of using the callback API, it moves to the event API. This PR does not change any of the public rdkafka API, but it give us the chance to introduce some optimizations. Some of them might break the current API though and hence this PR does not go into that route yet. For example, consider https://github.com/fede1024/rust-rdkafka/issues/273.

Some other benefits:
* it allows to extend the lifetime of BorrowMessages. For example, consider the `FutureProducer` where we need to [detach](https://github.com/fede1024/rust-rdkafka/blob/93e6cd4f36d04e01fe5e025699bb78be938c1f1a/src/producer/future_producer.rs#L187) the borrowMessage on errors.
* it allows handling the rebalance events outside of the scope of the registered callback. This is specially useful for services using rust-rdkafka to build FFI libraries on top of it.

Performance wise, I've run kafka-benchmark I've got a pretty similar outcome for both the callback vs event based approach. I didn't find much differences here. I've also run long running services on our staging infra and we didn't find noticeable changes on cpu/rss on the producer/consumer side.

There's one main difference here though. Operation errors not related to consumption (like transient broker transport failures) are passed back to the user with the Event API. This is not the case for the Callback API. Details can be found https://github.com/confluentinc/librdkafka/issues/4493.  These errors should generally be considered informational as the underlying client will automatically try to recover from any errors encountered, the application does not need to take action on them. However, fatal errors are also propagated via the Event API. These indicates that the particular instance of the client (producer/consumer) becomes non-functional.


