### PR TITLE
Expand implementation of ToBytes for references to non-Sized types

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -809,7 +809,7 @@ impl ToBytes for String {
     }
 }
 
-impl<T: ToBytes> ToBytes for &T {
+impl<T: ToBytes + ?Sized> ToBytes for &T {
     fn to_bytes(&self) -> &[u8] {
         (*self).to_bytes()
     }
@@ -879,5 +879,16 @@ mod test {
                 value: Some("value2")
             })
         );
+    }
+
+    #[test]
+    fn test_headers_double_reference() {
+        let value = "value";
+        let value_ref: &&str = &value;
+
+        let _ = OwnedHeaders::new().insert(Header {
+            key: "key",
+            value: Some(value_ref),
+        });
     }
 }


### PR DESCRIPTION
Right now, `ToBytes` is implemented for references, but only when the referenced type is `Sized`. In particular, it's not implemented for `&str`, despite being implemented for `str`; therefore every place expecting `&T where T: ToBytes`, when passed `&&str`, can lead to somewhat [cryptic errors](https://stackoverflow.com/questions/79827841/rdkafkamessagetobytes-is-not-implemented-for-str).

This merge request relaxes requirements on `impl ToBytes for &T` and includes a simple unit test to ensure that this change actually removes the compilation error.