### PR TITLE
Get rid of CString alloc in OwnedHeader::insert

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -1,9 +1,9 @@
 //! Store and manipulate Kafka messages.
 
-use std::ffi::{CStr, CString};
+use std::ffi::CStr;
 use std::fmt;
 use std::marker::PhantomData;
-use std::os::raw::c_void;
+use std::os::raw::{c_char, c_void};
 use std::ptr;
 use std::str;
 use std::sync::Arc;
@@ -534,7 +534,6 @@ impl OwnedHeaders {
     where
         V: ToBytes + ?Sized,
     {
-        let name_cstring = CString::new(header.key).unwrap();
         let (value_ptr, value_len) = match header.value {
             None => (ptr::null_mut(), 0),
             Some(value) => {
@@ -548,8 +547,8 @@ impl OwnedHeaders {
         let err = unsafe {
             rdsys::rd_kafka_header_add(
                 self.ptr(),
-                name_cstring.as_ptr(),
-                name_cstring.as_bytes().len() as isize,
+                header.key.as_ptr() as *const c_char,
+                header.key.as_bytes().len() as isize,
                 value_ptr,
                 value_len,
             )


### PR DESCRIPTION
We pass length of header's key so in such case librdkafka doesn't calculate name's length and relies on the passed value. Additionally it adds null byte at the end - https://github.com/confluentinc/librdkafka/blob/10f988f493695ee2ff180d9927f1e881ab98a36d/src/rdkafka_header.c#L96 so no point of creating c string in rust code.

I think that issue is there since forever - https://github.com/fede1024/rust-rdkafka/commit/56366ae8c1443318aa4036097c6fbc879f93e238#diff-e070e0bbef3fd7da263a02197f5b3ba50d6b086f1a882a639dcf70a03db48704R376. The logic to add \0 in librdkafka code base seems also present since forever - https://github.com/confluentinc/librdkafka/pull/1480/files#diff-7daf545224b7aa45b8eeecc8f32b1e07815e64fc6dae003af54ee4a96810a995R97