### PR TITLE
Use CStr::from_bytes_until_nul to read rdkafka config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [master]
 
 env:
-  rust_version: 1.61.0
+  rust_version: 1.69.0
 
 jobs:
   lint:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ keywords = ["kafka", "rdkafka"]
 categories = ["api-bindings"]
 edition = "2018"
 exclude = ["Cargo.lock"]
-rust-version = "1.61"
+rust-version = "1.69"
 
 [workspace]
 members = ["rdkafka-sys"]

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ re-exported as rdkafka features.
 
 ### Minimum supported Rust version (MSRV)
 
-The current minimum supported Rust version (MSRV) is 1.61.0. Note that
+The current minimum supported Rust version (MSRV) is 1.69.0. Note that
 bumping the MSRV is not considered a breaking change. Any release of
 rust-rdkafka may bump the MSRV.
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@ See also the [rdkafka-sys changelog](rdkafka-sys/changelog.md).
 
 ## Unreleased
 
+* Bump MSRV to 1.69
+
 ## 0.36.2 (2024-01-16)
 
 * Update `BaseConsumer::poll` to return `None` when handling rebalance

--- a/rdkafka-sys/Cargo.toml
+++ b/rdkafka-sys/Cargo.toml
@@ -10,7 +10,7 @@ description = "Native bindings to the librdkafka library"
 keywords = ["kafka", "rdkafka"]
 categories = ["external-ffi-bindings"]
 edition = "2018"
-rust-version = "1.61"
+rust-version = "1.69"
 
 [dependencies]
 num_enum = "0.5.0"

--- a/src/config.rs
+++ b/src/config.rs
@@ -150,7 +150,10 @@ impl NativeClientConfig {
         }
 
         // Convert the C string to a Rust string.
-        Ok(String::from_utf8_lossy(&buf).to_string())
+        Ok(CStr::from_bytes_until_nul(&buf)
+            .expect("rd_kafka_conf_get to write a NUL-terminated string.")
+            .to_string_lossy()
+            .to_string())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,7 +176,7 @@
 //!
 //! ### Minimum supported Rust version (MSRV)
 //!
-//! The current minimum supported Rust version (MSRV) is 1.61.0. Note that
+//! The current minimum supported Rust version (MSRV) is 1.69.0. Note that
 //! bumping the MSRV is not considered a breaking change. Any release of
 //! rust-rdkafka may bump the MSRV.
 //!


### PR DESCRIPTION
Commit 353812ff958b4b65f9e65dd22a60e770ed6ba948 replaced the more finicky `CStr::from_bytes_with_nul` with `String::from_utf8_lossy`. This causes tests to fail, both for me locally and in [CI](https://github.com/fede1024/rust-rdkafka/actions/runs/8417735908/job/23046767982). 

That commit eliminated a panic but now the returned Rust string (from `NativeClientConfig.get`) contains NUL bytes. This might have accidentally worked in FFI APIs that take C strings, but it fails when such a string is passed to a Rust API, such as integer parsing in `stream_consumer.rs:217`.

The newer `CStr::from_bytes_until_nul` function
 1. does not panic
 2. ends the string at the first NUL byte

It does return an error when there is no NUL byte in the input slice.

While it would be possible to fall back to `String::from_utf8_lossy` in that case, I'm not sure that would be a good idea. If we are in that situation, librdkafka clearly has messed something up completely. The contents of the buffer are then more likely complete garbage.