### PR TITLE
Add convenience function set_if on ClientConfig

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -208,6 +208,20 @@ impl ClientConfig {
         self.conf_map.insert(key.into(), value.into());
         self
     }
+    /// Sets a parameter in the configuration if the value is Some.
+    ///
+    /// If there is an existing value for `key` in the configuration and value is Some, it is
+    /// overridden with the new `Some(value)`.
+    pub fn set_if<K, V>(&mut self, key: K, value: Option<V>) -> &mut ClientConfig
+    where
+        K: Into<String>,
+        V: Into<String>,
+    {
+        match value {
+            Some(value) => self.set(key, value),
+            None => self,
+        }
+    }
 
     /// Removes a parameter from the configuration.
     pub fn remove<'a>(&'a mut self, key: &str) -> &'a mut ClientConfig {


### PR DESCRIPTION
Adds a simple function `ClientConfig.set_if` that wraps `ClientConfig.set` to allow for passing values that are options. This is helpful for configuring clients dynamically via config files that may or may not have values set.

```rust
// Such a value could be read from a config file if the user wanted to set it otherwise, it would read in as `None`.
let message_max_bytes = Some(1024u32);

let config = ClientConfig::new()
    .set_if(
        "message.max.bytes",
        message_max_bytes.map(|v| v.to_string()),
    );
```