### PR TITLE
Implement FromIterator for TopicPartitionList

### DIFF
--- a/src/topic_partition_list.rs
+++ b/src/topic_partition_list.rs
@@ -610,8 +610,17 @@ mod tests {
         .collect();
 
         assert_eq!(tpl.count(), 3);
-        assert_eq!(tpl.find_partition("t1", 0).unwrap().offset(), Offset::Beginning);
-        assert_eq!(tpl.find_partition("t1", 1).unwrap().offset(), Offset::Offset(7));
-        assert_eq!(tpl.find_partition("t2", 0).unwrap().offset(), Offset::Stored);
+        assert_eq!(
+            tpl.find_partition("t1", 0).unwrap().offset(),
+            Offset::Beginning
+        );
+        assert_eq!(
+            tpl.find_partition("t1", 1).unwrap().offset(),
+            Offset::Offset(7)
+        );
+        assert_eq!(
+            tpl.find_partition("t2", 0).unwrap().offset(),
+            Offset::Stored
+        );
     }
 }


### PR DESCRIPTION
Implemented a FromIterator using topic/partition/offset tuple and topic map iterators.

This satisfies: https://github.com/fede1024/rust-rdkafka/issues/790