### PR TITLE
Return back to the caller on rebalance events

### DIFF
--- a/src/consumer/base_consumer.rs
+++ b/src/consumer/base_consumer.rs
@@ -144,9 +144,15 @@ where
                     }
                     rdsys::RD_KAFKA_EVENT_REBALANCE => {
                         self.handle_rebalance_event(event);
+                        if timeout != Timeout::Never {
+                            return None;
+                        }
                     }
                     rdsys::RD_KAFKA_EVENT_OFFSET_COMMIT => {
                         self.handle_offset_commit_event(event);
+                        if timeout != Timeout::Never {
+                            return None;
+                        }
                     }
                     _ => {
                         let buf = unsafe {


### PR DESCRIPTION
This does not affect the StreamConsumer or any other wrapper consumer. It will only incur on an extra Poll call when there's a rebalance event which is negligible. 

why is this needed?

When using bindings built upon the rust-rdkafka ffi, the caller is responsible for initiating the rebalance calls (*assign). If a high timeout is specified, the rebalance handler will only be triggered once the timeout period has elapsed. This fixes it by always returning on rebalance events.