### PR TITLE
add feature to statically link against existing librdkafka

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ zstd = ["rdkafka-sys/zstd"]
 zstd-pkg-config = ["rdkafka-sys/zstd-pkg-config"]
 external-lz4 = ["rdkafka-sys/external-lz4"]
 external_lz4 = ["rdkafka-sys/external_lz4"]
+static-linking = ["rdkafka-sys/static-linking"]
 
 [package.metadata.docs.rs]
 # docs.rs doesn't allow writing to ~/.cargo/registry (reasonably), so we have to

--- a/README.md
+++ b/README.md
@@ -176,6 +176,10 @@ the system's version of librdkafka. Example:
 rdkafka = { version = "0.25", features = ["dynamic-linking"] }
 ```
 
+If you'd like to compile librdkafka statically yourself, then use
+that, you can use `static-linking` while supplying `DEP_LIBRDKAFKA_STATIC_ROOT`
+with path to where librdkafka was built.
+
 For a full listing of features, consult the [rdkafka-sys crate's
 documentation][rdkafka-sys-features]. All of rdkafka-sys features are
 re-exported as rdkafka features.

--- a/rdkafka-sys/Cargo.toml
+++ b/rdkafka-sys/Cargo.toml
@@ -93,6 +93,9 @@ external-lz4 = ["lz4-sys"]
 # Deprecated alias for the `external-lz4` feature.
 external_lz4 = ["external-lz4"]
 
+# Link against precompiled static build of librdkafka
+static-linking = []
+
 [package.metadata.docs.rs]
 # docs.rs doesn't allow writing to ~/.cargo/registry (reasonably), so we have to
 # use the CMake build for a proper out-of-tree build.

--- a/rdkafka-sys/README.md
+++ b/rdkafka-sys/README.md
@@ -45,6 +45,11 @@ system, and it will configure the compiler to dynamically link against it.
 The system version of librdkafka must exactly match the version of
 librdkafka bundled with this crate.
 
+The **`static-linking`** feature can be used to link rdkafka to a locally
+built version of librdkafka: if the feature is enabled, the build script
+will try to find `DEP_LIBRDKAFKA_STATIC_ROOT` environment variable
+and it will statically link against it.
+
 The **`cmake-build`** feature builds librdkafka with its [CMake] build
 system, rather than its default [mklove]-based build system. This feature
 requires that CMake is installed on the build machine.

--- a/rdkafka-sys/build.rs
+++ b/rdkafka-sys/build.rs
@@ -73,7 +73,19 @@ fn main() {
                 process::exit(1);
             }
         }
-    } else {
+    } else if env::var("CARGO_FEATURE_STATIC_EXTERNAL").is_ok() {
+        if let Ok(rdkafka_dir) = env::var("DEP_LIBRDKAFKA_STATIC_ROOT") {
+            println!("cargo:rustc-link-search=native={}/src", rdkafka_dir);
+            println!("cargo:rustc-link-lib=static=rdkafka");
+            println!("cargo:root={}", rdkafka_dir);
+        } else {
+            eprintln!("Path to DEP_LIBRDKAFKA_STATIC_ROOT not set. Static linking failed. Exiting.");
+            process::exit(1);
+        }
+        eprintln!("librdkafka will be linked statically using prebuilt binaries");
+
+    }
+        else {
         // Ensure that we are in the right directory
         let rdkafkasys_root = Path::new("rdkafka-sys");
         if rdkafkasys_root.exists() {


### PR DESCRIPTION
This feature allows users to pre-build their own static librdkafka and use it with rust-rdkafka.
In our case, to make it easier for cross compilation we preferred to compile natively librdkafka for each architecture, then re-use it from a container image.