### PR TITLE
Add rust-version, so that our MSRV is enforced by cargo:

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ keywords = ["kafka", "rdkafka"]
 categories = ["api-bindings"]
 edition = "2018"
 exclude = ["Cargo.lock"]
+rust-version = "1.61"
 
 [workspace]
 members = ["rdkafka-sys"]

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@ See also the [rdkafka-sys changelog](rdkafka-sys/changelog.md).
 ## Unreleased
 
 * Update bundled librdkafka to 2.3.0.
+* Add cargo enforcement of MSRV of 1.61.
 
 ## 0.34.0 (2023-08-25)
 

--- a/rdkafka-sys/Cargo.toml
+++ b/rdkafka-sys/Cargo.toml
@@ -10,6 +10,7 @@ description = "Native bindings to the librdkafka library"
 keywords = ["kafka", "rdkafka"]
 categories = ["external-ffi-bindings"]
 edition = "2018"
+rust-version = "1.61"
 
 [dependencies]
 num_enum = "0.5.0"

--- a/rdkafka-sys/changelog.md
+++ b/rdkafka-sys/changelog.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Upgrade to librdkafka v2.3.0.
+* Add cargo enforcement of MSRV of 1.61.
 
 ## v4.6.0+2.2.0 (2023-08-25)
 


### PR DESCRIPTION
https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field