### PR TITLE
Pass BaseConsumer to ConsumerContext::rebalance

### DIFF
--- a/examples/simple_consumer.rs
+++ b/examples/simple_consumer.rs
@@ -4,7 +4,7 @@ use log::{info, warn};
 use rdkafka::client::ClientContext;
 use rdkafka::config::{ClientConfig, RDKafkaLogLevel};
 use rdkafka::consumer::stream_consumer::StreamConsumer;
-use rdkafka::consumer::{CommitMode, Consumer, ConsumerContext, Rebalance};
+use rdkafka::consumer::{BaseConsumer, CommitMode, Consumer, ConsumerContext, Rebalance};
 use rdkafka::error::KafkaResult;
 use rdkafka::message::{Headers, Message};
 use rdkafka::topic_partition_list::TopicPartitionList;
@@ -22,11 +22,11 @@ struct CustomContext;
 impl ClientContext for CustomContext {}
 
 impl ConsumerContext for CustomContext {
-    fn pre_rebalance(&self, rebalance: &Rebalance) {
+    fn pre_rebalance(&self, _: &BaseConsumer<Self>, rebalance: &Rebalance) {
         info!("Pre rebalance {:?}", rebalance);
     }
 
-    fn post_rebalance(&self, rebalance: &Rebalance) {
+    fn post_rebalance(&self, _: &BaseConsumer<Self>, rebalance: &Rebalance) {
         info!("Post rebalance {:?}", rebalance);
     }
 

--- a/src/consumer/base_consumer.rs
+++ b/src/consumer/base_consumer.rs
@@ -11,7 +11,7 @@ use log::{error, warn};
 use rdkafka_sys as rdsys;
 use rdkafka_sys::types::*;
 
-use crate::client::{Client, NativeQueue};
+use crate::client::{Client, NativeClient, NativeQueue};
 use crate::config::{
     ClientConfig, FromClientConfig, FromClientConfigAndContext, NativeClientConfig,
 };
@@ -188,8 +188,7 @@ where
                 // The TPL is owned by the Event and will be destroyed when the event is destroyed.
                 // Dropping it here will lead to double free.
                 let mut tpl = ManuallyDrop::new(tpl);
-                self.context()
-                    .rebalance(self.client.native_client(), err, &mut tpl);
+                self.context().rebalance(self, err, &mut tpl);
             }
             _ => {
                 let buf = unsafe {
@@ -352,6 +351,10 @@ where
     /// Returns true if the consumer is closed, else false.
     pub fn closed(&self) -> bool {
         unsafe { rdsys::rd_kafka_consumer_closed(self.client.native_ptr()) == 1 }
+    }
+
+    pub(crate) fn native_client(&self) -> &NativeClient {
+        self.client.native_client()
     }
 }
 


### PR DESCRIPTION
# Description of the change
This changes the interface of `ConsumerContext` in the following ways:

* The `&NativeClient` parameter in `rebalance` is replaced with a `&BaseConsumer<Self>` parameter.
* `pre_rebalance` and `post_rebalance` also gain `&BaseConsumer<Self>` parameters.

This also requires
* the addition of a `BaseConsumer::native_client` method;
* the addition of a `Sized` bound to `ConsumerContext`.

# Reason for the change
We're building an abstraction around Kafka at Sentry. It's set up in such a way that offsets are committed in batches, not individually, for performance reasons. This means, however, that when a rebalance happens, there may still be outstanding offsets that need to be committed. We want to do this by means of the `pre_rebalance` hook on `ConsumerContext`, but the problem is that this callback has no access to the `BaseConsumer` (or any client that could perform the commit). We previously tried holding an `Arc` to the `BaseConsumer` in the `ConsumerContext`, but that leads to a mire of reference cycles and deadlocks.

Passing the `BaseConsumer` to the callbacks would neatly enable this use case for us.