### PR TITLE
Add support for kafka 3.5 in integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - confluent-version: 7.5.1
+            kafka-version: 3.5
           - confluent-version: 5.3.1
             kafka-version: 2.3
           - confluent-version: 5.0.3

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   kafka:
-    image: confluentinc/cp-kafka:${CONFLUENT_VERSION:-5.3.1}
+    image: confluentinc/cp-kafka:${CONFLUENT_VERSION:-7.5.1}
     environment:
       - KAFKA_BROKER_ID=0
       - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
@@ -16,7 +16,7 @@ services:
     links: [zookeeper]
 
   zookeeper:
-    image: confluentinc/cp-zookeeper:${CONFLUENT_VERSION:-5.3.1}
+    image: confluentinc/cp-zookeeper:${CONFLUENT_VERSION:-7.5.1}
     environment:
       - ZOOKEEPER_CLIENT_PORT=2181
     ports: ["2181:2181"]

--- a/tests/test_admin.rs
+++ b/tests/test_admin.rs
@@ -174,9 +174,14 @@ async fn test_topics() {
             is_default: false,
             is_sensitive: false,
         };
+        let default_max_msg_bytes = if get_broker_version() <= KafkaVersion(2, 3, 0, 0) {
+            "1000012"
+        } else {
+            "1048588"
+        };
         let expected_entry2 = ConfigEntry {
             name: "max.message.bytes".into(),
-            value: Some("1000012".into()),
+            value: Some(default_max_msg_bytes.into()),
             source: ConfigSource::Default,
             is_read_only: false,
             is_default: true,


### PR DESCRIPTION
cp-kafka 7.5.1 would match kafka 3.5.1 based on https://docs.confluent.io/platform/current/installation/versions-interoperability.html.