### PR TITLE
Poll error callbacks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1070,7 +1070,7 @@ dependencies = [
 
 [[package]]
 name = "rdkafka"
-version = "0.36.2"
+version = "0.36.3"
 dependencies = [
  "async-std",
  "backoff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rdkafka"
-version = "0.36.2"
+version = "0.36.3"
 authors = ["Federico Giraud <giraud.federico@gmail.com>"]
 repository = "https://github.com/fede1024/rust-rdkafka"
 readme = "README.md"

--- a/src/client.rs
+++ b/src/client.rs
@@ -212,6 +212,8 @@ impl NativeClient {
 pub struct Client<C: ClientContext = DefaultClientContext> {
     native: NativeClient,
     context: Arc<C>,
+    /// A poll error callback for main queue
+    pub queue_poll_error_cb: Option<fn(String)>,
 }
 
 impl<C: ClientContext> Client<C> {
@@ -260,6 +262,7 @@ impl<C: ClientContext> Client<C> {
         Ok(Client {
             native: unsafe { NativeClient::from_ptr(client_ptr) },
             context,
+            queue_poll_error_cb: config.queue_poll_error_cb,
         })
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -23,7 +23,7 @@
 //! [librdkafka-config]: https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md
 
 use std::collections::HashMap;
-use std::ffi::{CStr, CString};
+use std::ffi::CString;
 use std::iter::FromIterator;
 use std::os::raw::c_char;
 use std::ptr;
@@ -161,6 +161,8 @@ pub struct ClientConfig {
     /// The librdkafka logging level. Refer to [`RDKafkaLogLevel`] for the list
     /// of available levels.
     pub log_level: RDKafkaLogLevel,
+    /// Poll error callback
+    pub queue_poll_error_cb: Option<fn(String)>,
 }
 
 impl Default for ClientConfig {
@@ -175,6 +177,7 @@ impl ClientConfig {
         ClientConfig {
             conf_map: HashMap::new(),
             log_level: log_level_from_global_config(),
+            queue_poll_error_cb: None,
         }
     }
 
@@ -219,6 +222,12 @@ impl ClientConfig {
     /// on the global log level of the log crate.
     pub fn set_log_level(&mut self, log_level: RDKafkaLogLevel) -> &mut ClientConfig {
         self.log_level = log_level;
+        self
+    }
+
+    /// Sets the error callback for poll method.
+    pub fn set_queue_poll_error_cb(&mut self, error_cb: fn(String)) -> &mut ClientConfig {
+        self.queue_poll_error_cb = Some(error_cb);
         self
     }
 

--- a/src/producer/base_producer.rs
+++ b/src/producer/base_producer.rs
@@ -367,6 +367,14 @@ where
             let evtype = unsafe { rdsys::rd_kafka_event_type(ev.ptr()) };
             match evtype {
                 rdsys::RD_KAFKA_EVENT_DR => self.handle_delivery_report_event(ev),
+                rdsys::RD_KAFKA_EVENT_ERROR => if let Some(queue_poll_error_cb) = self.client.queue_poll_error_cb {
+                    let event_error_str = unsafe {
+                        let event_error_str = rdsys::rd_kafka_event_error_string(ev.ptr());
+                        CStr::from_ptr(event_error_str).to_string_lossy()
+                    };
+                    let event_error_str = String::from(event_error_str);
+                    queue_poll_error_cb(event_error_str)
+                }
                 _ => {
                     let evname = unsafe {
                         let evname = rdsys::rd_kafka_event_name(ev.ptr());


### PR DESCRIPTION
Hello,

This PR adds a callback logic for errors occurred on `poll` method call in producer. The idea is to handle several kinds of errors immediately.

Here is a use case for this feature. If the application fails to connect or to authenticate to Kafka server then it exits with error code:
https://github.com/ignytis/send2kafka/blob/705f022beb50d8c8be77abbf6e15bd79707e9ebe/src/kafka_producer.rs#L32 <- setting the callback
https://github.com/ignytis/send2kafka/blob/705f022beb50d8c8be77abbf6e15bd79707e9ebe/src/kafka_producer.rs#L8-L13 <- callback itself
This way the connection issues might be handled before trying to send actual messages to the broker.

I'd appreciate any recommendations if there are any option to improve this code or implement this feature the other way.