### PR TITLE
Make path to pre-built version of librdkafka more flexible

### DIFF
--- a/rdkafka-sys/build.rs
+++ b/rdkafka-sys/build.rs
@@ -75,7 +75,11 @@ fn main() {
         }
     } else if env::var("CARGO_FEATURE_STATIC_EXTERNAL").is_ok() {
         if let Ok(rdkafka_dir) = env::var("DEP_LIBRDKAFKA_STATIC_ROOT") {
-            println!("cargo:rustc-link-search=native={}/src", rdkafka_dir);
+            let rdkafka = PathBuf::from(&rdkafka_dir);
+            println!(
+                "cargo:rustc-link-search=native={}",
+                rdkafka.parent().unwrap().display()
+            );
             println!("cargo:rustc-link-lib=static=rdkafka");
             println!("cargo:root={}", rdkafka_dir);
         } else {


### PR DESCRIPTION
Sister PR to https://github.com/fede1024/rust-rdkafka/pull/787.

The build script currently expects a very specific filesystem layout in order to statically link. If you check out the source code for librdkafka somewhere and compile it with `./configure` and `make`, the build artifacts will exist in the `src/` directory under the project directory and everything will work. The rdkafka-sys crate does something similar behind the scenes by default.

However, sometimes we already have librdkafka built for us. For example, when installed via a package manager like Homebrew or APT, we will have the build artifacts available somewhere like `/opt/homebrew/lib` or `/usr/lib/aarch64-linux-gnu`. In those cases, the automatic appending of `src/` to the path in `DEP_LIBRDKAFKA_STATIC_ROOT` is problematic.

Taking a page from jemallocator[^1], another Rust crate that wraps a C/C++ library, we can instead accept a path to the static library file and pass its parent (the directory in which it resides) to `cargo:rustc-link-search`. This supports both the case where we have the library installed via a package manager (by setting `DEP_LIBRDKAFKA_STATIC_ROOT` to something like `/opt/homebrew/lib/librdkafka.a`) and the case where we're building from source ourselves (by pointing to something like `~/Downloads/librdkafka/src/librdkafka.a`).

[^1]: https://github.com/tikv/jemallocator/blob/5c5a9f79b3be3c19e253527f16a091132a455c2e/jemalloc-sys/build.rs#L126-L137