### PR TITLE
Set proper volumes for Kafka / ZK logs & data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 target
 src/*.bk
 .idea
+kafka/
+zookeeper/

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,3 +18,7 @@ services:
     environment:
       - ZOOKEEPER_CLIENT_PORT=2181
     ports: ["2181:2181"]
+    volumes:
+      - ./zookeeper/data:/var/lib/zookeeper/data
+      - ./zookeeper/log:/var/lib/zookeeper/log
+      - ./kafka/data:/var/lib/kafka/data


### PR DESCRIPTION
Without volumes set ZK & Kafka were throwing tons of errors like:

```
rust-rdkafka-zookeeper-1  | org.apache.zookeeper.server.persistence.FileTxnSnapLog$DatadirException: Cannot write to data directory /var/lib/zookeeper/log/version-2
rust-rdkafka-zookeeper-1  |     at org.apache.zookeeper.server.persistence.FileTxnSnapLog.<init>(FileTxnSnapLog.java:140)
rust-rdkafka-zookeeper-1  |     at org.apache.zookeeper.server.ZooKeeperServerMain.runFromConfig(ZooKeeperServerMain.java:137)
rust-rdkafka-zookeeper-1  |     at org.apache.zookeeper.server.ZooKeeperServerMain.initializeAndRun(ZooKeeperServerMain.java:112)
rust-rdkafka-zookeeper-1  |     at org.apache.zookeeper.server.ZooKeeperServerMain.main(ZooKeeperServerMain.java:67)
rust-rdkafka-zookeeper-1  |     at org.apache.zookeeper.server.quorum.QuorumPeerMain.initializeAndRun(QuorumPeerMain.java:140)
rust-rdkafka-zookeeper-1  |     at org.apache.zookeeper.server.quorum.QuorumPeerMain.main(QuorumPeerMain.java:90)
rust-rdkafka-zookeeper-1  | Unable to access datadir, exiting abnormally
```

when trying to start those via docker compose.