### PR TITLE
Use CStr::from_bytes_until_nul to read rdkafka config

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -23,7 +23,7 @@
 //! [librdkafka-config]: https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md
 
 use std::collections::HashMap;
-use std::ffi::CString;
+use std::ffi::{CStr, CString};
 use std::iter::FromIterator;
 use std::os::raw::c_char;
 use std::ptr;
@@ -150,8 +150,9 @@ impl NativeClientConfig {
         }
 
         // Convert the C string to a Rust string.
-        Ok(String::from_utf8_lossy(&buf)
-            .trim_matches(char::from(0))
+        Ok(CStr::from_bytes_until_nul(&buf)
+            .expect("rd_kafka_conf_get to write a NUL-terminated string.")
+            .to_string_lossy()
             .to_string())
     }
 }


### PR DESCRIPTION
Rebased version of #671 as per the discussion in [#688](https://github.com/fede1024/rust-rdkafka/pull/688#issuecomment-2270587567) (forgot to re-open _before_ I pushed the updated branch). Original PR text below

----

Commit 353812ff958b4b65f9e65dd22a60e770ed6ba948 replaced the more finicky `CStr::from_bytes_with_nul` with `String::from_utf8_lossy`.

That eliminated a panic but the returned Rust string now contained NUL bytes. This might have accidentally worked in FFI APIs that take C strings, but it fails when such a string is passed to a Rust API, such as integer parsing in `stream_consumer.rs:217`.

The newer `CStr::from_bytes_until_nul` function
 1. does not panic
 2. ends the string at the first NUL byte

It does return an error when there is no NUL byte in the input slice.

While it would be possible to fall back to `String::from_utf8_lossy` in that case, I'm not sure that would be a good idea. If we are in that situation, librdkafka clearly has messed something up completely. The contents of the buffer are then more likely complete garbage.