### PR TITLE
Fix name of Cargo feature for static linking

### DIFF
--- a/rdkafka-sys/build.rs
+++ b/rdkafka-sys/build.rs
@@ -73,7 +73,7 @@ fn main() {
                 process::exit(1);
             }
         }
-    } else if env::var("CARGO_FEATURE_STATIC_EXTERNAL").is_ok() {
+    } else if env::var("CARGO_FEATURE_STATIC_LINKING").is_ok() {
         if let Ok(rdkafka_dir) = env::var("DEP_LIBRDKAFKA_STATIC_ROOT") {
             println!("cargo:rustc-link-search=native={}/src", rdkafka_dir);
             println!("cargo:rustc-link-lib=static=rdkafka");


### PR DESCRIPTION
d3879c2f29f7580da619e795b5e4883efbe5b6a8 (PR #750) added the ability to statically link to a pre-built version of librdkafka when the `static-linking` Cargo feature is enabled but the build script for rdkafka-sys checks for `static-external` instead. These need to match for static linking to take effect so let's fix the build script to use `static-linking`.