### PR TITLE
Require a minimum of CMake 3.5 compatibility for librdkafka build.

### DIFF
--- a/rdkafka-sys/build.rs
+++ b/rdkafka-sys/build.rs
@@ -213,7 +213,10 @@ fn build_librdkafka() {
         // want a stable location that we can add to the linker search path.
         // Since we're not actually installing to /usr or /usr/local, there's no
         // harm to always using "lib" here.
-        .define("CMAKE_INSTALL_LIBDIR", "lib");
+        .define("CMAKE_INSTALL_LIBDIR", "lib")
+	// CMake 4.0.0 drops support for 3.2 compatibility, which is
+	// required by librdkafka 2.3.0.
+	.define("CMAKE_POLICY_VERSION_MINIMUM", "3.5");
 
     if env::var("CARGO_FEATURE_LIBZ").is_ok() {
         config.define("WITH_ZLIB", "1");


### PR DESCRIPTION
The most recent CMake (released March 28, 2025) drops 3.2 compatibility, which the version of librdkafka in rdkafka-sys (2.3.0) depends on. Recent versions of librdkafka increase the min cmake version to 3.5. Rather than upgrade rdkafka-sys to a new librdkafka or patch that source, this PR simply specifies a new min CMake version in the `build.rs` file.

To check that it's working, you can just run `cargo build --features cmake-build`, which fails on head in master.
