### PR TITLE
Update MSRV to 1.70

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ re-exported as rdkafka features.
 
 ### Minimum supported Rust version (MSRV)
 
-The current minimum supported Rust version (MSRV) is 1.61.0. Note that
+The current minimum supported Rust version (MSRV) is 1.70.0. Note that
 bumping the MSRV is not considered a breaking change. Any release of
 rust-rdkafka may bump the MSRV.
 


### PR DESCRIPTION
I think https://github.com/fede1024/rust-rdkafka/pull/703 updated Rust's MSRV to 1.70. It might be good to update the Readme accordingly as well.

Closes https://github.com/fede1024/rust-rdkafka/issues/720 