### PR TITLE
relax clone trait bound on context

### DIFF
--- a/src/producer/base_producer.rs
+++ b/src/producer/base_producer.rs
@@ -639,7 +639,6 @@ where
 /// queued events, such as delivery notifications. The thread will be
 /// automatically stopped when the producer is dropped.
 #[must_use = "The threaded producer will stop immediately if unused"]
-#[derive(Clone)]
 pub struct ThreadedProducer<C, Part: Partitioner = NoCustomPartitioner>
 where
     C: ProducerContext<Part> + 'static,
@@ -769,6 +768,16 @@ where
 
     fn abort_transaction<T: Into<Timeout>>(&self, timeout: T) -> KafkaResult<()> {
         self.producer.abort_transaction(timeout)
+    }
+}
+
+impl<C: ProducerContext + 'static> Clone for ThreadedProducer<C> {
+    fn clone(&self) -> Self {
+        Self {
+            producer: Arc::clone(&self.producer),
+            should_stop: Arc::clone(&self.should_stop),
+            handle: self.handle.clone(),
+        }
     }
 }
 


### PR DESCRIPTION
My previous PR implemented `Clone` through `derive` which added an unecessary `C: Clone` bound on the context. This PR fixes it by manually implementing the trait. 