### PR TITLE
Remove nul chars from string before parsing to numerical values

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -150,7 +150,7 @@ impl NativeClientConfig {
         }
 
         // Convert the C string to a Rust string.
-        Ok(String::from_utf8_lossy(&buf).to_string())
+        Ok(String::from_utf8_lossy(&buf).trim_matches(char::from(0)).to_string())
     }
 }
 


### PR DESCRIPTION
Looks like this change https://github.com/fede1024/rust-rdkafka/commit/353812ff958b4b65f9e65dd22a60e770ed6ba948 is causing following error (when SimpleConsumer is being run) - at least on OSX 
```
librdkafka validated config value is valid u64: ParseIntError { kind: InvalidDigit }
```
That is because rd_kafka_conf_get returns null terminated string, 
```rust
// Allocate a buffer of that size and call again to get the actual
// string.
let mut buf = vec![0_u8; size];
let res = unsafe {
    rdsys::rd_kafka_conf_get(
        self.ptr(),
        key_c.as_ptr(),
        buf.as_mut_ptr() as *mut c_char,
        &mut size,
    )
};
```
ends with buf equal:
```
[51, 48, 48, 48, 48, 48, 0];
```
I guess reverting this change will cause issues on windows, so maybe my PR will be good enough to handle this.

This pr should also fix this case https://github.com/fede1024/rust-rdkafka/pull/683 
