### PR TITLE
Fix regression on MacOS

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -150,7 +150,11 @@ impl NativeClientConfig {
         }
 
         // Convert the C string to a Rust string.
-        Ok(String::from_utf8_lossy(&buf).to_string())
+        let cstr = CStr::from_bytes_until_nul(&buf)
+            .unwrap()
+            .to_string_lossy()
+            .into();
+        Ok(cstr)
     }
 }
 


### PR DESCRIPTION
https://github.com/fede1024/rust-rdkafka/pull/587 introduced a regression on MacOS. Using `CStr:: from_bytes_until_nul` fixes it and should fix the OP's issue as well.