### PR TITLE
Clarify that alter_configs resets unspecified parameters to default

### DIFF
--- a/src/admin.rs
+++ b/src/admin.rs
@@ -283,7 +283,8 @@ impl<C: ClientContext> AdminClient<C> {
         Ok(rx)
     }
 
-    /// Sets configuration parameters for the specified resources.
+    /// Sets configuration parameters for the specified resources,
+    /// resetting unspecified parameters to their default values.
     ///
     /// Note that while the API supports altering multiple resources at once, it
     /// is not transactional. Alteration of some resources may succeed while


### PR DESCRIPTION
See https://docs.confluent.io/platform/7.5/clients/librdkafka/html/rdkafka_8h.html#ade8d161dfb86a94179d286f36ec5b28e