### PR TITLE
Various BaseProducer::flush fixes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,8 @@ See also the [rdkafka-sys changelog](rdkafka-sys/changelog.md).
 * Remove testing for old Kafka versions (before 3.0). Add tests for 3.7.
 * Fix test dependency on docker compose.
 * Address wakeup races introduced by pivoting to the event API.
+* Update `BaseProducer::poll` to not return early, and instead continue
+  looping until the passed timeout is reached.
 
 ## 0.36.2 (2024-01-16)
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -300,10 +300,10 @@ impl<C: ClientContext> Client<C> {
         &self.context
     }
 
-    pub(crate) fn poll_event(
+    pub(crate) fn poll_event<T: Into<Timeout>>(
         &self,
         queue: &NativeQueue,
-        timeout: Timeout,
+        timeout: T,
     ) -> EventPollResult<NativeEvent> {
         let event = unsafe { NativeEvent::from_ptr(queue.poll(timeout)) };
         if let Some(ev) = event {

--- a/src/producer/base_producer.rs
+++ b/src/producer/base_producer.rs
@@ -366,7 +366,7 @@ where
             Duration::MAX
         };
         let mut attempt = 0;
-        while attempt > 0 && remaining > Duration::ZERO {
+        while attempt >= 0 && remaining > Duration::ZERO {
             let start = Instant::now();
             let event = self
                 .client()

--- a/src/producer/base_producer.rs
+++ b/src/producer/base_producer.rs
@@ -361,8 +361,8 @@ where
     /// the message delivery callbacks.
     pub fn poll<T: Into<Timeout>>(&self, timeout: T) {
         let deadline: Deadline = timeout.into().into();
-        let mut attempt = 0;
-        while attempt >= 0 && !deadline.elapsed() {
+        let mut called = false;
+        while !called || !deadline.elapsed() {
             let event = self
                 .client()
                 .poll_event(&self.queue, Timeout::After(deadline.remaining()));
@@ -379,7 +379,7 @@ where
                     }
                 }
             }
-            attempt += 1;
+            called = true;
         }
     }
 

--- a/src/producer/base_producer.rs
+++ b/src/producer/base_producer.rs
@@ -505,6 +505,8 @@ where
             };
             if ret.is_error() {
                 return Err(KafkaError::Flush(ret.into()));
+            } else if let Deadline::Never = &deadline {
+                self.poll(Timeout::After(Duration::ZERO));
             } else {
                 self.poll(&deadline);
             }

--- a/src/producer/base_producer.rs
+++ b/src/producer/base_producer.rs
@@ -503,13 +503,14 @@ where
             let ret = unsafe {
                 rdsys::rd_kafka_flush(self.client().native_ptr(), deadline.remaining_millis_i32())
             };
-            if ret.is_error() {
-                return Err(KafkaError::Flush(ret.into()));
-            } else if let Deadline::Never = &deadline {
+            if let Deadline::Never = &deadline {
                 self.poll(Timeout::After(Duration::ZERO));
             } else {
                 self.poll(&deadline);
             }
+            if ret.is_error() {
+                return Err(KafkaError::Flush(ret.into()));
+            };
         }
         Ok(())
     }

--- a/src/producer/base_producer.rs
+++ b/src/producer/base_producer.rs
@@ -508,12 +508,12 @@ where
         let mut remaining = if let Timeout::After(dur) = timeout.into() {
             dur
         } else {
-            // librdkafka's flush api requires an i32 millisecond timeout
-            Duration::from_millis(i32::MAX as u64)
+            Duration::MAX
         };
         while self.in_flight_count() > 0 && remaining > Duration::ZERO {
             let flush_start = Instant::now();
             let ret = unsafe {
+                // This cast to i32 will truncate to i32::MAX
                 rdsys::rd_kafka_flush(self.client().native_ptr(), remaining.as_millis() as i32)
             };
             if ret.is_error() {

--- a/src/producer/base_producer.rs
+++ b/src/producer/base_producer.rs
@@ -360,11 +360,7 @@ where
     /// Regular calls to `poll` are required to process the events and execute
     /// the message delivery callbacks.
     pub fn poll<T: Into<Timeout>>(&self, timeout: T) {
-        let deadline = if let Timeout::After(dur) = timeout.into() {
-            Deadline::new(dur)
-        } else {
-            Deadline::new(Duration::MAX)
-        };
+        let deadline: Deadline = timeout.into().into();
         let mut attempt = 0;
         while attempt >= 0 && !deadline.elapsed() {
             let event = self
@@ -503,11 +499,7 @@ where
     // As this library uses the rdkafka Event API, flush will not call rd_kafka_poll() but instead wait for
     // the librdkafka-handled message count to reach zero. Runs until value reaches zero or timeout.
     fn flush<T: Into<Timeout>>(&self, timeout: T) -> KafkaResult<()> {
-        let deadline = if let Timeout::After(dur) = timeout.into() {
-            Deadline::new(dur)
-        } else {
-            Deadline::new(Duration::MAX)
-        };
+        let deadline: Deadline = timeout.into().into();
         while self.in_flight_count() > 0 && !deadline.elapsed() {
             let ret = unsafe {
                 // This cast to i32 will truncate to i32::MAX

--- a/src/producer/base_producer.rs
+++ b/src/producer/base_producer.rs
@@ -362,9 +362,7 @@ where
     pub fn poll<T: Into<Timeout>>(&self, timeout: T) {
         let deadline: Deadline = timeout.into().into();
         loop {
-            let event = self
-                .client()
-                .poll_event(&self.queue, Timeout::After(deadline.remaining()));
+            let event = self.client().poll_event(&self.queue, &deadline);
             if let EventPollResult::Event(ev) = event {
                 let evtype = unsafe { rdsys::rd_kafka_event_type(ev.ptr()) };
                 match evtype {

--- a/src/producer/base_producer.rs
+++ b/src/producer/base_producer.rs
@@ -361,8 +361,7 @@ where
     /// the message delivery callbacks.
     pub fn poll<T: Into<Timeout>>(&self, timeout: T) {
         let deadline: Deadline = timeout.into().into();
-        let mut called = false;
-        while !called || !deadline.elapsed() {
+        loop {
             let event = self
                 .client()
                 .poll_event(&self.queue, Timeout::After(deadline.remaining()));
@@ -379,7 +378,9 @@ where
                     }
                 }
             }
-            called = true;
+            if deadline.elapsed() {
+                break;
+            }
         }
     }
 

--- a/src/producer/base_producer.rs
+++ b/src/producer/base_producer.rs
@@ -503,11 +503,7 @@ where
         let deadline: Deadline = timeout.into().into();
         while self.in_flight_count() > 0 && !deadline.elapsed() {
             let ret = unsafe {
-                // This cast to i32 will truncate to i32::MAX
-                rdsys::rd_kafka_flush(
-                    self.client().native_ptr(),
-                    deadline.remaining().as_millis() as i32,
-                )
+                rdsys::rd_kafka_flush(self.client().native_ptr(), deadline.remaining_millis_i32())
             };
             if ret.is_error() {
                 return Err(KafkaError::Flush(ret.into()));

--- a/src/util.rs
+++ b/src/util.rs
@@ -57,6 +57,10 @@ impl Deadline {
         }
     }
 
+    pub(crate) fn remaining_millis_i32(&self) -> i32 {
+        cmp::min(Deadline::MAX_FLUSH_DURATION, self.remaining()).as_millis() as i32
+    }
+
     pub(crate) fn elapsed(&self) -> bool {
         self.remaining() <= Duration::ZERO
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -96,6 +96,16 @@ impl std::ops::SubAssign for Timeout {
     }
 }
 
+impl From<Timeout> for Deadline {
+    fn from(t: Timeout) -> Deadline {
+        if let Timeout::After(dur) = t {
+            Deadline::new(dur)
+        } else {
+            Deadline::new(Duration::MAX)
+        }
+    }
+}
+
 impl From<Deadline> for Timeout {
     fn from(d: Deadline) -> Timeout {
         Timeout::After(d.remaining())

--- a/src/util.rs
+++ b/src/util.rs
@@ -114,7 +114,7 @@ impl std::ops::SubAssign for Timeout {
 impl From<Timeout> for Deadline {
     fn from(t: Timeout) -> Deadline {
         if let Timeout::After(dur) = t {
-            Deadline::new(Some(cmp::min(Deadline::MAX_FLUSH_DURATION, dur)))
+            Deadline::new(Some(dur))
         } else {
             Deadline::new(None)
         }

--- a/src/util.rs
+++ b/src/util.rs
@@ -121,16 +121,6 @@ impl From<Timeout> for Deadline {
     }
 }
 
-impl From<Deadline> for Timeout {
-    fn from(d: Deadline) -> Timeout {
-        if let Deadline::Never = d {
-            Timeout::Never
-        } else {
-            Timeout::After(d.remaining())
-        }
-    }
-}
-
 impl From<&Deadline> for Timeout {
     fn from(d: &Deadline) -> Timeout {
         if let Deadline::Never = d {


### PR DESCRIPTION
Refactor `BaseProducer::poll` to not return early, but instead continue processing events until the passed timeout.

Refactor `BaseProducer::flush` to spend most time in `librdkafka`, and whatever is left in `BaseProducer::poll`.